### PR TITLE
fix(decode): bounds-check MVT geometry to avoid panic on truncation (#102)

### DIFF
--- a/src/map/tile/decode.rs
+++ b/src/map/tile/decode.rs
@@ -91,6 +91,13 @@ fn decode_geometry(geometry: &[u32]) -> Vec<Vec<TilePoint>> {
             1 => {
                 // MoveTo
                 for _ in 0..count {
+                    // Truncated / malformed tile: the command header
+                    // claims more parameter pairs than the buffer
+                    // actually carries. Stop instead of panicking on
+                    // OOB; partial geometry is acceptable. See #102.
+                    if i + 1 >= geometry.len() {
+                        break;
+                    }
                     if !current.is_empty() {
                         rings.push(std::mem::take(&mut current));
                     }
@@ -105,6 +112,9 @@ fn decode_geometry(geometry: &[u32]) -> Vec<Vec<TilePoint>> {
             2 => {
                 // LineTo
                 for _ in 0..count {
+                    if i + 1 >= geometry.len() {
+                        break;
+                    }
                     let dx = zigzag(geometry[i]);
                     let dy = zigzag(geometry[i + 1]);
                     i += 2;
@@ -330,6 +340,41 @@ mod tests {
         assert_eq!(rings[0][0].y, 0);
         assert_eq!(rings[0][1].x, 1);
         assert_eq!(rings[0][1].y, 2);
+    }
+
+    /// Regression for issue #102. A MoveTo command claiming more
+    /// points than the geometry buffer actually carries (truncated
+    /// fetch, server bug, adversarial input) must NOT panic the
+    /// decoder. The valid prefix should still come back.
+    #[test]
+    fn decode_geometry_truncated_moveto_does_not_panic() {
+        // MoveTo(count=3) but only 2 (dx,dy) pairs follow.
+        // 1 | (3 << 3) = 25.
+        let geometry = vec![25u32, 2, 2, 2, 2];
+        let rings = decode_geometry(&geometry);
+        // First two MoveTo iterations succeed: each starts a fresh ring
+        // with a single point. Third would index past the end → break.
+        assert_eq!(rings.len(), 2);
+        assert_eq!(rings[0].len(), 1);
+        assert_eq!((rings[0][0].x, rings[0][0].y), (1, 1));
+        assert_eq!(rings[1].len(), 1);
+        assert_eq!((rings[1][0].x, rings[1][0].y), (2, 2));
+    }
+
+    /// Same regression on the LineTo branch.
+    #[test]
+    fn decode_geometry_truncated_lineto_does_not_panic() {
+        // MoveTo(1) → (1,1). LineTo(count=3) but only 1 pair follows.
+        // MoveTo: 1 | (1<<3) = 9. LineTo: 2 | (3<<3) = 26.
+        let geometry = vec![9u32, 2, 2, 26, 2, 2];
+        let rings = decode_geometry(&geometry);
+        // MoveTo writes (1,1). LineTo iter 1 writes (2,2). Iter 2 of
+        // LineTo would index past the end → break. Single ring with
+        // both points.
+        assert_eq!(rings.len(), 1);
+        assert_eq!(rings[0].len(), 2);
+        assert_eq!((rings[0][0].x, rings[0][0].y), (1, 1));
+        assert_eq!((rings[0][1].x, rings[0][1].y), (2, 2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Closes #102. `decode_geometry`'s MoveTo / LineTo loops indexed `geometry[i]` and `geometry[i + 1]` without checking the slice length. When the command header claims more parameter pairs than the buffer carries (truncated tile, server bug, adversarial input), the render thread panicked with OOB.
- Fix: \`if i + 1 >= geometry.len() { break; }\` at the top of both inner loops. Partial geometry comes back instead of crashing.

The broader hardening — switching `decode` to `Result<DecodedTile, _>` and discarding malformed tiles in the cache with a warning — is left to a follow-up. This PR is the minimal panic fix.

## Test plan

TDD: tests written and watched fail before the fix, then watched pass.

- [x] `decode_geometry_truncated_moveto_does_not_panic` — `MoveTo(count=3)` with only 2 pairs. Before fix: \`index out of bounds: the len is 5 but the index is 5\`. After fix: returns the 2 single-point rings that were valid.
- [x] `decode_geometry_truncated_lineto_does_not_panic` — `MoveTo(1)` + `LineTo(count=3)` with only 1 pair after the header. Before fix: same OOB pattern. After fix: returns the ring with the two valid points.
- [x] `cargo test` — 241/241 pass.
- [x] `cargo clippy` clean for the changed file.
- [x] `cargo fmt --check` clean (pre-commit hook enforced).