### PR TITLE
refactor(compositor): Window API — imperative &mut Window handle, drop EventResult

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -113,7 +113,8 @@ impl App {
             // Drain per-tick messages: compositor components first,
             // then tasks. Both borrow &mut self transitively through
             // dispatch, so collect into a Vec first.
-            let compositor_msgs = self.compositor.poll();
+            let ctx = self.context();
+            let compositor_msgs = self.compositor.poll(&ctx);
             for msg in compositor_msgs {
                 self.dispatch(msg);
             }

--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -20,11 +20,11 @@
 //! does *not* live here — those are focus transitions, handled
 //! internally by the
 //! [`Compositor`](crate::compositor::Compositor) via
-//! [`EventResult::Push`](crate::compositor::EventResult::Push) /
-//! [`CloseAndPush`](crate::compositor::EventResult::CloseAndPush)
-//! returned from a [`Component`](crate::compositor::Component).
-//! Keeping them off `AppMsg` means the focus state machine isn't
-//! coupled to the dispatch table.
+//! [`Window::open`](crate::compositor::window::Window::open) /
+//! [`Window::close`](crate::compositor::window::Window::close) calls
+//! from a [`Component`](crate::compositor::Component). Keeping them
+//! off `AppMsg` means the focus state machine isn't coupled to the
+//! dispatch table.
 
 use crate::color_palette::ThemeId;
 use crate::geo::LonLat;

--- a/src/compositor/base.rs
+++ b/src/compositor/base.rs
@@ -7,8 +7,8 @@
 //! - **Keymap fallback**: resolves `h/j/k/l/q/0/+/-/…` via [`KeyMap`]
 //! - **Activation dispatch**: `:` / `/` / `i` / `?` (and any future
 //!   plugin activation key) looked up in an [`Activation`] table.
-//!   When the base layer sees an activation key it returns
-//!   [`EventResult::Push`] with the freshly-spawned component.
+//!   When the base layer sees an activation key it calls
+//!   `win.open(spawn(ctx))` with the freshly-spawned component.
 //! - **`gg` multi-key sequence**: tracks `pending_g` and emits
 //!   `ZoomToWorld` on the second `g`.
 //!
@@ -17,9 +17,9 @@
 //! BaseLayer doesn't need to know about it.
 //!
 //! Because it's always at the very bottom of the stack, its
-//! `handle_event` only runs when every modal above it has returned
-//! [`EventResult::Ignored`] — exactly the "pass through to
-//! background" cases the old `FocusManager` handled.
+//! `handle_event` only runs when the focused (possibly higher)
+//! component called `win.ignore()` — exactly the old
+//! "pass through to background" cases.
 //!
 //! The base layer renders nothing (the map comes from the render
 //! thread's `MapFrame`, drawn by `App` separately from the
@@ -27,7 +27,8 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use super::{Activation, Component, Context, EventResult};
+use super::window::Window;
+use super::{Activation, Component};
 use crate::app::AppMsg;
 use crate::keymap::KeyMap;
 use crate::map::Action;
@@ -80,7 +81,7 @@ impl BaseLayer {
 }
 
 impl Component for BaseLayer {
-    fn handle_event(&mut self, event: KeyEvent, ctx: &Context) -> EventResult {
+    fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
         let KeyEvent {
             code, modifiers, ..
         } = event;
@@ -94,18 +95,18 @@ impl Component for BaseLayer {
         // Activation keys: spawn the plugin's fresh component and
         // push it on top.
         if let Some(activation) = self.activation_for(code, modifiers) {
-            let new_component = (activation.spawn)(ctx);
-            return EventResult::Push(new_component, Vec::new());
+            let new_component = (activation.spawn)(win.ctx());
+            win.open(new_component);
+            return;
         }
 
         if let Some(msg) = keymap_msg {
-            return EventResult::Consumed(vec![msg]);
+            win.emit(msg);
         }
 
-        // First `g` of `gg` and unrecognised keys land here. Bottom
-        // layer has nothing below it, so we consume rather than
-        // Ignore — there is no lower layer to fall through to.
-        EventResult::Consumed(Vec::new())
+        // First `g` of `gg` and unrecognised keys land here. Base
+        // layer has nothing below it, so we implicitly consume
+        // (no `win.ignore()`).
     }
 
     fn render(
@@ -133,6 +134,8 @@ impl Component for BaseLayer {
 
 #[cfg(test)]
 mod tests {
+    use super::super::Context;
+    use super::super::window::WindowOps;
     use super::*;
     use crate::color_palette::ThemeId;
     use crate::geo::LonLat;
@@ -147,41 +150,35 @@ mod tests {
         BaseLayer::new(KeyMap::default(), Vec::new())
     }
 
-    fn key(code: KeyCode) -> KeyEvent {
-        KeyEvent::new(code, NONE)
-    }
-
-    fn assert_consumed_msg(effect: EventResult, expected: AppMsg) {
-        match effect {
-            EventResult::Consumed(msgs) => assert_eq!(msgs, vec![expected]),
-            _ => panic!("expected Consumed, got something else"),
+    fn dispatch(bg: &mut BaseLayer, code: KeyCode) -> WindowOps {
+        let mut ops = WindowOps::default();
+        {
+            let mut win = Window::new(&mut ops, &CTX);
+            bg.handle_event(KeyEvent::new(code, NONE), &mut win);
         }
+        ops
     }
 
     #[test]
     fn gg_produces_zoom_to_world_on_second_g() {
         let mut bg = bg();
         // 1st g: nothing fires, pending_g latched.
-        match bg.handle_event(key(KeyCode::Char('g')), &CTX) {
-            EventResult::Consumed(msgs) => assert!(msgs.is_empty()),
-            _ => panic!("expected Consumed(empty)"),
-        }
+        let ops = dispatch(&mut bg, KeyCode::Char('g'));
+        assert!(ops.msgs.is_empty());
+        assert!(!ops.close);
+        assert!(ops.opens.is_empty());
         // 2nd g: ZoomToWorld.
-        assert_consumed_msg(
-            bg.handle_event(key(KeyCode::Char('g')), &CTX),
-            AppMsg::Map(Action::ZoomToWorld),
-        );
+        let ops = dispatch(&mut bg, KeyCode::Char('g'));
+        assert_eq!(ops.msgs, vec![AppMsg::Map(Action::ZoomToWorld)]);
     }
 
     #[test]
     fn gg_sequence_broken_by_other_key() {
         let mut bg = bg();
-        bg.handle_event(key(KeyCode::Char('g')), &CTX);
-        bg.handle_event(key(KeyCode::Char('h')), &CTX); // breaks
+        dispatch(&mut bg, KeyCode::Char('g'));
+        dispatch(&mut bg, KeyCode::Char('h')); // breaks
         // Now pending_g was reset; this g latches afresh, doesn't fire.
-        match bg.handle_event(key(KeyCode::Char('g')), &CTX) {
-            EventResult::Consumed(msgs) => assert!(msgs.is_empty()),
-            _ => panic!("expected Consumed(empty)"),
-        }
+        let ops = dispatch(&mut bg, KeyCode::Char('g'));
+        assert!(ops.msgs.is_empty());
     }
 }

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -27,6 +27,7 @@
 //! the one place that imports each plugin.
 
 pub mod base;
+pub mod window;
 
 pub use base::BaseLayer;
 

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! Replaces the `FocusManager` + `FocusSurface` + `Plugin` trio with a
 //! single primitive: a stack of [`Component`]s. The top of the stack
-//! holds focus; push on activation, pop on [`EventResult::Close`].
+//! holds focus; push on activation, pop when a component calls
+//! `win.close()`.
 //! Object lifetime *is* the visibility lifecycle, so plugins never
 //! have to maintain a separate `is_visible` / `activate` / `deactivate`
 //! contract — fresh instances on every push, dropped on every pop.
@@ -66,29 +67,9 @@ fn intercept_focus_key(event: KeyEvent) -> Option<AppMsg> {
 
 // ── Component + event routing ──────────────────────────────────────
 
-/// Outcome of delivering an event to a [`Component`].
-///
-/// - `Ignored`: the component is not interested; compositor tries the
-///   next layer down. If nothing claims it, the event is discarded.
-/// - `Consumed(msgs)`: absorbed, may emit messages, stack unchanged.
-/// - `Close(msgs)`: absorbed + pop me. Messages dispatch before the
-///   pop (so e.g. a `Jump` fires before the modal disappears).
-/// - `Push(component, msgs)`: absorbed + push a new component on top
-///   of me. Used by the bottom-layer keymap component to open modals
-///   on activation keys without knowing about the compositor.
-/// - `CloseAndPush(component, msgs)`: pop me and push `component`
-///   next. Used by the palette: selecting a Spawn-kind entry closes
-///   the palette and opens the target component.
-pub enum EventResult {
-    Ignored,
-    Consumed(Vec<AppMsg>),
-    Close(Vec<AppMsg>),
-    Push(Box<dyn Component>, Vec<AppMsg>),
-    CloseAndPush(Box<dyn Component>, Vec<AppMsg>),
-}
-
 /// Read-only snapshot of app-level context a component may need
-/// during key handling. Equivalent to today's `SurfaceCtx`.
+/// during a hook. Reached by the component through
+/// [`Window::ctx`](window::Window::ctx).
 #[derive(Debug, Clone, Copy)]
 pub struct Context {
     pub center: LonLat,
@@ -104,12 +85,20 @@ pub struct Context {
 /// tag. Pressing an activation key twice with the base focused in
 /// between still produces one instance of the plugin on the stack,
 /// because the framework notices the type already present.
+///
+/// The event-producing hooks ([`handle_event`](Self::handle_event)
+/// and [`poll`](Self::poll)) receive a
+/// [`&mut Window`](window::Window) and express intent through it
+/// (`win.close()`, `win.open(c)`, `win.emit(msg)`, `win.ignore()`).
+/// The framework applies those ops atomically after the hook
+/// returns, so components cannot break stack / focus invariants
+/// regardless of what order they call the methods.
 pub trait Component: Any {
-    /// Handle a single key event. Return `Ignored` to let lower
-    /// layers see it, `Consumed(msgs)` to absorb, `Close(msgs)` to
-    /// absorb and pop, or `Push(c, msgs)` to absorb and push `c` on
-    /// top.
-    fn handle_event(&mut self, event: KeyEvent, ctx: &Context) -> EventResult;
+    /// Handle a single key event. Call `win.close()` / `open(c)` /
+    /// `emit(msg)` / `ignore()` to express what should happen next.
+    /// Silence (no `win.*` call) is implicit consumption — the
+    /// event is treated as handled but with no state change.
+    fn handle_event(&mut self, event: KeyEvent, win: &mut Window);
 
     /// Paint this component into `area`. Called once per frame while
     /// on the stack; compositor renders bottom-to-top.
@@ -124,17 +113,18 @@ pub trait Component: Any {
     fn paint_on_map(&self, _p: &mut MapPainter<'_>) {}
 
     /// Advance async work and surface new messages. Called every tick
-    /// on every component on the stack. Replaces `Plugin::poll()` +
-    /// `Plugin::pending_msgs()` — one hook instead of two.
-    fn poll(&mut self) -> Vec<AppMsg> {
-        Vec::new()
-    }
+    /// on every component on the stack. Use `win.emit(msg)` to
+    /// dispatch app-level state changes when a future completes,
+    /// and `win.close()` if the component should self-remove.
+    fn poll(&mut self, _win: &mut Window) {}
 
     /// Footer hints shown while this component is on top.
     fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
         Vec::new()
     }
 }
+
+use window::{Window, WindowOps};
 
 // ── Compositor stack ───────────────────────────────────────────────
 
@@ -179,12 +169,11 @@ impl Compositor {
         }
     }
 
-    /// Deliver a key event to the focused component first; if it
-    /// returns [`EventResult::Ignored`] and the focus isn't already
+    /// Deliver a key event to the focused component first; if the
+    /// component called only `win.ignore()` and focus isn't already
     /// on the [`BaseLayer`], re-deliver to the base layer. This
     /// two-step routing restores the old "non-modal plugin passes
-    /// unknown keys through to the keymap" semantic under the
-    /// compositor model.
+    /// unknown keys through to the keymap" semantic.
     ///
     /// `Tab` / `Shift-Tab` / `BackTab` are **framework-reserved**
     /// and never reach any component — focus cycling is a property
@@ -197,38 +186,37 @@ impl Compositor {
             return Vec::new();
         }
         let focused = self.focused_idx;
-        let first = self.stack[focused].handle_event(event, ctx);
-        match first {
-            EventResult::Ignored if focused != 0 => {
-                // Non-modal fall-through: re-deliver to BaseLayer.
-                let second = self.stack[0].handle_event(event, ctx);
-                self.apply_event_result(0, second)
-            }
-            EventResult::Ignored => Vec::new(),
-            result => self.apply_event_result(focused, result),
+        let mut ops = WindowOps::default();
+        {
+            let mut win = Window::new(&mut ops, ctx);
+            self.stack[focused].handle_event(event, &mut win);
         }
+        // Fall-through: only when the hook queued nothing *and*
+        // explicitly called `ignore()`, and the focus isn't already
+        // on the base layer.
+        if ops.is_ignorable_noop() && ops.ignored && focused != 0 {
+            let mut ops = WindowOps::default();
+            {
+                let mut win = Window::new(&mut ops, ctx);
+                self.stack[0].handle_event(event, &mut win);
+            }
+            return self.apply_ops(0, ops);
+        }
+        self.apply_ops(focused, ops)
     }
 
-    fn apply_event_result(&mut self, idx: usize, result: EventResult) -> Vec<AppMsg> {
-        match result {
-            EventResult::Ignored => Vec::new(),
-            EventResult::Consumed(msgs) => msgs,
-            EventResult::Close(msgs) => {
-                self.stack.remove(idx);
-                self.clamp_focus_after_shrink();
-                msgs
-            }
-            EventResult::Push(new_component, msgs) => {
-                self.push_or_focus(new_component);
-                msgs
-            }
-            EventResult::CloseAndPush(new_component, msgs) => {
-                self.stack.remove(idx);
-                self.clamp_focus_after_shrink();
-                self.push_or_focus(new_component);
-                msgs
-            }
+    /// Drain a [`WindowOps`] queue in the documented order:
+    /// `close` → `opens` (with TypeId dedup) → return `msgs` for
+    /// the caller to dispatch. See [`window`] module docs.
+    fn apply_ops(&mut self, idx: usize, ops: WindowOps) -> Vec<AppMsg> {
+        if ops.close {
+            self.stack.remove(idx);
+            self.clamp_focus_after_shrink();
         }
+        for c in ops.opens {
+            self.push_or_focus(c);
+        }
+        ops.msgs
     }
 
     /// Push `c` on top **unless** a component of the same concrete
@@ -255,13 +243,25 @@ impl Compositor {
         self.focused_idx = self.stack.len() - 1;
     }
 
-    /// Poll every component; messages appended in stack order.
-    pub fn poll(&mut self) -> Vec<AppMsg> {
-        let mut out = Vec::new();
-        for c in self.stack.iter_mut() {
-            out.extend(c.poll());
+    /// Poll every component; drain all queued `win.emit(...)` /
+    /// `win.close()` / `win.open(...)` ops and apply them in the
+    /// same way [`handle_event`](Self::handle_event) does.
+    pub fn poll(&mut self, ctx: &Context) -> Vec<AppMsg> {
+        // Walk in reverse so closing a component doesn't disturb
+        // indices of later ones. Collect ops per index first; apply
+        // after the borrow of `stack` is released.
+        let mut all_msgs: Vec<AppMsg> = Vec::new();
+        let len = self.stack.len();
+        for i in (0..len).rev() {
+            let mut ops = WindowOps::default();
+            {
+                let mut win = Window::new(&mut ops, ctx);
+                self.stack[i].poll(&mut win);
+            }
+            let msgs = self.apply_ops(i, ops);
+            all_msgs.extend(msgs);
         }
-        out
+        all_msgs
     }
 
     /// Render bottom-up so later pushes draw on top.
@@ -404,9 +404,7 @@ mod tests {
     struct TagComponent(&'static str);
 
     impl Component for TagComponent {
-        fn handle_event(&mut self, _: KeyEvent, _: &Context) -> EventResult {
-            EventResult::Consumed(Vec::new())
-        }
+        fn handle_event(&mut self, _: KeyEvent, _: &mut Window) {}
         fn render(&self, _: &mut Frame, _: Rect, _: &UiTheme) {}
         fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
             vec![(self.0, "")]
@@ -492,11 +490,10 @@ mod tests {
     }
 
     impl Component for Spawner {
-        fn handle_event(&mut self, event: KeyEvent, _ctx: &Context) -> EventResult {
+        fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
             if event.code == self.spawn_key {
-                return EventResult::Push(Box::new(TagComponent(self.spawn_label)), Vec::new());
+                win.open(Box::new(TagComponent(self.spawn_label)));
             }
-            EventResult::Consumed(Vec::new())
         }
         fn render(&self, _: &mut Frame, _: Rect, _: &UiTheme) {}
         fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
@@ -548,11 +545,12 @@ mod tests {
     fn tab_is_intercepted_before_components() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-        /// Consumes literally every event, including Tab.
+        /// Absorbs every event and emits a no-op msg — the "bad
+        /// plugin" that would swallow Tab if Tab reached it.
         struct SwallowsAll;
         impl Component for SwallowsAll {
-            fn handle_event(&mut self, _: KeyEvent, _: &Context) -> EventResult {
-                EventResult::Consumed(vec![AppMsg::Map(crate::map::Action::None)])
+            fn handle_event(&mut self, _: KeyEvent, win: &mut Window) {
+                win.emit(AppMsg::Map(crate::map::Action::None));
             }
             fn render(&self, _: &mut Frame, _: Rect, _: &UiTheme) {}
         }

--- a/src/compositor/window.rs
+++ b/src/compositor/window.rs
@@ -1,390 +1,124 @@
-//! Window API — capability-constrained handle passed to components.
+//! [`Window`] — capability-constrained handle passed to components.
 //!
-//! **Prototype.** Compiles (so types are validated) but not wired
-//! into `Compositor` yet. Documents the target shape for replacing
-//! the `EventResult`-return-value Component API with an imperative
-//! `&mut Window` call API.
-//!
-//! # Why
-//!
-//! Today a component's `handle_event` returns a `Vec<AppMsg>` + an
-//! `EventResult` variant describing what the compositor should do
-//! with the stack (`Consumed` / `Close` / `Push` / `CloseAndPush` /
-//! `Ignored`). Compound operations like "close me and open a sibling"
-//! need their own variant (`CloseAndPush`). Adding a new compound
-//! requires a new variant.
-//!
-//! With a `Window` handle, the component expresses the same intents
-//! imperatively:
+//! Components receive a `&mut Window` on every hook (`handle_event`
+//! and `poll`). They express intent by calling methods on it:
 //!
 //! ```ignore
 //! fn handle_event(&mut self, ev: KeyEvent, win: &mut Window) {
-//!     if esc {
+//!     if ev.code == KeyCode::Esc {
 //!         win.close();
-//!     } else if picked_search {
+//!     } else if enter_with_selection {
+//!         win.emit(AppMsg::Jump(loc));
+//!         win.close();
+//!     } else if ev.code == KeyCode::Char('/') {
 //!         win.close();
 //!         win.open(Box::new(SearchComponent::new()));
-//!     } else if picked_theme(theme) {
-//!         win.emit(AppMsg::SetTheme(theme));
-//!         win.close();
 //!     }
 //! }
 //! ```
 //!
-//! The `close()` / `open()` / `emit()` calls are **queued into
-//! `WindowOps`**. When `handle_event` returns, the compositor reads
-//! the queue and applies it atomically in a deterministic order
-//! (close → push → msgs). The component never holds `&mut
-//! Compositor`, so invariants remain enforced by the framework.
+//! Method calls queue into [`WindowOps`]. The compositor drains the
+//! queue after the hook returns and applies the ops atomically in a
+//! deterministic order: `close` → `opens` (with TypeId dedup) → and
+//! the collected `msgs` are returned to `App::dispatch`.
 //!
-//! # What this gains over EventResult
+//! # Why a handle instead of a return value
 //!
-//! - **No variant explosion.** `CloseAndPush` collapses into
-//!   `win.close(); win.open(c);` — two atomic queued ops, compositor
-//!   applies them in order. Future compounds are free.
-//! - **Theme injection goes away.** `win.theme()` exposes theme
-//!   without a `theme: &UiTheme` argument threaded through every
-//!   render path.
-//! - **Uniform draw primitives.** `win.popup(...)`, `win.list(...)`,
-//!   `win.text(...)` factor the `Clear + Block + centered_rect +
-//!   Paragraph` boilerplate currently duplicated across every
-//!   plugin's panel.rs.
-//!
-//! # What it doesn't lose
-//!
-//! Plugin still cannot mutate `Compositor` directly — `Window` is a
-//! narrow capability type. Every method queues into `WindowOps`;
-//! compositor applies with dedup, clamping, and ordering rules. The
-//! "plugin can't break focus/stack invariants" guarantee is
-//! preserved.
-
-#![allow(dead_code)] // prototype; wired in incrementally
-
-use std::any::Any;
-
-use crossterm::event::KeyEvent;
-use ratatui::Frame;
-use ratatui::layout::Rect;
+//! Returning an `EventResult` enum with one variant per op
+//! combination (`Close`, `Push`, `CloseAndPush`, …) does not scale
+//! — every new compound op needs a new variant. The handle queues
+//! primitive ops so compounds are expressed by composition. Plugin
+//! still cannot hold `&mut Compositor` or mutate the stack directly;
+//! the compositor is the sole applier of the queue, so invariants
+//! (focus, dedup, clamp) remain framework-enforced.
 
 use crate::app::AppMsg;
-use crate::compositor::Context;
-use crate::theme::UiTheme;
+use crate::compositor::{Component, Context};
 
-// ── WindowOps: the queue ───────────────────────────────────────────
-
-/// Queue of actions the compositor applies after `Component::*`
-/// returns. Plugin never sees this type directly; it mutates it only
-/// through [`Window`] methods.
+/// Queue of actions a [`Component`] hook recorded through [`Window`].
+/// Drained and applied by the compositor after the hook returns.
 #[derive(Default)]
-pub struct WindowOps {
-    /// `true` if the plugin called `win.close()`. Close fires before
-    /// any queued `open`s, so a plugin that does `close(); open(x);`
-    /// in one `handle_event` ends with `x` in its slot.
+pub(crate) struct WindowOps {
+    /// `true` if the plugin called [`Window::close`]. Pops the
+    /// calling component. Applied before `opens` so `close + open`
+    /// replaces the component in the stack slot.
     pub close: bool,
-    /// Components queued by `win.open(c)`. Pushed in the order they
-    /// were queued. Dedup (by `TypeId`) is applied when the
-    /// compositor drains the queue.
+    /// Components queued by [`Window::open`]. Each goes through
+    /// TypeId dedup when pushed; a duplicate of an existing stack
+    /// entry shifts focus to the existing one instead.
     pub opens: Vec<Box<dyn Component>>,
-    /// Messages for `App::dispatch`. Emitted in the order queued.
-    /// Typically dispatched **before** the stack is mutated so e.g.
-    /// a `Jump` fires while the current focus is still valid.
+    /// Messages for [`App::dispatch`](crate::app::App). Returned
+    /// from `Compositor::handle_event` to the caller (App), which
+    /// dispatches them after the ops have been applied.
     pub msgs: Vec<AppMsg>,
-    /// `true` if the plugin explicitly returned "I don't handle
-    /// this". Triggers fall-through to the base layer (if this
-    /// component isn't already the base).
+    /// `true` if the plugin called [`Window::ignore`]. Meaningful
+    /// only when no other op was queued — in that case the
+    /// compositor re-delivers the event to the base layer (unless
+    /// the handler already was the base). Ignored otherwise.
     pub ignored: bool,
 }
 
 impl WindowOps {
-    /// Compositor application order (documented here, not
-    /// implemented by this prototype):
-    ///
-    /// 1. `msgs` → forwarded to `App::dispatch` before stack
-    ///    mutations so user-visible effects (Jump, SetTheme) fire
-    ///    while the current component is still conceptually alive.
-    /// 2. `close` → if true, pop the calling component.
-    /// 3. `opens` → each is pushed in order; each push goes through
-    ///    TypeId dedup (existing instance → focus moves, new drop).
-    /// 4. `ignored` → only honoured if `opens` empty and `close`
-    ///    false and `msgs` empty. Otherwise the plugin *did*
-    ///    express intent, so `ignored` is a contradiction and is
-    ///    silently dropped.
-    pub fn is_noop(&self) -> bool {
-        !self.close && self.opens.is_empty() && self.msgs.is_empty() && !self.ignored
+    /// `true` iff the hook made no state-changing call. When the
+    /// hook's only effect was `ignore()`, this is also true (ignore
+    /// itself is a signal, not an op).
+    pub(crate) fn is_ignorable_noop(&self) -> bool {
+        !self.close && self.opens.is_empty() && self.msgs.is_empty()
     }
 }
 
-// ── Window: the capability type ────────────────────────────────────
-
-/// Handle plugins receive in place of returning `EventResult`.
-/// Constrained by construction: no `&mut Compositor`, no direct
-/// access to the stack, no way to reorder siblings.
+/// Handle components receive on every hook. Constrained by design:
+/// no `&mut Compositor` is reachable through it, so components
+/// cannot break focus / stack invariants even if buggy.
+///
+/// Read-only accessors (`ctx`) give the component what it needs for
+/// decision-making without granting any capability.
 pub struct Window<'a> {
     ops: &'a mut WindowOps,
     ctx: &'a Context,
-    theme: &'a UiTheme,
-    frame: Option<&'a mut Frame<'a>>, // only populated during render
-    area: Rect,
 }
 
 impl<'a> Window<'a> {
-    /// Constructor used by the compositor when delivering events —
-    /// prototype-only; real version will be crate-private.
-    pub fn new_for_event(ops: &'a mut WindowOps, ctx: &'a Context, theme: &'a UiTheme) -> Self {
-        Self {
-            ops,
-            ctx,
-            theme,
-            frame: None,
-            area: Rect::default(),
-        }
+    pub(crate) fn new(ops: &'a mut WindowOps, ctx: &'a Context) -> Self {
+        Self { ops, ctx }
     }
 
-    /// Constructor used by the compositor during render — prototype-
-    /// only. Real version will be crate-private and set frame/area.
-    pub fn new_for_render(
-        ops: &'a mut WindowOps,
-        ctx: &'a Context,
-        theme: &'a UiTheme,
-        frame: &'a mut Frame<'a>,
-        area: Rect,
-    ) -> Self {
-        Self {
-            ops,
-            ctx,
-            theme,
-            frame: Some(frame),
-            area,
-        }
-    }
-
-    // ── Read-only accessors (no capability) ───────────────────────
-
-    pub fn theme(&self) -> &UiTheme {
-        self.theme
-    }
-
+    /// App-level snapshot passed for this hook (map center, theme id).
     pub fn ctx(&self) -> &Context {
         self.ctx
     }
 
-    pub fn area(&self) -> Rect {
-        self.area
-    }
-
-    // ── Queued actions (compositor applies later) ─────────────────
-
-    /// Pop this component from the compositor stack after
-    /// `handle_event` returns. Idempotent — second call does
-    /// nothing. Atomic with `open` calls in the same event (close
-    /// fires first).
+    /// Pop the calling component from the stack after the hook
+    /// returns. Idempotent — a second call is a no-op. Applied
+    /// before `open()`s so `close(); open(c);` replaces this
+    /// component with `c`.
     pub fn close(&mut self) {
         self.ops.close = true;
     }
 
-    /// Push a new component on top of the compositor stack after
-    /// `handle_event` returns. If `win.close()` was also called this
-    /// event, the stack ends up with `c` replacing the current
-    /// component — the equivalent of the old
-    /// `EventResult::CloseAndPush`. If not, `c` sits on top of the
-    /// current component — the equivalent of `EventResult::Push`.
+    /// Push `c` on top of the stack after the hook returns. Subject
+    /// to TypeId dedup: if a component of the same concrete type is
+    /// already on the stack, focus shifts to the existing instance
+    /// and `c` is dropped.
     pub fn open(&mut self, c: Box<dyn Component>) {
         self.ops.opens.push(c);
     }
 
-    /// Queue a message for `App::dispatch`. Emitted before stack
-    /// mutations settle, so downstream state changes happen while
-    /// the calling component is still on the stack (e.g. a `Jump`
-    /// fires first, then `close()` pops the picker).
+    /// Queue `msg` for `App::dispatch`. Dispatched by the caller
+    /// (App) after the compositor has applied `close` / `open`. For
+    /// typical `emit + close` patterns this means the msg still
+    /// fires, but the component is already popped when it runs —
+    /// identical to the old `EventResult::Close(msgs)` semantic.
     pub fn emit(&mut self, msg: AppMsg) {
         self.ops.msgs.push(msg);
     }
 
-    /// Mark this event as not-mine; compositor re-delivers to the
-    /// base layer (if this isn't already it). Only meaningful when
-    /// no other op was queued — mixing with `close` / `open` /
-    /// `emit` is silently dropped.
+    /// Signal "this event isn't mine". With no other op queued,
+    /// the compositor falls through to the base layer (if this
+    /// component isn't already it). If combined with `close` /
+    /// `open` / `emit`, the flag is silently dropped — the
+    /// component clearly handled the event.
     pub fn ignore(&mut self) {
         self.ops.ignored = true;
     }
-
-    // ── Draw primitives (only meaningful during render) ───────────
-    //
-    // These are stubs in the prototype. Real versions will wrap
-    // ratatui constructs (`Clear` + `Block` + `Paragraph` + layout
-    // math) with theme applied automatically.
-
-    /// Fill a sub-area with a theme-styled bordered popup containing
-    /// the given content. Convenience for `Clear + Block +
-    /// Paragraph`. Takes a relative rect inside `self.area()`.
-    pub fn popup(&mut self, _rect: Rect, _title: &str, _content: &str) {
-        // TODO prototype — real impl uses self.frame.as_mut().unwrap()
-    }
-
-    /// Render a theme-styled selectable list. Higher-level than a
-    /// raw `List` widget because it handles highlight style and
-    /// wrapping.
-    pub fn list<'i, I: IntoIterator<Item = &'i str>>(
-        &mut self,
-        _rect: Rect,
-        _items: I,
-        _selected: usize,
-    ) {
-        // TODO prototype
-    }
-
-    /// Render a single line of theme-styled text.
-    pub fn text(&mut self, _rect: Rect, _text: &str) {
-        // TODO prototype
-    }
 }
-
-// ── Component trait (new shape) ────────────────────────────────────
-
-/// Prototype of the post-Window-API `Component` trait. **Not yet
-/// replacing [`crate::compositor::Component`]** — coexists during
-/// migration; plugins will be converted one at a time.
-///
-/// Every hook receives a `&mut Window` instead of returning
-/// `EventResult`. The plugin expresses intent through `win.*` calls.
-pub trait Component: Any {
-    /// Handle a single key event. Plugin queues actions via `win`.
-    /// If no `win.*` call was made, the event is implicitly ignored.
-    fn handle_event(&mut self, event: KeyEvent, win: &mut Window);
-
-    /// Paint this component's popup / panel into `win.area()`.
-    /// Plugin calls `win.popup(...)` etc. to render; theme is
-    /// automatically applied.
-    fn render(&self, win: &mut Window);
-
-    /// Paint world-space primitives on the map. Called every frame
-    /// while the component is on the stack; gated on stack presence
-    /// exactly like `render`.
-    fn paint_on_map(&self, _win: &mut Window) {}
-
-    /// Periodic tick for async work. Plugin drains completed
-    /// futures and emits messages via `win.emit(...)`.
-    fn poll(&mut self, _win: &mut Window) {}
-
-    /// Footer hints shown while this component is focused.
-    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
-        Vec::new()
-    }
-}
-
-// ── Prototype: what SearchComponent looks like after conversion ────
-//
-// Mirrors the real `plugin::search::SearchComponent` — just the
-// handle_event path to show how Close/Push collapse.
-
-use crate::geo::LonLat as _LonLat;
-
-struct StubSearchResult {
-    location: _LonLat,
-}
-
-pub struct SearchComponent {
-    query: String,
-    candidates: Vec<StubSearchResult>,
-    selected: usize,
-}
-
-impl SearchComponent {
-    pub fn new() -> Self {
-        Self {
-            query: String::new(),
-            candidates: Vec::new(),
-            selected: 0,
-        }
-    }
-
-    fn has_candidates(&self) -> bool {
-        !self.candidates.is_empty()
-    }
-}
-
-impl Default for SearchComponent {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Component for SearchComponent {
-    fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
-        use crossterm::event::{KeyCode, KeyModifiers};
-
-        let ctrl = event.modifiers.contains(KeyModifiers::CONTROL);
-
-        if self.has_candidates() {
-            let up = matches!(event.code, KeyCode::Up | KeyCode::Char('k'))
-                || (ctrl && event.code == KeyCode::Char('p'));
-            let down = matches!(event.code, KeyCode::Down | KeyCode::Char('j'))
-                || (ctrl && event.code == KeyCode::Char('n'));
-
-            if event.code == KeyCode::Esc {
-                win.close();
-            } else if event.code == KeyCode::Enter {
-                let loc = self.candidates[self.selected].location;
-                win.emit(AppMsg::Jump(loc));
-                win.close();
-            } else if up && self.selected > 0 {
-                self.selected -= 1;
-            } else if down && self.selected + 1 < self.candidates.len() {
-                self.selected += 1;
-            }
-            return;
-        }
-
-        match event.code {
-            KeyCode::Esc => win.close(),
-            KeyCode::Enter if self.query.is_empty() => win.close(),
-            KeyCode::Enter => { /* kick off async search; no stack op */ }
-            KeyCode::Backspace => {
-                self.query.pop();
-            }
-            KeyCode::Char('h') if ctrl => {
-                self.query.pop();
-            }
-            KeyCode::Char('u') if ctrl => {
-                self.query.clear();
-            }
-            KeyCode::Char(c) => self.query.push(c),
-            _ => { /* modal */ }
-        }
-    }
-
-    fn render(&self, win: &mut Window) {
-        // Real: win.popup(...), win.list(...) etc.
-        let _ = win;
-    }
-}
-
-// ── Prototype: what PaletteComponent's "open search" looks like ────
-//
-// Shows how CloseAndPush collapses. The entire PaletteAction::Push
-// variant goes away.
-//
-// ```ignore
-// // Before (EventResult world):
-// PaletteAction::Push(component) => EventResult::CloseAndPush(component, Vec::new()),
-//
-// // After (Window world):
-// fn handle_event(&mut self, ev, win) {
-//     match ev.code {
-//         KeyCode::Enter => match self.provider.execute(idx, win.ctx()) {
-//             PaletteAction::Close => win.close(),
-//             PaletteAction::Run(msgs) => {
-//                 for m in msgs { win.emit(m); }
-//                 win.close();
-//             }
-//             PaletteAction::Push(c) => {
-//                 // No new EventResult variant — just close + open.
-//                 win.close();
-//                 win.open(c);
-//             }
-//             PaletteAction::SwitchProvider(p) => { self.provider = p; }
-//         },
-//         ...
-//     }
-// }
-// ```

--- a/src/compositor/window.rs
+++ b/src/compositor/window.rs
@@ -1,0 +1,390 @@
+//! Window API — capability-constrained handle passed to components.
+//!
+//! **Prototype.** Compiles (so types are validated) but not wired
+//! into `Compositor` yet. Documents the target shape for replacing
+//! the `EventResult`-return-value Component API with an imperative
+//! `&mut Window` call API.
+//!
+//! # Why
+//!
+//! Today a component's `handle_event` returns a `Vec<AppMsg>` + an
+//! `EventResult` variant describing what the compositor should do
+//! with the stack (`Consumed` / `Close` / `Push` / `CloseAndPush` /
+//! `Ignored`). Compound operations like "close me and open a sibling"
+//! need their own variant (`CloseAndPush`). Adding a new compound
+//! requires a new variant.
+//!
+//! With a `Window` handle, the component expresses the same intents
+//! imperatively:
+//!
+//! ```ignore
+//! fn handle_event(&mut self, ev: KeyEvent, win: &mut Window) {
+//!     if esc {
+//!         win.close();
+//!     } else if picked_search {
+//!         win.close();
+//!         win.open(Box::new(SearchComponent::new()));
+//!     } else if picked_theme(theme) {
+//!         win.emit(AppMsg::SetTheme(theme));
+//!         win.close();
+//!     }
+//! }
+//! ```
+//!
+//! The `close()` / `open()` / `emit()` calls are **queued into
+//! `WindowOps`**. When `handle_event` returns, the compositor reads
+//! the queue and applies it atomically in a deterministic order
+//! (close → push → msgs). The component never holds `&mut
+//! Compositor`, so invariants remain enforced by the framework.
+//!
+//! # What this gains over EventResult
+//!
+//! - **No variant explosion.** `CloseAndPush` collapses into
+//!   `win.close(); win.open(c);` — two atomic queued ops, compositor
+//!   applies them in order. Future compounds are free.
+//! - **Theme injection goes away.** `win.theme()` exposes theme
+//!   without a `theme: &UiTheme` argument threaded through every
+//!   render path.
+//! - **Uniform draw primitives.** `win.popup(...)`, `win.list(...)`,
+//!   `win.text(...)` factor the `Clear + Block + centered_rect +
+//!   Paragraph` boilerplate currently duplicated across every
+//!   plugin's panel.rs.
+//!
+//! # What it doesn't lose
+//!
+//! Plugin still cannot mutate `Compositor` directly — `Window` is a
+//! narrow capability type. Every method queues into `WindowOps`;
+//! compositor applies with dedup, clamping, and ordering rules. The
+//! "plugin can't break focus/stack invariants" guarantee is
+//! preserved.
+
+#![allow(dead_code)] // prototype; wired in incrementally
+
+use std::any::Any;
+
+use crossterm::event::KeyEvent;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+
+use crate::app::AppMsg;
+use crate::compositor::Context;
+use crate::theme::UiTheme;
+
+// ── WindowOps: the queue ───────────────────────────────────────────
+
+/// Queue of actions the compositor applies after `Component::*`
+/// returns. Plugin never sees this type directly; it mutates it only
+/// through [`Window`] methods.
+#[derive(Default)]
+pub struct WindowOps {
+    /// `true` if the plugin called `win.close()`. Close fires before
+    /// any queued `open`s, so a plugin that does `close(); open(x);`
+    /// in one `handle_event` ends with `x` in its slot.
+    pub close: bool,
+    /// Components queued by `win.open(c)`. Pushed in the order they
+    /// were queued. Dedup (by `TypeId`) is applied when the
+    /// compositor drains the queue.
+    pub opens: Vec<Box<dyn Component>>,
+    /// Messages for `App::dispatch`. Emitted in the order queued.
+    /// Typically dispatched **before** the stack is mutated so e.g.
+    /// a `Jump` fires while the current focus is still valid.
+    pub msgs: Vec<AppMsg>,
+    /// `true` if the plugin explicitly returned "I don't handle
+    /// this". Triggers fall-through to the base layer (if this
+    /// component isn't already the base).
+    pub ignored: bool,
+}
+
+impl WindowOps {
+    /// Compositor application order (documented here, not
+    /// implemented by this prototype):
+    ///
+    /// 1. `msgs` → forwarded to `App::dispatch` before stack
+    ///    mutations so user-visible effects (Jump, SetTheme) fire
+    ///    while the current component is still conceptually alive.
+    /// 2. `close` → if true, pop the calling component.
+    /// 3. `opens` → each is pushed in order; each push goes through
+    ///    TypeId dedup (existing instance → focus moves, new drop).
+    /// 4. `ignored` → only honoured if `opens` empty and `close`
+    ///    false and `msgs` empty. Otherwise the plugin *did*
+    ///    express intent, so `ignored` is a contradiction and is
+    ///    silently dropped.
+    pub fn is_noop(&self) -> bool {
+        !self.close && self.opens.is_empty() && self.msgs.is_empty() && !self.ignored
+    }
+}
+
+// ── Window: the capability type ────────────────────────────────────
+
+/// Handle plugins receive in place of returning `EventResult`.
+/// Constrained by construction: no `&mut Compositor`, no direct
+/// access to the stack, no way to reorder siblings.
+pub struct Window<'a> {
+    ops: &'a mut WindowOps,
+    ctx: &'a Context,
+    theme: &'a UiTheme,
+    frame: Option<&'a mut Frame<'a>>, // only populated during render
+    area: Rect,
+}
+
+impl<'a> Window<'a> {
+    /// Constructor used by the compositor when delivering events —
+    /// prototype-only; real version will be crate-private.
+    pub fn new_for_event(ops: &'a mut WindowOps, ctx: &'a Context, theme: &'a UiTheme) -> Self {
+        Self {
+            ops,
+            ctx,
+            theme,
+            frame: None,
+            area: Rect::default(),
+        }
+    }
+
+    /// Constructor used by the compositor during render — prototype-
+    /// only. Real version will be crate-private and set frame/area.
+    pub fn new_for_render(
+        ops: &'a mut WindowOps,
+        ctx: &'a Context,
+        theme: &'a UiTheme,
+        frame: &'a mut Frame<'a>,
+        area: Rect,
+    ) -> Self {
+        Self {
+            ops,
+            ctx,
+            theme,
+            frame: Some(frame),
+            area,
+        }
+    }
+
+    // ── Read-only accessors (no capability) ───────────────────────
+
+    pub fn theme(&self) -> &UiTheme {
+        self.theme
+    }
+
+    pub fn ctx(&self) -> &Context {
+        self.ctx
+    }
+
+    pub fn area(&self) -> Rect {
+        self.area
+    }
+
+    // ── Queued actions (compositor applies later) ─────────────────
+
+    /// Pop this component from the compositor stack after
+    /// `handle_event` returns. Idempotent — second call does
+    /// nothing. Atomic with `open` calls in the same event (close
+    /// fires first).
+    pub fn close(&mut self) {
+        self.ops.close = true;
+    }
+
+    /// Push a new component on top of the compositor stack after
+    /// `handle_event` returns. If `win.close()` was also called this
+    /// event, the stack ends up with `c` replacing the current
+    /// component — the equivalent of the old
+    /// `EventResult::CloseAndPush`. If not, `c` sits on top of the
+    /// current component — the equivalent of `EventResult::Push`.
+    pub fn open(&mut self, c: Box<dyn Component>) {
+        self.ops.opens.push(c);
+    }
+
+    /// Queue a message for `App::dispatch`. Emitted before stack
+    /// mutations settle, so downstream state changes happen while
+    /// the calling component is still on the stack (e.g. a `Jump`
+    /// fires first, then `close()` pops the picker).
+    pub fn emit(&mut self, msg: AppMsg) {
+        self.ops.msgs.push(msg);
+    }
+
+    /// Mark this event as not-mine; compositor re-delivers to the
+    /// base layer (if this isn't already it). Only meaningful when
+    /// no other op was queued — mixing with `close` / `open` /
+    /// `emit` is silently dropped.
+    pub fn ignore(&mut self) {
+        self.ops.ignored = true;
+    }
+
+    // ── Draw primitives (only meaningful during render) ───────────
+    //
+    // These are stubs in the prototype. Real versions will wrap
+    // ratatui constructs (`Clear` + `Block` + `Paragraph` + layout
+    // math) with theme applied automatically.
+
+    /// Fill a sub-area with a theme-styled bordered popup containing
+    /// the given content. Convenience for `Clear + Block +
+    /// Paragraph`. Takes a relative rect inside `self.area()`.
+    pub fn popup(&mut self, _rect: Rect, _title: &str, _content: &str) {
+        // TODO prototype — real impl uses self.frame.as_mut().unwrap()
+    }
+
+    /// Render a theme-styled selectable list. Higher-level than a
+    /// raw `List` widget because it handles highlight style and
+    /// wrapping.
+    pub fn list<'i, I: IntoIterator<Item = &'i str>>(
+        &mut self,
+        _rect: Rect,
+        _items: I,
+        _selected: usize,
+    ) {
+        // TODO prototype
+    }
+
+    /// Render a single line of theme-styled text.
+    pub fn text(&mut self, _rect: Rect, _text: &str) {
+        // TODO prototype
+    }
+}
+
+// ── Component trait (new shape) ────────────────────────────────────
+
+/// Prototype of the post-Window-API `Component` trait. **Not yet
+/// replacing [`crate::compositor::Component`]** — coexists during
+/// migration; plugins will be converted one at a time.
+///
+/// Every hook receives a `&mut Window` instead of returning
+/// `EventResult`. The plugin expresses intent through `win.*` calls.
+pub trait Component: Any {
+    /// Handle a single key event. Plugin queues actions via `win`.
+    /// If no `win.*` call was made, the event is implicitly ignored.
+    fn handle_event(&mut self, event: KeyEvent, win: &mut Window);
+
+    /// Paint this component's popup / panel into `win.area()`.
+    /// Plugin calls `win.popup(...)` etc. to render; theme is
+    /// automatically applied.
+    fn render(&self, win: &mut Window);
+
+    /// Paint world-space primitives on the map. Called every frame
+    /// while the component is on the stack; gated on stack presence
+    /// exactly like `render`.
+    fn paint_on_map(&self, _win: &mut Window) {}
+
+    /// Periodic tick for async work. Plugin drains completed
+    /// futures and emits messages via `win.emit(...)`.
+    fn poll(&mut self, _win: &mut Window) {}
+
+    /// Footer hints shown while this component is focused.
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
+        Vec::new()
+    }
+}
+
+// ── Prototype: what SearchComponent looks like after conversion ────
+//
+// Mirrors the real `plugin::search::SearchComponent` — just the
+// handle_event path to show how Close/Push collapse.
+
+use crate::geo::LonLat as _LonLat;
+
+struct StubSearchResult {
+    location: _LonLat,
+}
+
+pub struct SearchComponent {
+    query: String,
+    candidates: Vec<StubSearchResult>,
+    selected: usize,
+}
+
+impl SearchComponent {
+    pub fn new() -> Self {
+        Self {
+            query: String::new(),
+            candidates: Vec::new(),
+            selected: 0,
+        }
+    }
+
+    fn has_candidates(&self) -> bool {
+        !self.candidates.is_empty()
+    }
+}
+
+impl Default for SearchComponent {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Component for SearchComponent {
+    fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        let ctrl = event.modifiers.contains(KeyModifiers::CONTROL);
+
+        if self.has_candidates() {
+            let up = matches!(event.code, KeyCode::Up | KeyCode::Char('k'))
+                || (ctrl && event.code == KeyCode::Char('p'));
+            let down = matches!(event.code, KeyCode::Down | KeyCode::Char('j'))
+                || (ctrl && event.code == KeyCode::Char('n'));
+
+            if event.code == KeyCode::Esc {
+                win.close();
+            } else if event.code == KeyCode::Enter {
+                let loc = self.candidates[self.selected].location;
+                win.emit(AppMsg::Jump(loc));
+                win.close();
+            } else if up && self.selected > 0 {
+                self.selected -= 1;
+            } else if down && self.selected + 1 < self.candidates.len() {
+                self.selected += 1;
+            }
+            return;
+        }
+
+        match event.code {
+            KeyCode::Esc => win.close(),
+            KeyCode::Enter if self.query.is_empty() => win.close(),
+            KeyCode::Enter => { /* kick off async search; no stack op */ }
+            KeyCode::Backspace => {
+                self.query.pop();
+            }
+            KeyCode::Char('h') if ctrl => {
+                self.query.pop();
+            }
+            KeyCode::Char('u') if ctrl => {
+                self.query.clear();
+            }
+            KeyCode::Char(c) => self.query.push(c),
+            _ => { /* modal */ }
+        }
+    }
+
+    fn render(&self, win: &mut Window) {
+        // Real: win.popup(...), win.list(...) etc.
+        let _ = win;
+    }
+}
+
+// ── Prototype: what PaletteComponent's "open search" looks like ────
+//
+// Shows how CloseAndPush collapses. The entire PaletteAction::Push
+// variant goes away.
+//
+// ```ignore
+// // Before (EventResult world):
+// PaletteAction::Push(component) => EventResult::CloseAndPush(component, Vec::new()),
+//
+// // After (Window world):
+// fn handle_event(&mut self, ev, win) {
+//     match ev.code {
+//         KeyCode::Enter => match self.provider.execute(idx, win.ctx()) {
+//             PaletteAction::Close => win.close(),
+//             PaletteAction::Run(msgs) => {
+//                 for m in msgs { win.emit(m); }
+//                 win.close();
+//             }
+//             PaletteAction::Push(c) => {
+//                 // No new EventResult variant — just close + open.
+//                 win.close();
+//                 win.open(c);
+//             }
+//             PaletteAction::SwitchProvider(p) => { self.provider = p; }
+//         },
+//         ...
+//     }
+// }
+// ```

--- a/src/plugin/help/mod.rs
+++ b/src/plugin/help/mod.rs
@@ -10,9 +10,8 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, Paragraph};
 
 use crate::app::AppMsg;
-use crate::compositor::{
-    Activation, Component, Context, EventResult, PaletteEntry, PaletteKind, Registrar,
-};
+use crate::compositor::window::Window;
+use crate::compositor::{Activation, Component, Context, PaletteEntry, PaletteKind, Registrar};
 use crate::keymap::KeyMap;
 use crate::map::Action;
 use crate::theme::UiTheme;
@@ -96,10 +95,10 @@ impl HelpComponent {
 }
 
 impl Component for HelpComponent {
-    fn handle_event(&mut self, _event: KeyEvent, _ctx: &Context) -> EventResult {
+    fn handle_event(&mut self, _event: KeyEvent, win: &mut Window) {
         // Help is fully modal: any key closes the panel. (Tab is
         // intercepted by the compositor before it reaches here.)
-        EventResult::Close(Vec::new())
+        win.close();
     }
 
     fn render(&self, f: &mut Frame, map_inner: Rect, theme: &UiTheme) {

--- a/src/plugin/palette/mod.rs
+++ b/src/plugin/palette/mod.rs
@@ -25,7 +25,8 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 
 use crate::color_palette::ThemeId;
-use crate::compositor::{Activation, Component, Context, EventResult, Registrar};
+use crate::compositor::window::Window;
+use crate::compositor::{Activation, Component, Context, Registrar};
 use crate::keymap::KeyMap;
 use crate::theme::UiTheme;
 
@@ -65,69 +66,70 @@ impl PaletteComponent {
 }
 
 impl Component for PaletteComponent {
-    fn handle_event(&mut self, event: KeyEvent, ctx: &Context) -> EventResult {
+    fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
         let ctrl = event.modifiers.contains(KeyModifiers::CONTROL);
         let up = matches!(event.code, KeyCode::Up) || (ctrl && event.code == KeyCode::Char('p'));
         let down =
             matches!(event.code, KeyCode::Down) || (ctrl && event.code == KeyCode::Char('n'));
 
         match event.code {
-            KeyCode::Esc => EventResult::Close(Vec::new()),
+            KeyCode::Esc => win.close(),
             KeyCode::Enter => {
                 let has_item = self.selected < self.items_len();
                 if !has_item {
-                    return EventResult::Close(Vec::new());
+                    win.close();
+                    return;
                 }
                 let idx = self.selected;
-                let action = self.provider.execute(idx, ctx);
+                let action = self.provider.execute(idx, win.ctx());
                 match action {
-                    PaletteAction::Close => EventResult::Close(Vec::new()),
-                    PaletteAction::Run(msgs) => EventResult::Close(msgs),
+                    PaletteAction::Close => win.close(),
+                    PaletteAction::Run(msgs) => {
+                        for m in msgs {
+                            win.emit(m);
+                        }
+                        win.close();
+                    }
                     PaletteAction::Push(component) => {
-                        EventResult::CloseAndPush(component, Vec::new())
+                        // The compositor applies `close` before
+                        // `open` from the same WindowOps, so the
+                        // palette is out of the way before the new
+                        // component lands — identical to what the
+                        // old `EventResult::CloseAndPush` did.
+                        win.close();
+                        win.open(component);
                     }
                     PaletteAction::SwitchProvider(next) => {
                         self.query.clear();
                         self.selected = 0;
                         self.provider = next;
                         self.provider.filter("");
-                        EventResult::Consumed(Vec::new())
                     }
                 }
             }
-            _ if up => {
-                if self.selected > 0 {
-                    self.selected -= 1;
-                }
-                EventResult::Consumed(Vec::new())
+            _ if up && self.selected > 0 => {
+                self.selected -= 1;
             }
-            _ if down => {
-                if self.selected + 1 < self.items_len() {
-                    self.selected += 1;
-                }
-                EventResult::Consumed(Vec::new())
+            _ if down && self.selected + 1 < self.items_len() => {
+                self.selected += 1;
             }
             KeyCode::Backspace => {
                 self.query.pop();
                 self.refilter();
-                EventResult::Consumed(Vec::new())
             }
             KeyCode::Char('h') if ctrl => {
                 self.query.pop();
                 self.refilter();
-                EventResult::Consumed(Vec::new())
             }
             KeyCode::Char('u') if ctrl => {
                 self.query.clear();
                 self.refilter();
-                EventResult::Consumed(Vec::new())
             }
             KeyCode::Char(c) => {
                 self.query.push(c);
                 self.refilter();
-                EventResult::Consumed(Vec::new())
             }
-            _ => EventResult::Consumed(Vec::new()),
+            _ => {}
         }
     }
 
@@ -243,15 +245,21 @@ mod tests {
             .collect()
     }
 
-    fn key(p: &mut PaletteComponent, code: KeyCode, mods: KeyModifiers) -> EventResult {
-        p.handle_event(KeyEvent::new(code, mods), &CTX)
+    use crate::compositor::window::WindowOps;
+
+    fn dispatch(p: &mut PaletteComponent, code: KeyCode, mods: KeyModifiers) -> WindowOps {
+        let mut ops = WindowOps::default();
+        {
+            let mut win = Window::new(&mut ops, &CTX);
+            p.handle_event(KeyEvent::new(code, mods), &mut win);
+        }
+        ops
     }
 
-    fn expect_consumed(r: EventResult) {
-        match r {
-            EventResult::Consumed(msgs) => assert!(msgs.is_empty()),
-            _ => panic!("expected Consumed"),
-        }
+    fn expect_consumed(ops: WindowOps) {
+        assert!(!ops.close);
+        assert!(ops.opens.is_empty());
+        assert!(ops.msgs.is_empty());
     }
 
     #[test]
@@ -263,80 +271,73 @@ mod tests {
     #[test]
     fn filter_substring_case_insensitive() {
         let mut p = palette_with(&["Zoom in", "Zoom out", "Quit"]);
-        key(&mut p, KeyCode::Char('Z'), NONE);
+        dispatch(&mut p, KeyCode::Char('Z'), NONE);
         assert_eq!(filtered_labels(&p), vec!["Zoom in", "Zoom out"]);
     }
 
     #[test]
     fn filter_earlier_match_ranks_first() {
         let mut p = palette_with(&["Zoom in", "Quit"]);
-        key(&mut p, KeyCode::Char('i'), NONE);
+        dispatch(&mut p, KeyCode::Char('i'), NONE);
         assert_eq!(filtered_labels(&p), vec!["Quit", "Zoom in"]);
     }
 
     #[test]
     fn backspace_widens_filter() {
         let mut p = palette_with(&["Zoom in", "Quit"]);
-        key(&mut p, KeyCode::Char('z'), NONE);
+        dispatch(&mut p, KeyCode::Char('z'), NONE);
         assert_eq!(filtered_labels(&p), vec!["Zoom in"]);
-        key(&mut p, KeyCode::Backspace, NONE);
+        dispatch(&mut p, KeyCode::Backspace, NONE);
         assert_eq!(filtered_labels(&p), vec!["Zoom in", "Quit"]);
     }
 
     #[test]
     fn down_up_stays_in_bounds() {
         let mut p = palette_with(&["A", "B", "C"]);
-        expect_consumed(key(&mut p, KeyCode::Down, NONE));
-        expect_consumed(key(&mut p, KeyCode::Down, NONE));
-        expect_consumed(key(&mut p, KeyCode::Down, NONE)); // past end
+        expect_consumed(dispatch(&mut p, KeyCode::Down, NONE));
+        expect_consumed(dispatch(&mut p, KeyCode::Down, NONE));
+        expect_consumed(dispatch(&mut p, KeyCode::Down, NONE)); // past end
         assert_eq!(p.selected, 2);
-        expect_consumed(key(&mut p, KeyCode::Up, NONE));
-        expect_consumed(key(&mut p, KeyCode::Up, NONE));
-        expect_consumed(key(&mut p, KeyCode::Up, NONE)); // past top
+        expect_consumed(dispatch(&mut p, KeyCode::Up, NONE));
+        expect_consumed(dispatch(&mut p, KeyCode::Up, NONE));
+        expect_consumed(dispatch(&mut p, KeyCode::Up, NONE)); // past top
         assert_eq!(p.selected, 0);
     }
 
     #[test]
-    fn enter_returns_close_with_selected_msgs() {
+    fn enter_closes_with_selected_msgs() {
         let mut p = palette_with(&["A", "B", "C"]);
-        expect_consumed(key(&mut p, KeyCode::Down, NONE));
-        let r = key(&mut p, KeyCode::Enter, NONE);
-        match r {
-            EventResult::Close(msgs) => {
-                assert_eq!(msgs, vec![AppMsg::Map(Action::None)]);
-            }
-            _ => panic!("expected Close"),
-        }
+        expect_consumed(dispatch(&mut p, KeyCode::Down, NONE));
+        let ops = dispatch(&mut p, KeyCode::Enter, NONE);
+        assert!(ops.close);
+        assert_eq!(ops.msgs, vec![AppMsg::Map(Action::None)]);
+        assert!(ops.opens.is_empty());
     }
 
     #[test]
     fn enter_with_empty_filter_closes_without_run() {
         let mut p = palette_with(&["Zoom in"]);
-        key(&mut p, KeyCode::Char('x'), NONE);
+        dispatch(&mut p, KeyCode::Char('x'), NONE);
         assert!(filtered_labels(&p).is_empty());
-        let r = key(&mut p, KeyCode::Enter, NONE);
-        match r {
-            EventResult::Close(msgs) => assert!(msgs.is_empty()),
-            _ => panic!("expected Close"),
-        }
+        let ops = dispatch(&mut p, KeyCode::Enter, NONE);
+        assert!(ops.close);
+        assert!(ops.msgs.is_empty());
     }
 
     #[test]
     fn esc_closes() {
         let mut p = palette_with(&["A"]);
-        let r = key(&mut p, KeyCode::Esc, NONE);
-        match r {
-            EventResult::Close(msgs) => assert!(msgs.is_empty()),
-            _ => panic!("expected Close"),
-        }
+        let ops = dispatch(&mut p, KeyCode::Esc, NONE);
+        assert!(ops.close);
+        assert!(ops.msgs.is_empty());
     }
 
     #[test]
     fn ctrl_u_clears_query() {
         let mut p = palette_with(&["A"]);
-        key(&mut p, KeyCode::Char('a'), NONE);
-        key(&mut p, KeyCode::Char('b'), NONE);
-        key(&mut p, KeyCode::Char('u'), KeyModifiers::CONTROL);
+        dispatch(&mut p, KeyCode::Char('a'), NONE);
+        dispatch(&mut p, KeyCode::Char('b'), NONE);
+        dispatch(&mut p, KeyCode::Char('u'), KeyModifiers::CONTROL);
         assert_eq!(p.query, "");
     }
 }

--- a/src/plugin/palette/provider/mod.rs
+++ b/src/plugin/palette/provider/mod.rs
@@ -22,7 +22,7 @@ pub struct PaletteItem {
 
 /// What a provider wants the host to do when the user activates an
 /// item. Translated by the palette Component into the equivalent
-/// [`EventResult`](crate::compositor::EventResult).
+/// `win.*` calls.
 pub enum PaletteAction {
     /// Close the palette with no side effect.
     Close,

--- a/src/plugin/search/mod.rs
+++ b/src/plugin/search/mod.rs
@@ -17,9 +17,8 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 
 use crate::app::AppMsg;
-use crate::compositor::{
-    Activation, Component, Context, EventResult, PaletteEntry, PaletteKind, Registrar,
-};
+use crate::compositor::window::Window;
+use crate::compositor::{Activation, Component, Context, PaletteEntry, PaletteKind, Registrar};
 use crate::shared::nominatim::{NominatimClient, SearchResult};
 use crate::theme::UiTheme;
 
@@ -48,7 +47,7 @@ impl SearchComponent {
 }
 
 impl Component for SearchComponent {
-    fn handle_event(&mut self, event: KeyEvent, _ctx: &Context) -> EventResult {
+    fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
         let ctrl = event.modifiers.contains(KeyModifiers::CONTROL);
 
         if self.has_candidates() {
@@ -57,57 +56,42 @@ impl Component for SearchComponent {
             let down = matches!(event.code, KeyCode::Down | KeyCode::Char('j'))
                 || (ctrl && event.code == KeyCode::Char('n'));
 
-            return match event.code {
-                KeyCode::Esc => EventResult::Close(Vec::new()),
-                KeyCode::Enter => {
-                    let loc = self.candidates[self.selected].location;
-                    EventResult::Close(vec![AppMsg::Jump(loc)])
-                }
-                _ if up => {
-                    if self.selected > 0 {
-                        self.selected -= 1;
-                    }
-                    EventResult::Consumed(Vec::new())
-                }
-                _ if down => {
-                    if self.selected + 1 < self.candidates.len() {
-                        self.selected += 1;
-                    }
-                    EventResult::Consumed(Vec::new())
-                }
-                _ => EventResult::Consumed(Vec::new()),
-            };
+            if event.code == KeyCode::Esc {
+                win.close();
+            } else if event.code == KeyCode::Enter {
+                let loc = self.candidates[self.selected].location;
+                win.emit(AppMsg::Jump(loc));
+                win.close();
+            } else if up && self.selected > 0 {
+                self.selected -= 1;
+            } else if down && self.selected + 1 < self.candidates.len() {
+                self.selected += 1;
+            }
+            return;
         }
 
         match event.code {
-            KeyCode::Esc => EventResult::Close(Vec::new()),
+            KeyCode::Esc => win.close(),
             KeyCode::Enter => {
                 if self.query.is_empty() {
-                    EventResult::Close(Vec::new())
+                    win.close();
                 } else {
                     self.service.search(&self.query);
-                    EventResult::Consumed(Vec::new())
                 }
             }
             KeyCode::Backspace => {
                 self.query.pop();
-                EventResult::Consumed(Vec::new())
             }
             KeyCode::Char('h') if ctrl => {
                 self.query.pop();
-                EventResult::Consumed(Vec::new())
             }
             KeyCode::Char('u') if ctrl => {
                 self.query.clear();
-                EventResult::Consumed(Vec::new())
             }
-            KeyCode::Char(c) => {
-                self.query.push(c);
-                EventResult::Consumed(Vec::new())
-            }
-            // Modal: any other key is still consumed (don't fall
-            // through to the keymap while the search popup is up).
-            _ => EventResult::Consumed(Vec::new()),
+            KeyCode::Char(c) => self.query.push(c),
+            // Modal: any other key is implicitly consumed (no
+            // `win.ignore()`), so it doesn't fall through to keymap.
+            _ => {}
         }
     }
 
@@ -115,12 +99,11 @@ impl Component for SearchComponent {
         panel::render_panel(self, f, area, theme);
     }
 
-    fn poll(&mut self) -> Vec<AppMsg> {
+    fn poll(&mut self, _win: &mut Window) {
         if let Some(results) = self.service.poll() {
             self.candidates = results;
             self.selected = 0;
         }
-        Vec::new()
     }
 
     fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {

--- a/src/plugin/wiki/mod.rs
+++ b/src/plugin/wiki/mod.rs
@@ -31,9 +31,8 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use log::debug;
 
 use crate::app::AppMsg;
-use crate::compositor::{
-    Activation, Component, Context, EventResult, PaletteEntry, PaletteKind, Registrar,
-};
+use crate::compositor::window::Window;
+use crate::compositor::{Activation, Component, Context, PaletteEntry, PaletteKind, Registrar};
 use crate::geo::LonLat;
 use crate::painter::MapPainter;
 use crate::shared::throttle::Throttle;
@@ -127,19 +126,20 @@ impl WikiComponent {
 }
 
 impl Component for WikiComponent {
-    fn handle_event(&mut self, event: KeyEvent, ctx: &Context) -> EventResult {
+    fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
         let mut state = self.state.borrow_mut();
         let ctrl = event.modifiers.contains(KeyModifiers::CONTROL);
 
         // Self-toggle on the activation key.
         if event.code == KeyCode::Char('i') && event.modifiers == KeyModifiers::NONE {
-            return EventResult::Close(Vec::new());
+            win.close();
+            return;
         }
 
         // Refresh is available even when the list is empty.
         if event.code == KeyCode::Char('r') {
-            state.refresh(ctx.center);
-            return EventResult::Consumed(Vec::new());
+            state.refresh(win.ctx().center);
+            return;
         }
 
         let up = (ctrl && event.code == KeyCode::Char('p')) || event.code == KeyCode::Up;
@@ -152,18 +152,19 @@ impl Component for WikiComponent {
         if state.articles.is_empty() {
             // Panel is open but has nothing yet — still swallow
             // widget-control keys so they don't fall through to the
-            // keymap.
-            if up || down || exit_detail {
-                return EventResult::Consumed(Vec::new());
+            // keymap, but let everything else pass through (non-
+            // modal behaviour).
+            if !(up || down || exit_detail) {
+                win.ignore();
             }
-            return EventResult::Ignored;
+            return;
         }
 
         // ── Detail mode ─────────────────────────────────────────────
         if state.is_detail_open() {
             if exit_detail {
                 state.detail = None;
-                return EventResult::Consumed(Vec::new());
+                return;
             }
             if up || down {
                 let n = state.articles.len();
@@ -182,9 +183,9 @@ impl Component for WikiComponent {
                     lon: article.lon,
                 };
                 state.detail = Some(article);
-                return EventResult::Consumed(vec![AppMsg::Jump(loc)]);
+                win.emit(AppMsg::Jump(loc));
             }
-            return EventResult::Consumed(Vec::new());
+            return;
         }
 
         // ── List mode ───────────────────────────────────────────────
@@ -195,9 +196,9 @@ impl Component for WikiComponent {
                     lon: article.lon,
                 };
                 state.detail = Some(article.clone());
-                return EventResult::Consumed(vec![AppMsg::Jump(loc)]);
+                win.emit(AppMsg::Jump(loc));
             }
-            return EventResult::Consumed(Vec::new());
+            return;
         }
         if up || down {
             let n = state.articles.len();
@@ -211,17 +212,18 @@ impl Component for WikiComponent {
                 (state.selected + 1) % n
             };
             let article = &state.articles[state.selected];
-            return EventResult::Consumed(vec![AppMsg::Jump(LonLat {
+            win.emit(AppMsg::Jump(LonLat {
                 lat: article.lat,
                 lon: article.lon,
-            })]);
+            }));
+            return;
         }
         if matches!(event.code, KeyCode::Esc | KeyCode::Backspace) {
-            return EventResult::Consumed(Vec::new());
+            return;
         }
 
         // Non-modal: let lower layers handle unknown keys.
-        EventResult::Ignored
+        win.ignore();
     }
 
     fn render(&self, f: &mut ratatui::Frame, area: ratatui::layout::Rect, theme: &UiTheme) {
@@ -247,9 +249,8 @@ impl Component for WikiComponent {
         }
     }
 
-    fn poll(&mut self) -> Vec<AppMsg> {
+    fn poll(&mut self, _win: &mut Window) {
         self.state.borrow_mut().poll();
-        Vec::new()
     }
 
     fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {


### PR DESCRIPTION
## Summary

Replace the `EventResult` return-value enum (Ignored / Consumed /
Close / Push / CloseAndPush) with an imperative `&mut Window` handle
passed to every component hook.

Components now express intent through method calls:

```rust
fn handle_event(&mut self, ev: KeyEvent, win: &mut Window) {
    if ev.code == KeyCode::Esc {
        win.close();
    } else if ev.code == KeyCode::Enter && has_selection {
        win.emit(AppMsg::Jump(loc));
        win.close();
    } else if activation {
        win.close();
        win.open(Box::new(SomePlugin::new()));
    }
}
```

Calls queue into `WindowOps`; the compositor drains and applies them
atomically after the hook returns (close → opens with TypeId dedup →
msgs forwarded to `App::dispatch`).

### Why

`EventResult::CloseAndPush` was the canary — compound ops demand
their own variants. Every future "do A and B" pattern would add
another. Queue semantics let compounds emerge by composition without
expanding the plugin-facing surface.

### Invariants preserved

Components still can't hold `&mut Compositor` or reach the stack
directly. The queue is the only channel; the compositor is the sole
applier. Every invariant (Tab interception, TypeId dedup, focused_idx
clamp, non-modal fall-through via `win.ignore()`) remains
type-enforced — plugin authors cannot break stack/focus correctness.

## Commits

- `be2982e` prototype: design reference, dead code, shape validation
- `36a535a` migration: full plugin + compositor conversion, delete
  EventResult, 166 tests green

## Test plan

- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 166 tests (palette / base tests rewritten to
  inspect `WindowOps` contents instead of matching variants)
- [ ] Manual smoke:
  - [ ] `cargo run` → pan/zoom/reset/gg/Tab cycle/Ctrl-C exit
  - [ ] `:` palette → Enter on map action → dispatches + closes
  - [ ] `:` palette → "Theme" → sub-mode → pick → SetTheme
  - [ ] `:` palette → "Search location" → palette closes + search opens (CloseAndPush replacement)
  - [ ] `/` search → Enter jumps
  - [ ] `?` help → any key closes
  - [ ] `i` wiki → panel + map markers; Tab between wiki and map keymap
  - [ ] Resize, Ctrl-C

## Follow-ups (not in this PR)

- Draw primitives (`win.popup` / `win.list` / `win.text`) to fold
  the `Clear + Block + centered_rect + Paragraph` boilerplate
  duplicated across every plugin's `panel.rs`
- Theme injection removal (`render(f, area, theme)` → `render(win)`
  via `win.theme()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)