### PR TITLE
refactor(window): RenderWindow + semantic style accessors — UiTheme hidden from plugins

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -125,7 +125,9 @@ impl App {
 
             self.ui.overlay.poll();
 
-            terminal.draw(|f| crate::ui::draw(f, &self.ui, &self.compositor, &self.ui_theme))?;
+            let ctx = self.context();
+            terminal
+                .draw(|f| crate::ui::draw(f, &self.ui, &self.compositor, &self.ui_theme, &ctx))?;
 
             let mut poll_timeout = Duration::from_millis(4);
             while event::poll(poll_timeout)? {

--- a/src/compositor/base.rs
+++ b/src/compositor/base.rs
@@ -27,7 +27,7 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use super::window::Window;
+use super::window::{RenderWindow, Window};
 use super::{Activation, Component};
 use crate::app::AppMsg;
 use crate::keymap::KeyMap;
@@ -109,12 +109,7 @@ impl Component for BaseLayer {
         // (no `win.ignore()`).
     }
 
-    fn render(
-        &self,
-        _f: &mut ratatui::Frame,
-        _area: ratatui::layout::Rect,
-        _theme: &crate::theme::UiTheme,
-    ) {
+    fn render(&self, _win: &mut RenderWindow) {
         // Bottom layer draws nothing — the map is painted by `App`
         // separately from the compositor (see `App::run`).
     }

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -100,9 +100,12 @@ pub trait Component: Any {
     /// event is treated as handled but with no state change.
     fn handle_event(&mut self, event: KeyEvent, win: &mut Window);
 
-    /// Paint this component into `area`. Called once per frame while
-    /// on the stack; compositor renders bottom-to-top.
-    fn render(&self, f: &mut Frame, area: Rect, theme: &UiTheme);
+    /// Paint this component into `win.area()`. Called once per
+    /// frame while on the stack; compositor renders bottom-to-top.
+    /// `win` carries the ratatui frame, the component's allowed
+    /// area, and the current theme — plugins read all three through
+    /// `win` so theme does not thread through helper signatures.
+    fn render(&self, win: &mut window::RenderWindow);
 
     /// Paint world-space primitives on the map via [`MapPainter`].
     /// Called every frame while on the stack, before `render`. Default
@@ -265,9 +268,10 @@ impl Compositor {
     }
 
     /// Render bottom-up so later pushes draw on top.
-    pub fn render(&self, f: &mut Frame, area: Rect, theme: &UiTheme) {
+    pub fn render(&self, f: &mut Frame, area: Rect, theme: &UiTheme, ctx: &Context) {
         for c in self.stack.iter() {
-            c.render(f, area, theme);
+            let mut win = window::RenderWindow::new(f, area, theme, ctx);
+            c.render(&mut win);
         }
     }
 
@@ -405,7 +409,7 @@ mod tests {
 
     impl Component for TagComponent {
         fn handle_event(&mut self, _: KeyEvent, _: &mut Window) {}
-        fn render(&self, _: &mut Frame, _: Rect, _: &UiTheme) {}
+        fn render(&self, _: &mut window::RenderWindow) {}
         fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
             vec![(self.0, "")]
         }
@@ -495,7 +499,7 @@ mod tests {
                 win.open(Box::new(TagComponent(self.spawn_label)));
             }
         }
-        fn render(&self, _: &mut Frame, _: Rect, _: &UiTheme) {}
+        fn render(&self, _: &mut window::RenderWindow) {}
         fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
             vec![(self.label, "")]
         }
@@ -552,7 +556,7 @@ mod tests {
             fn handle_event(&mut self, _: KeyEvent, win: &mut Window) {
                 win.emit(AppMsg::Map(crate::map::Action::None));
             }
-            fn render(&self, _: &mut Frame, _: Rect, _: &UiTheme) {}
+            fn render(&self, _: &mut window::RenderWindow) {}
         }
 
         let ctx = Context {

--- a/src/compositor/window.rs
+++ b/src/compositor/window.rs
@@ -34,7 +34,8 @@
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::widgets::Clear;
+use ratatui::style::Style;
+use ratatui::widgets::{Block, Clear};
 
 use crate::app::AppMsg;
 use crate::compositor::{Component, Context};
@@ -131,15 +132,21 @@ impl<'a> Window<'a> {
 // ── RenderWindow: draw-time handle ─────────────────────────────────
 
 /// Render-time companion to [`Window`]. Carries the ratatui
-/// [`Frame`], the layout area the component should draw into, the
-/// active [`UiTheme`], and a read-only snapshot of [`Context`] — so
-/// the component doesn't have to thread these through every helper
-/// as separate arguments.
+/// [`Frame`], the layout area the component may draw into, a
+/// read-only snapshot of [`Context`], and — internally, never
+/// exposed — the active [`UiTheme`].
 ///
-/// Plugins receive this on [`Component::render`](super::Component)
-/// (and, when added, `paint_on_map`). It exposes ratatui's `Frame`
-/// when a primitive isn't yet provided, so existing panel code can
-/// keep calling `win.frame().render_widget(...)` during migration.
+/// **Components never see `UiTheme`.** They ask for semantic styles
+/// (body / muted / accent / highlight / selected / link), and
+/// [`RenderWindow`] maps them to the current theme's concrete
+/// `Style`. Adding a new theme-driven field requires one accessor
+/// here, not a signature change in every plugin.
+///
+/// `frame()` remains as an escape hatch for widgets not yet wrapped
+/// by this module (lists, tables, scrollable paragraphs). A
+/// follow-up refactor will fold those into Window primitives and
+/// retire the escape hatch — at which point plugins won't need
+/// `use ratatui::*` at all.
 pub struct RenderWindow<'a, 'b> {
     frame: &'a mut Frame<'b>,
     area: Rect,
@@ -161,12 +168,6 @@ impl<'a, 'b> RenderWindow<'a, 'b> {
             theme,
             ctx,
         }
-    }
-
-    /// The theme currently in effect. Use for styling primitives
-    /// instead of threading `&UiTheme` through helper signatures.
-    pub fn theme(&self) -> &UiTheme {
-        self.theme
     }
 
     /// The area this component is allowed to draw into (usually
@@ -202,5 +203,61 @@ impl<'a, 'b> RenderWindow<'a, 'b> {
         let inner = block.inner(rect);
         self.frame.render_widget(block, rect);
         inner
+    }
+
+    /// Build a theme-styled [`Block`] without drawing anything. Use
+    /// when the content widget (Paragraph / List) needs to own the
+    /// Block via `.block(...)`, as in wiki's scrollable list or
+    /// help's centered text overlay.
+    pub fn panel_block<'t>(&self, title: &'t str) -> Block<'t> {
+        self.theme.panel(title)
+    }
+
+    // ── Semantic style accessors (UiTheme hidden) ─────────────────
+
+    /// Plain body text style. Maps to the theme's "fg on bg"
+    /// combination; plugin never sees which palette entry that is.
+    pub fn body_style(&self) -> Style {
+        self.theme.text()
+    }
+
+    /// Subdued text — hints, distances, coordinates, auxiliary
+    /// info. Lower contrast than body.
+    pub fn muted_style(&self) -> Style {
+        self.theme.muted()
+    }
+
+    /// Primary accent — section titles, key hints in help, plugin
+    /// panel headers.
+    pub fn accent_style(&self) -> Style {
+        self.theme.accent_style()
+    }
+
+    /// Secondary accent — the "look at this one" highlight used for
+    /// selected wiki titles. Distinct from [`selected_style`]
+    /// (which is the full selected-row chrome including bold);
+    /// this is just the alt accent colour on fg.
+    pub fn highlight_style(&self) -> Style {
+        Style::default().fg(self.theme.accent_alt)
+    }
+
+    /// Selected list / table row — accent colour + bold. Matches
+    /// the palette's row highlight and search candidate selection.
+    pub fn selected_style(&self) -> Style {
+        self.theme.selected()
+    }
+
+    /// URL / clickable text. Terminals that detect OSC 8 or auto-
+    /// link by regex will activate it. Distinct from plain accent
+    /// because it's underlined.
+    pub fn link_style(&self) -> Style {
+        self.theme.link()
+    }
+
+    /// Foreground-only style using the muted colour — suitable for
+    /// thin separator lines (`─`) where `muted_style()`'s
+    /// foreground-on-background combination would bleed the bg.
+    pub fn muted_fg_style(&self) -> Style {
+        Style::default().fg(self.theme.muted_color)
     }
 }

--- a/src/compositor/window.rs
+++ b/src/compositor/window.rs
@@ -32,8 +32,13 @@
 //! the compositor is the sole applier of the queue, so invariants
 //! (focus, dedup, clamp) remain framework-enforced.
 
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::widgets::Clear;
+
 use crate::app::AppMsg;
 use crate::compositor::{Component, Context};
+use crate::theme::UiTheme;
 
 /// Queue of actions a [`Component`] hook recorded through [`Window`].
 /// Drained and applied by the compositor after the hook returns.
@@ -120,5 +125,82 @@ impl<'a> Window<'a> {
     /// component clearly handled the event.
     pub fn ignore(&mut self) {
         self.ops.ignored = true;
+    }
+}
+
+// ── RenderWindow: draw-time handle ─────────────────────────────────
+
+/// Render-time companion to [`Window`]. Carries the ratatui
+/// [`Frame`], the layout area the component should draw into, the
+/// active [`UiTheme`], and a read-only snapshot of [`Context`] — so
+/// the component doesn't have to thread these through every helper
+/// as separate arguments.
+///
+/// Plugins receive this on [`Component::render`](super::Component)
+/// (and, when added, `paint_on_map`). It exposes ratatui's `Frame`
+/// when a primitive isn't yet provided, so existing panel code can
+/// keep calling `win.frame().render_widget(...)` during migration.
+pub struct RenderWindow<'a, 'b> {
+    frame: &'a mut Frame<'b>,
+    area: Rect,
+    theme: &'a UiTheme,
+    #[allow(dead_code)] // read via ctx(); kept even if unused
+    ctx: &'a Context,
+}
+
+impl<'a, 'b> RenderWindow<'a, 'b> {
+    pub(crate) fn new(
+        frame: &'a mut Frame<'b>,
+        area: Rect,
+        theme: &'a UiTheme,
+        ctx: &'a Context,
+    ) -> Self {
+        Self {
+            frame,
+            area,
+            theme,
+            ctx,
+        }
+    }
+
+    /// The theme currently in effect. Use for styling primitives
+    /// instead of threading `&UiTheme` through helper signatures.
+    pub fn theme(&self) -> &UiTheme {
+        self.theme
+    }
+
+    /// The area this component is allowed to draw into (usually
+    /// the map viewport minus the border).
+    pub fn area(&self) -> Rect {
+        self.area
+    }
+
+    /// App-level snapshot (center, theme id). Kept for parity with
+    /// [`Window::ctx`] so `paint_on_map` and future render-side
+    /// hooks can read it uniformly.
+    #[allow(dead_code)]
+    pub fn ctx(&self) -> &Context {
+        self.ctx
+    }
+
+    /// Escape hatch for direct ratatui access while primitives are
+    /// being built out. Components can call
+    /// `win.frame().render_widget(w, rect)` for anything not yet
+    /// covered by a `RenderWindow` primitive.
+    pub fn frame(&mut self) -> &mut Frame<'b> {
+        self.frame
+    }
+
+    /// Clear `rect` and draw a theme-styled bordered panel with
+    /// `title` inside it. Returns the inner rect (content region
+    /// inside the borders) for further widgets. Factors the
+    /// `Clear + theme.panel(title) + f.render_widget(block, rect)`
+    /// triplet duplicated across every plugin's panel module.
+    pub fn panel(&mut self, rect: Rect, title: &str) -> Rect {
+        self.frame.render_widget(Clear, rect);
+        let block = self.theme.panel(title);
+        let inner = block.inner(rect);
+        self.frame.render_widget(block, rect);
+        inner
     }
 }

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -32,8 +32,17 @@ impl<'a> MapPainter<'a> {
         }
     }
 
-    pub fn theme(&self) -> &UiTheme {
-        self.theme
+    /// Primary accent colour — used by plugins to highlight features
+    /// (wiki markers, search pins, ...). Semantic accessor; the
+    /// underlying theme is hidden from plugins.
+    pub fn accent_color(&self) -> Color {
+        self.theme.accent
+    }
+
+    /// Secondary accent colour — typically used to distinguish the
+    /// selected / focused feature from the rest.
+    pub fn accent_alt_color(&self) -> Color {
+        self.theme.accent_alt
     }
 
     /// Plot a single-cell glyph at the given world coordinate. No-op

--- a/src/plugin/help/mod.rs
+++ b/src/plugin/help/mod.rs
@@ -13,7 +13,6 @@ use crate::compositor::window::{RenderWindow, Window};
 use crate::compositor::{Activation, Component, Context, PaletteEntry, PaletteKind, Registrar};
 use crate::keymap::KeyMap;
 use crate::map::Action;
-use crate::theme::UiTheme;
 
 /// A colored span of help text. Theme is applied at render time so
 /// theme switches update the colors without rebuilding the help
@@ -65,16 +64,19 @@ impl HelpText {
         Self { lines }
     }
 
-    fn rendered_lines<'a>(&'a self, theme: &UiTheme) -> Vec<Line<'a>> {
+    fn rendered_lines<'a>(&'a self, win: &RenderWindow) -> Vec<Line<'a>> {
+        let body = win.body_style();
+        let accent = win.accent_style();
+        let link = win.link_style();
         self.lines
             .iter()
             .map(|segs| {
                 let spans: Vec<Span<'a>> = segs
                     .iter()
                     .map(|s| match s {
-                        Seg::Text(t) => Span::styled(t.as_str(), theme.text()),
-                        Seg::Key(k) => Span::styled(k.as_str(), theme.accent_style()),
-                        Seg::Url(u) => Span::styled(u.as_str(), theme.link()),
+                        Seg::Text(t) => Span::styled(t.as_str(), body),
+                        Seg::Key(k) => Span::styled(k.as_str(), accent),
+                        Seg::Url(u) => Span::styled(u.as_str(), link),
                     })
                     .collect();
                 Line::from(spans)
@@ -106,8 +108,7 @@ impl Component for HelpComponent {
             return;
         }
 
-        let theme = win.theme();
-        let rendered = self.text.rendered_lines(theme);
+        let rendered = self.text.rendered_lines(win);
 
         let content_width = rendered
             .iter()
@@ -126,9 +127,9 @@ impl Component for HelpComponent {
         let y = map_inner.y + (map_inner.height - popup_height) / 2;
 
         let area = Rect::new(x, y, popup_width, popup_height);
-        let text_style = theme.text();
-        let block = theme.panel("help").title_alignment(Alignment::Center);
-        let widget = Paragraph::new(rendered).style(text_style).block(block);
+        let body = win.body_style();
+        let block = win.panel_block("help").title_alignment(Alignment::Center);
+        let widget = Paragraph::new(rendered).style(body).block(block);
         win.frame().render_widget(Clear, area);
         win.frame().render_widget(widget, area);
     }

--- a/src/plugin/help/mod.rs
+++ b/src/plugin/help/mod.rs
@@ -4,13 +4,12 @@
 //! on every push. Any key closes it.
 
 use crossterm::event::{KeyEvent, KeyModifiers};
-use ratatui::Frame;
 use ratatui::layout::{Alignment, Rect};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, Paragraph};
 
 use crate::app::AppMsg;
-use crate::compositor::window::Window;
+use crate::compositor::window::{RenderWindow, Window};
 use crate::compositor::{Activation, Component, Context, PaletteEntry, PaletteKind, Registrar};
 use crate::keymap::KeyMap;
 use crate::map::Action;
@@ -101,11 +100,13 @@ impl Component for HelpComponent {
         win.close();
     }
 
-    fn render(&self, f: &mut Frame, map_inner: Rect, theme: &UiTheme) {
+    fn render(&self, win: &mut RenderWindow) {
+        let map_inner = win.area();
         if map_inner.width < 20 || map_inner.height < 10 {
             return;
         }
 
+        let theme = win.theme();
         let rendered = self.text.rendered_lines(theme);
 
         let content_width = rendered
@@ -125,11 +126,11 @@ impl Component for HelpComponent {
         let y = map_inner.y + (map_inner.height - popup_height) / 2;
 
         let area = Rect::new(x, y, popup_width, popup_height);
-        f.render_widget(Clear, area);
-
+        let text_style = theme.text();
         let block = theme.panel("help").title_alignment(Alignment::Center);
-        let widget = Paragraph::new(rendered).style(theme.text()).block(block);
-        f.render_widget(widget, area);
+        let widget = Paragraph::new(rendered).style(text_style).block(block);
+        win.frame().render_widget(Clear, area);
+        win.frame().render_widget(widget, area);
     }
 
     fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {

--- a/src/plugin/palette/mod.rs
+++ b/src/plugin/palette/mod.rs
@@ -21,14 +21,11 @@ pub mod provider;
 use std::rc::Rc;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use ratatui::Frame;
-use ratatui::layout::Rect;
 
 use crate::color_palette::ThemeId;
-use crate::compositor::window::Window;
+use crate::compositor::window::{RenderWindow, Window};
 use crate::compositor::{Activation, Component, Context, Registrar};
 use crate::keymap::KeyMap;
-use crate::theme::UiTheme;
 
 use provider::{CommandProvider, CommandSeed, PaletteAction, PaletteProvider};
 
@@ -133,8 +130,8 @@ impl Component for PaletteComponent {
         }
     }
 
-    fn render(&self, f: &mut Frame, area: Rect, theme: &UiTheme) {
-        panel::render_panel(self, f, area, theme);
+    fn render(&self, win: &mut RenderWindow) {
+        panel::render_panel(self, win);
     }
 
     fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {

--- a/src/plugin/palette/panel.rs
+++ b/src/plugin/palette/panel.rs
@@ -41,8 +41,7 @@ pub fn render_panel(widget: &PaletteComponent, win: &mut RenderWindow) {
     let muted = win.muted_style();
     let selected = win.selected_style();
 
-    let input_text =
-        Paragraph::new(format!("{}{}", provider.prompt(), widget.query)).style(body);
+    let input_text = Paragraph::new(format!("{}{}", provider.prompt(), widget.query)).style(body);
     win.frame().render_widget(input_text, chunks[0]);
 
     let table_rows: Vec<Row> = items

--- a/src/plugin/palette/panel.rs
+++ b/src/plugin/palette/panel.rs
@@ -1,16 +1,16 @@
 //! Command-palette popup — centered over the map. Single bordered
 //! block enclosing an input line (provider prompt + query) and a
-//! scrollable `Table` driven by the current provider's items.
+//! scrollable [`Table`] driven by the current provider's items.
 
-use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::widgets::{Cell, Clear, Paragraph, Row, Table, TableState};
+use ratatui::widgets::{Cell, Paragraph, Row, Table, TableState};
 
-use crate::theme::UiTheme;
+use crate::compositor::window::RenderWindow;
 
 use super::PaletteComponent;
 
-pub fn render_panel(widget: &PaletteComponent, f: &mut Frame, map_inner: Rect, theme: &UiTheme) {
+pub fn render_panel(widget: &PaletteComponent, win: &mut RenderWindow) {
+    let map_inner = win.area();
     if map_inner.width < 30 || map_inner.height < 6 {
         return;
     }
@@ -18,20 +18,15 @@ pub fn render_panel(widget: &PaletteComponent, f: &mut Frame, map_inner: Rect, t
     let items = provider.items();
 
     let popup_width = (map_inner.width * 2 / 3).max(40).min(map_inner.width - 2);
-    // outer borders + input line + blank + table rows
     let max_rows = map_inner.height.saturating_sub(6).max(3);
     let rows = (items.len() as u16).max(1).min(max_rows);
     let popup_height = rows + 4;
 
     let x = map_inner.x + (map_inner.width - popup_width) / 2;
     let y = map_inner.y + 1;
-    let area = Rect::new(x, y, popup_width, popup_height);
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
 
-    f.render_widget(Clear, area);
-
-    let block = theme.panel("command palette");
-    let inner = block.inner(area);
-    f.render_widget(block, area);
+    let inner = win.panel(popup_area, "command palette");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -42,9 +37,14 @@ pub fn render_panel(widget: &PaletteComponent, f: &mut Frame, map_inner: Rect, t
         ])
         .split(inner);
 
-    let input =
-        Paragraph::new(format!("{}{}", provider.prompt(), widget.query)).style(theme.text());
-    f.render_widget(input, chunks[0]);
+    let theme = win.theme();
+    let text_style = theme.text();
+    let muted_style = theme.muted();
+    let selected_style = theme.selected();
+
+    let input_text =
+        Paragraph::new(format!("{}{}", provider.prompt(), widget.query)).style(text_style);
+    win.frame().render_widget(input_text, chunks[0]);
 
     let table_rows: Vec<Row> = items
         .iter()
@@ -56,7 +56,7 @@ pub fn render_panel(widget: &PaletteComponent, f: &mut Frame, map_inner: Rect, t
             };
             Row::new(vec![
                 Cell::from(item.label.clone()),
-                Cell::from(hint_cell).style(theme.muted()),
+                Cell::from(hint_cell).style(muted_style),
             ])
         })
         .collect();
@@ -67,10 +67,11 @@ pub fn render_panel(widget: &PaletteComponent, f: &mut Frame, map_inner: Rect, t
     }
 
     let table = Table::new(table_rows, [Constraint::Min(10), Constraint::Length(16)])
-        .style(theme.text())
+        .style(text_style)
         .highlight_symbol("> ")
-        .row_highlight_style(theme.selected())
+        .row_highlight_style(selected_style)
         .column_spacing(1);
 
-    f.render_stateful_widget(table, chunks[2], &mut ts);
+    win.frame()
+        .render_stateful_widget(table, chunks[2], &mut ts);
 }

--- a/src/plugin/palette/panel.rs
+++ b/src/plugin/palette/panel.rs
@@ -37,13 +37,12 @@ pub fn render_panel(widget: &PaletteComponent, win: &mut RenderWindow) {
         ])
         .split(inner);
 
-    let theme = win.theme();
-    let text_style = theme.text();
-    let muted_style = theme.muted();
-    let selected_style = theme.selected();
+    let body = win.body_style();
+    let muted = win.muted_style();
+    let selected = win.selected_style();
 
     let input_text =
-        Paragraph::new(format!("{}{}", provider.prompt(), widget.query)).style(text_style);
+        Paragraph::new(format!("{}{}", provider.prompt(), widget.query)).style(body);
     win.frame().render_widget(input_text, chunks[0]);
 
     let table_rows: Vec<Row> = items
@@ -56,7 +55,7 @@ pub fn render_panel(widget: &PaletteComponent, win: &mut RenderWindow) {
             };
             Row::new(vec![
                 Cell::from(item.label.clone()),
-                Cell::from(hint_cell).style(muted_style),
+                Cell::from(hint_cell).style(muted),
             ])
         })
         .collect();
@@ -67,9 +66,9 @@ pub fn render_panel(widget: &PaletteComponent, win: &mut RenderWindow) {
     }
 
     let table = Table::new(table_rows, [Constraint::Min(10), Constraint::Length(16)])
-        .style(text_style)
+        .style(body)
         .highlight_symbol("> ")
-        .row_highlight_style(selected_style)
+        .row_highlight_style(selected)
         .column_spacing(1);
 
     win.frame()

--- a/src/plugin/search/mod.rs
+++ b/src/plugin/search/mod.rs
@@ -13,14 +13,11 @@ mod service;
 use std::sync::Arc;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use ratatui::Frame;
-use ratatui::layout::Rect;
 
 use crate::app::AppMsg;
-use crate::compositor::window::Window;
+use crate::compositor::window::{RenderWindow, Window};
 use crate::compositor::{Activation, Component, Context, PaletteEntry, PaletteKind, Registrar};
 use crate::shared::nominatim::{NominatimClient, SearchResult};
-use crate::theme::UiTheme;
 
 use service::SearchService;
 
@@ -95,8 +92,8 @@ impl Component for SearchComponent {
         }
     }
 
-    fn render(&self, f: &mut Frame, area: Rect, theme: &UiTheme) {
-        panel::render_panel(self, f, area, theme);
+    fn render(&self, win: &mut RenderWindow) {
+        panel::render_panel(self, win);
     }
 
     fn poll(&mut self, _win: &mut Window) {

--- a/src/plugin/search/panel.rs
+++ b/src/plugin/search/panel.rs
@@ -1,15 +1,16 @@
 //! Search side panel — center popup showing the input line or the
-//! candidate list. Stateless; reads the widget's internal widget.
+//! candidate list. Stateless; reads the component's fields and the
+//! theme through the supplied [`RenderWindow`].
 
-use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::widgets::{Clear, List, ListItem, Paragraph};
+use ratatui::widgets::{List, ListItem, Paragraph};
 
-use crate::theme::UiTheme;
+use crate::compositor::window::RenderWindow;
 
 use super::SearchComponent;
 
-pub fn render_panel(widget: &SearchComponent, f: &mut Frame, map_inner: Rect, theme: &UiTheme) {
+pub fn render_panel(widget: &SearchComponent, win: &mut RenderWindow) {
+    let map_inner = win.area();
     if map_inner.width < 10 || map_inner.height < 3 {
         return;
     }
@@ -23,44 +24,47 @@ pub fn render_panel(widget: &SearchComponent, f: &mut Frame, map_inner: Rect, th
 
     let x = map_inner.x + (map_inner.width - popup_width) / 2;
     let y = map_inner.y + 1;
-
     let popup_area = Rect::new(x, y, popup_width, popup_height);
-    f.render_widget(Clear, popup_area);
+
+    let title = if widget.has_candidates() {
+        format!("search: {}", widget.query)
+    } else {
+        "search".to_string()
+    };
+    let inner = win.panel(popup_area, &title);
 
     if widget.has_candidates() {
-        render_candidates(widget, f, popup_area, theme);
+        render_candidates(widget, win, inner);
     } else {
-        render_input(widget, f, popup_area, theme);
+        render_input(widget, win, inner);
     }
 }
 
-fn render_input(widget: &SearchComponent, f: &mut Frame, area: Rect, theme: &UiTheme) {
-    let block = theme.panel("search");
-    let w = Paragraph::new(format!("/{}", widget.query))
-        .style(theme.text())
-        .block(block);
-    f.render_widget(w, area);
+fn render_input(widget: &SearchComponent, win: &mut RenderWindow, area: Rect) {
+    let style = win.theme().text();
+    let text = Paragraph::new(format!("/{}", widget.query)).style(style);
+    win.frame().render_widget(text, area);
 }
 
-fn render_candidates(widget: &SearchComponent, f: &mut Frame, area: Rect, theme: &UiTheme) {
-    let title = format!("search: {}", widget.query);
-    let block = theme.panel(&title);
-
+fn render_candidates(widget: &SearchComponent, win: &mut RenderWindow, area: Rect) {
+    let theme = win.theme();
+    let text_style = theme.text();
+    let selected_style = theme.selected();
     let items: Vec<ListItem> = widget
         .candidates
         .iter()
         .enumerate()
         .map(|(i, result)| {
             let style = if i == widget.selected {
-                theme.selected()
+                selected_style
             } else {
-                theme.text()
+                text_style
             };
             let prefix = if i == widget.selected { "> " } else { "  " };
             ListItem::new(format!("{}{}", prefix, result.name)).style(style)
         })
         .collect();
 
-    let list = List::new(items).block(block);
-    f.render_widget(list, area);
+    let list = List::new(items);
+    win.frame().render_widget(list, area);
 }

--- a/src/plugin/search/panel.rs
+++ b/src/plugin/search/panel.rs
@@ -41,25 +41,19 @@ pub fn render_panel(widget: &SearchComponent, win: &mut RenderWindow) {
 }
 
 fn render_input(widget: &SearchComponent, win: &mut RenderWindow, area: Rect) {
-    let style = win.theme().text();
-    let text = Paragraph::new(format!("/{}", widget.query)).style(style);
+    let text = Paragraph::new(format!("/{}", widget.query)).style(win.body_style());
     win.frame().render_widget(text, area);
 }
 
 fn render_candidates(widget: &SearchComponent, win: &mut RenderWindow, area: Rect) {
-    let theme = win.theme();
-    let text_style = theme.text();
-    let selected_style = theme.selected();
+    let body = win.body_style();
+    let selected = win.selected_style();
     let items: Vec<ListItem> = widget
         .candidates
         .iter()
         .enumerate()
         .map(|(i, result)| {
-            let style = if i == widget.selected {
-                selected_style
-            } else {
-                text_style
-            };
+            let style = if i == widget.selected { selected } else { body };
             let prefix = if i == widget.selected { "> " } else { "  " };
             ListItem::new(format!("{}{}", prefix, result.name)).style(style)
         })

--- a/src/plugin/wiki/mod.rs
+++ b/src/plugin/wiki/mod.rs
@@ -231,12 +231,10 @@ impl Component for WikiComponent {
 
     fn paint_on_map(&self, p: &mut MapPainter<'_>) {
         let state = self.state.borrow();
-        let (primary, accent) = {
-            let theme = p.theme();
-            (theme.accent, theme.accent_alt)
-        };
+        let primary = p.accent_color();
+        let highlight = p.accent_alt_color();
         for (i, a) in state.articles.iter().enumerate() {
-            let fg = if i == state.selected { accent } else { primary };
+            let fg = if i == state.selected { highlight } else { primary };
             p.point(
                 LonLat {
                     lon: a.lon,

--- a/src/plugin/wiki/mod.rs
+++ b/src/plugin/wiki/mod.rs
@@ -234,7 +234,11 @@ impl Component for WikiComponent {
         let primary = p.accent_color();
         let highlight = p.accent_alt_color();
         for (i, a) in state.articles.iter().enumerate() {
-            let fg = if i == state.selected { highlight } else { primary };
+            let fg = if i == state.selected {
+                highlight
+            } else {
+                primary
+            };
             p.point(
                 LonLat {
                     lon: a.lon,

--- a/src/plugin/wiki/mod.rs
+++ b/src/plugin/wiki/mod.rs
@@ -31,12 +31,11 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use log::debug;
 
 use crate::app::AppMsg;
-use crate::compositor::window::Window;
+use crate::compositor::window::{RenderWindow, Window};
 use crate::compositor::{Activation, Component, Context, PaletteEntry, PaletteKind, Registrar};
 use crate::geo::LonLat;
 use crate::painter::MapPainter;
 use crate::shared::throttle::Throttle;
-use crate::theme::UiTheme;
 
 use service::WikiService;
 use wikipedia::WikiArticle;
@@ -226,8 +225,8 @@ impl Component for WikiComponent {
         win.ignore();
     }
 
-    fn render(&self, f: &mut ratatui::Frame, area: ratatui::layout::Rect, theme: &UiTheme) {
-        panel::render_panel(&self.state.borrow(), f, area, theme);
+    fn render(&self, win: &mut RenderWindow) {
+        panel::render_panel(&self.state.borrow(), win);
     }
 
     fn paint_on_map(&self, p: &mut MapPainter<'_>) {

--- a/src/plugin/wiki/panel.rs
+++ b/src/plugin/wiki/panel.rs
@@ -1,15 +1,15 @@
 //! Wiki side panel — list view and detail view.
 //!
-//! Stateless renderer; reads `WikiState` and draws into the ratatui frame.
+//! Stateless renderer; reads `WikiState` and draws through the
+//! supplied [`RenderWindow`].
 
-use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, Paragraph};
 use unicode_width::UnicodeWidthStr;
 
-use crate::theme::UiTheme;
+use crate::compositor::window::RenderWindow;
 
 use super::WikiState;
 use super::wikipedia::WikiArticle;
@@ -17,7 +17,8 @@ use super::wikipedia::WikiArticle;
 /// Render the wiki side panel (list or detail view). Caller ensures
 /// the panel is supposed to be up (compositor only calls this while
 /// `WikiComponent` is on the stack).
-pub fn render_panel(widget: &WikiState, f: &mut Frame, map_inner: Rect, theme: &UiTheme) {
+pub fn render_panel(widget: &WikiState, win: &mut RenderWindow) {
+    let map_inner = win.area();
     if map_inner.width < 30 || map_inner.height < 6 {
         return;
     }
@@ -32,32 +33,32 @@ pub fn render_panel(widget: &WikiState, f: &mut Frame, map_inner: Rect, theme: &
 
     let x = map_inner.right().saturating_sub(panel_width + 1);
     let area = Rect::new(x, y, panel_width, panel_height);
-    f.render_widget(Clear, area);
+    win.frame().render_widget(Clear, area);
 
     let content_width = (panel_width as usize).saturating_sub(4).max(10);
 
     if let Some(ref article) = widget.detail {
-        render_detail(f, area, content_width, article, theme);
+        render_detail(win, area, content_width, article);
     } else {
-        render_list(widget, f, area, panel_height, content_width, theme);
+        render_list(widget, win, area, panel_height, content_width);
     }
 }
 
 fn render_list(
     widget: &WikiState,
-    f: &mut Frame,
+    win: &mut RenderWindow,
     area: Rect,
     panel_height: u16,
     content_width: usize,
-    theme: &UiTheme,
 ) {
+    let theme = win.theme();
     let block = theme.panel("wiki (Enter: open)");
 
     if widget.articles.is_empty() {
-        let widget = Paragraph::new("  Loading...")
+        let paragraph = Paragraph::new("  Loading...")
             .style(theme.muted())
             .block(block);
-        f.render_widget(widget, area);
+        win.frame().render_widget(paragraph, area);
         return;
     }
 
@@ -89,9 +90,6 @@ fn render_list(
         ]));
 
         if !article.extract.is_empty() {
-            // Cap the extract at roughly two lines of content, then wrap
-            // manually so scroll math below can treat each pushed Line as
-            // one output row (Paragraph::wrap is not used any more).
             let max_chars = content_width * 2;
             let raw: String = article.extract.chars().take(max_chars).collect();
             let truncated = if article.extract.chars().count() > max_chars {
@@ -110,22 +108,6 @@ fn render_list(
         }
     }
 
-    // Scroll to keep the selected article visible, with "top-anchored on
-    // overflow" behavior:
-    //
-    //   - If the selection fits into the viewport starting from the top
-    //     of the list (scroll=0), don't scroll. Pressing down through
-    //     the first few articles keeps the viewport stable.
-    //   - Once the selection would go off the bottom (or the selection
-    //     itself is taller than the viewport), put the selection's top
-    //     at the viewport top. Next press-down jumps to the next article
-    //     at the top.
-    //   - Clamp against the end of the content so the viewport never
-    //     shows empty space below the last article; consecutive
-    //     selections near the end share the same viewport.
-    //
-    // With Paragraph's wrap disabled, each pushed `Line` maps to exactly
-    // one output row, so the math is in output rows throughout.
     let visible_lines = panel_height.saturating_sub(2);
     let total_lines = lines.len() as u16;
     let max_scroll = total_lines.saturating_sub(visible_lines);
@@ -135,20 +117,16 @@ fn render_list(
         0
     };
 
-    let widget = Paragraph::new(lines)
-        .style(theme.text())
+    let text_style = theme.text();
+    let paragraph = Paragraph::new(lines)
+        .style(text_style)
         .block(block)
         .scroll((scroll, 0));
-    f.render_widget(widget, area);
+    win.frame().render_widget(paragraph, area);
 }
 
-fn render_detail(
-    f: &mut Frame,
-    area: Rect,
-    content_width: usize,
-    article: &WikiArticle,
-    theme: &UiTheme,
-) {
+fn render_detail(win: &mut RenderWindow, area: Rect, content_width: usize, article: &WikiArticle) {
+    let theme = win.theme();
     let block = theme.panel("wiki (Esc: back)");
     let dist = crate::geo::format_distance(article.dist_m);
     let coords = format!("{:.3}, {:.3}", article.lat, article.lon);
@@ -179,8 +157,9 @@ fn render_detail(
         }
     }
 
-    let widget = Paragraph::new(lines).style(theme.text()).block(block);
-    f.render_widget(widget, area);
+    let text_style = theme.text();
+    let paragraph = Paragraph::new(lines).style(text_style).block(block);
+    win.frame().render_widget(paragraph, area);
 }
 
 /// Word-wrap `text` to visual cell `width` using `unicode-width` so CJK

--- a/src/plugin/wiki/panel.rs
+++ b/src/plugin/wiki/panel.rs
@@ -1,10 +1,10 @@
 //! Wiki side panel — list view and detail view.
 //!
 //! Stateless renderer; reads `WikiState` and draws through the
-//! supplied [`RenderWindow`].
+//! supplied [`RenderWindow`] — every style comes from `win`'s
+//! semantic accessors, so the panel never touches `UiTheme`.
 
 use ratatui::layout::Rect;
-use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, Paragraph};
 use unicode_width::UnicodeWidthStr;
@@ -51,16 +51,21 @@ fn render_list(
     panel_height: u16,
     content_width: usize,
 ) {
-    let theme = win.theme();
-    let block = theme.panel("wiki (Enter: open)");
+    let block = win.panel_block("wiki (Enter: open)");
 
     if widget.articles.is_empty() {
         let paragraph = Paragraph::new("  Loading...")
-            .style(theme.muted())
+            .style(win.muted_style())
             .block(block);
         win.frame().render_widget(paragraph, area);
         return;
     }
+
+    let body = win.body_style();
+    let muted = win.muted_style();
+    let accent = win.accent_style();
+    let highlight = win.highlight_style();
+    let separator = win.muted_fg_style();
 
     let sep = "─".repeat(content_width);
     let mut lines: Vec<Line> = Vec::new();
@@ -71,22 +76,15 @@ fn render_list(
         let article_start = lines.len() as u16;
 
         if i > 0 {
-            lines.push(Line::from(Span::styled(
-                &sep,
-                Style::default().fg(theme.muted_color),
-            )));
+            lines.push(Line::from(Span::styled(&sep, separator)));
         }
 
         let is_selected = i == widget.selected;
         let dist = crate::geo::format_distance(article.dist_m);
-        let title_style = if is_selected {
-            Style::default().fg(theme.accent_alt)
-        } else {
-            theme.accent_style()
-        };
+        let title_style = if is_selected { highlight } else { accent };
         lines.push(Line::from(vec![
             Span::styled(&article.title, title_style),
-            Span::styled(format!("  {}", dist), theme.muted()),
+            Span::styled(format!("  {}", dist), muted),
         ]));
 
         if !article.extract.is_empty() {
@@ -98,7 +96,7 @@ fn render_list(
                 raw
             };
             for wrapped in wrap_to_width(&truncated, content_width) {
-                lines.push(Line::from(Span::styled(wrapped, theme.text())));
+                lines.push(Line::from(Span::styled(wrapped, body)));
             }
         }
 
@@ -117,48 +115,38 @@ fn render_list(
         0
     };
 
-    let text_style = theme.text();
-    let paragraph = Paragraph::new(lines)
-        .style(text_style)
-        .block(block)
-        .scroll((scroll, 0));
+    let paragraph = Paragraph::new(lines).style(body).block(block).scroll((scroll, 0));
     win.frame().render_widget(paragraph, area);
 }
 
 fn render_detail(win: &mut RenderWindow, area: Rect, content_width: usize, article: &WikiArticle) {
-    let theme = win.theme();
-    let block = theme.panel("wiki (Esc: back)");
+    let block = win.panel_block("wiki (Esc: back)");
+    let body = win.body_style();
+    let muted = win.muted_style();
+    let highlight = win.highlight_style();
+    let separator = win.muted_fg_style();
+
     let dist = crate::geo::format_distance(article.dist_m);
     let coords = format!("{:.3}, {:.3}", article.lat, article.lon);
 
     let mut lines: Vec<Line> = Vec::new();
-    lines.push(Line::from(Span::styled(
-        &article.title,
-        Style::default().fg(theme.accent_alt),
-    )));
+    lines.push(Line::from(Span::styled(&article.title, highlight)));
     lines.push(Line::from(vec![
-        Span::styled(dist, theme.muted()),
-        Span::styled("  ", theme.muted()),
-        Span::styled(coords, theme.muted()),
+        Span::styled(dist, muted),
+        Span::styled("  ", muted),
+        Span::styled(coords, muted),
     ]));
-    lines.push(Line::from(Span::styled(
-        "─".repeat(content_width),
-        Style::default().fg(theme.muted_color),
-    )));
+    lines.push(Line::from(Span::styled("─".repeat(content_width), separator)));
 
     if article.extract.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "(no summary available)",
-            theme.muted(),
-        )));
+        lines.push(Line::from(Span::styled("(no summary available)", muted)));
     } else {
         for wrapped in wrap_to_width(&article.extract, content_width) {
-            lines.push(Line::from(Span::styled(wrapped, theme.text())));
+            lines.push(Line::from(Span::styled(wrapped, body)));
         }
     }
 
-    let text_style = theme.text();
-    let paragraph = Paragraph::new(lines).style(text_style).block(block);
+    let paragraph = Paragraph::new(lines).style(body).block(block);
     win.frame().render_widget(paragraph, area);
 }
 

--- a/src/plugin/wiki/panel.rs
+++ b/src/plugin/wiki/panel.rs
@@ -115,7 +115,10 @@ fn render_list(
         0
     };
 
-    let paragraph = Paragraph::new(lines).style(body).block(block).scroll((scroll, 0));
+    let paragraph = Paragraph::new(lines)
+        .style(body)
+        .block(block)
+        .scroll((scroll, 0));
     win.frame().render_widget(paragraph, area);
 }
 
@@ -136,7 +139,10 @@ fn render_detail(win: &mut RenderWindow, area: Rect, content_width: usize, artic
         Span::styled("  ", muted),
         Span::styled(coords, muted),
     ]));
-    lines.push(Line::from(Span::styled("─".repeat(content_width), separator)));
+    lines.push(Line::from(Span::styled(
+        "─".repeat(content_width),
+        separator,
+    )));
 
     if article.extract.is_empty() {
         lines.push(Line::from(Span::styled("(no summary available)", muted)));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,7 +14,7 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 
 use overlay::OverlayManager;
 
-use crate::compositor::Compositor;
+use crate::compositor::{Compositor, Context};
 use crate::map::render::frame::MapFrame;
 use crate::map::render::thread::RenderHandle;
 use crate::painter::MapPainter;
@@ -56,7 +56,7 @@ impl UiState {
 /// overlays (wiki markers via `Component::paint_on_map`) and on-top
 /// panels (via `Component::render`) go through the same draw pass
 /// as the map.
-pub fn draw(f: &mut Frame, ui: &UiState, compositor: &Compositor, theme: &UiTheme) {
+pub fn draw(f: &mut Frame, ui: &UiState, compositor: &Compositor, theme: &UiTheme, ctx: &Context) {
     let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(f.area());
 
     let map_area = chunks[0];
@@ -84,7 +84,7 @@ pub fn draw(f: &mut Frame, ui: &UiState, compositor: &Compositor, theme: &UiThem
     }
 
     // Modal panels on top of the map, bottom-up.
-    compositor.render(f, map_inner, theme);
+    compositor.render(f, map_inner, theme, ctx);
 
     let hints = build_hints(compositor);
     let sep = Span::styled("  ", Style::default().fg(theme.muted_color));


### PR DESCRIPTION
## Summary

Render-side parallel to [#71](https://github.com/Kohei-Wada/ttymap/pull/71). Replace the `render(f, area, theme)` 3-arg signature with `render(win: &mut RenderWindow)` and hide `UiTheme` behind semantic style accessors on `RenderWindow` / `MapPainter`.

**After this PR, no plugin imports `UiTheme`**. Plugin authors cannot construct a non-themed `Style`; they pick from a closed menu of semantic looks and the framework maps them to the active theme.

## What `RenderWindow` exposes

Draw helpers:
- `win.area()` — layout rect the component is allowed to paint
- `win.frame()` — ratatui `Frame` escape hatch (will be replaced by richer primitives in a follow-up)
- `win.panel(rect, title)` — Clear + bordered block; returns inner rect (used by search + palette)
- `win.panel_block(title)` — returns a themed `Block` for `Paragraph::block(...)` (used by wiki + help)

Semantic style accessors (theme hidden):
- `win.body_style()` — plain text
- `win.muted_style()` — hints / aux info
- `win.accent_style()` — primary accent
- `win.highlight_style()` — secondary accent fg only (wiki selected title)
- `win.selected_style()` — list row highlight
- `win.link_style()` — URLs
- `win.muted_fg_style()` — fg-only muted colour for separator lines

`MapPainter` gets the matching `accent_color()` / `accent_alt_color()` so `paint_on_map` hides theme too.

## Plugin-side impact

- `use crate::theme::UiTheme` gone from every plugin
- `theme.text()` / `theme.muted()` / etc. → `win.*_style()`
- `panel.rs` helpers take `&mut RenderWindow`, drop `theme: &UiTheme`
- Adding a new theme-derived style = 1 accessor on `RenderWindow`, zero plugin changes

## Scope boundary / what's next

`win.frame()` remains as an escape hatch for widgets not yet wrapped (Paragraph-with-scroll, Table, multi-span Line, ...). A follow-up PR will:

- add higher-level primitives (`win.paragraph(...)`, `win.list(...)`, `win.table(...)`, `win.span(Look, text)`)
- retire `win.frame()` so plugins **cannot even `use ratatui`** — ratatui becomes a framework-internal dependency, and plugins literally cannot construct a widget that would bypass the framework or scribble outside their `area`

That separation is intentional: this PR is a drop-in rename/refactor with no UI regressions; the next PR is the substantive capability lockdown.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 166 green
- [x] `rg UiTheme src/plugin/` returns only doc comments; no type reference
- [ ] Manual smoke:
  - [ ] `cargo run` → pan/zoom, resize
  - [ ] `:` palette → theme switch (colors update across all surfaces)
  - [ ] `/` search, `i` wiki (markers + panel), `?` help
  - [ ] Tab cycle

## Numbers

2 commits:
- `ff1d34a` — `RenderWindow` type + `render()` signature change
- `f129443` — semantic style accessors, `win.theme()` removed, `UiTheme` hidden

Combined: 15 files changed, +324 / -217 (net +107) — new weight is the `RenderWindow` type surface (~80 lines of methods + docs); savings come from eliminating theme threading at every call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)