### PR TITLE
fix(view): scan visible tiles dynamically by viewport size (#95)

### DIFF
--- a/src/map/render/view.rs
+++ b/src/map/render/view.rs
@@ -29,8 +29,15 @@ pub fn visible_tiles(
 
     let mut tiles = Vec::new();
 
-    for dy in -1i32..=1 {
-        for dx in -1i32..=1 {
+    // Dynamic scan radius: cover the viewport plus one tile of slack
+    // on each side so we never leave a gap at the edges (issue #95).
+    // The per-tile visibility check below filters anything that falls
+    // off-screen, so being generous here is cheap.
+    let half_w_tiles = (width as f64 / 2.0 / tile_size).ceil() as i32 + 1;
+    let half_h_tiles = (height as f64 / 2.0 / tile_size).ceil() as i32 + 1;
+
+    for dy in -half_h_tiles..=half_h_tiles {
+        for dx in -half_w_tiles..=half_w_tiles {
             let tile_x = center.x.floor() as i32 + dx;
             let tile_y = center.y.floor() as i32 + dy;
 
@@ -108,6 +115,35 @@ mod tests {
                 grid
             );
         }
+    }
+
+    /// Regression for issue #95. A 3×3 fixed scan covers at most
+    /// `3 × tile_size` pixels in each direction (~768 at z≥1). On
+    /// large terminals, the viewport edges are left blank — visible
+    /// black gaps. The visible tile set must scale with screen size.
+    #[test]
+    fn visible_tiles_cover_large_viewport() {
+        // 2000×1000 px viewport at z=4 → tile_size=256. The viewport
+        // is ~7.8 tiles wide and ~3.9 tall; a 3×3 scan reaches only
+        // 768 px on each axis so the right/bottom would be uncovered.
+        let tiles = visible_tiles(0.0, 0.0, 4.0, 2000, 1000);
+        assert!(!tiles.is_empty());
+
+        let min_x = tiles.iter().map(|t| t.pos_x).fold(f64::INFINITY, f64::min);
+        let max_x = tiles
+            .iter()
+            .map(|t| t.pos_x + t.size)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let min_y = tiles.iter().map(|t| t.pos_y).fold(f64::INFINITY, f64::min);
+        let max_y = tiles
+            .iter()
+            .map(|t| t.pos_y + t.size)
+            .fold(f64::NEG_INFINITY, f64::max);
+
+        assert!(min_x <= 0.0, "left edge uncovered (min_x={min_x})");
+        assert!(max_x >= 2000.0, "right edge uncovered (max_x={max_x})");
+        assert!(min_y <= 0.0, "top edge uncovered (min_y={min_y})");
+        assert!(max_y >= 1000.0, "bottom edge uncovered (max_y={max_y})");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Closes #95. `visible_tiles` looped over a hard-coded 3×3 grid (`-1..=1`) around the centre tile, covering at most `3 × tile_size = 768 px` per axis at integer zoom. On terminals taller / wider than that, the viewport edges were left blank — visible black gaps.
- Fix: derive the scan radius from the viewport. `half_w_tiles = ceil(width / 2 / tile_size) + 1`, ditto for height. The +1 covers the centre tile straddling the centre of the screen. The existing per-tile visibility check filters anything that genuinely falls off, so being generous on the scan radius is cheap.
- `pipeline::prefetch` calls `visible_tiles` indirectly via `visible_tiles_for`, so its z+1 / z-1 prefetch rings now scale with viewport too — automatic upside.

## Test plan

TDD: regression test added and watched fail before the fix, pass after.

- [x] `visible_tiles_cover_large_viewport` — 2000×1000 viewport at z=4 (tile_size=256, viewport ~7.8×3.9 tiles). Asserts the union of returned tile rects covers `[0, 2000] × [0, 1000]`. Pre-fix: `min_x = 744` (744 px gap at the left edge — and likewise at right/bottom). Post-fix: full coverage.
- [x] All existing `view::tests` still pass (small viewports unchanged in behaviour).
- [x] `cargo test` — 257/257 pass.
- [x] `cargo clippy` clean.
- [x] `cargo fmt --check` clean (pre-commit hook enforced).
- [ ] Manual smoke on a wide / tall terminal — black edge bands should be gone.