### PR TITLE
refactor(tile): rename mapscii.rs → http.rs, struct → HttpTileClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ src/
 │   └── tile/            MVT fetch + cache + decode
 │       ├── cache.rs         Memory (configurable LRU) + optional disk
 │       ├── decode.rs        Protobuf → DecodedTile
-│       └── fetch/           TileClient trait + mapscii backend + priority queue
+│       └── fetch/           TileClient trait + http backend + priority queue
 │
 ├── shared/              host-and-plugin utilities (plugin-only utilities live in plugin_api/)
 │   ├── geoip.rs         IP-based lat/lon lookup (also used by snap CLI)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -297,7 +297,7 @@ impl App {
 pub(crate) fn build_tile_cache(config: &Config) -> (crate::map::tile::TileCache, Option<String>) {
     use crate::map::tile::fetch::TileClient;
     let (tx, rx) = std::sync::mpsc::channel();
-    let client = crate::map::tile::fetch::MapsciiTileClient::new(tx);
+    let client = crate::map::tile::fetch::HttpTileClient::new(tx);
     let attribution = {
         let s = client.attribution();
         (!s.is_empty()).then(|| s.to_string())

--- a/src/map/tile/fetch/http.rs
+++ b/src/map/tile/fetch/http.rs
@@ -1,10 +1,10 @@
-//! Client for `mapscii.me` — fetches MVT (`.pbf`) tiles over HTTP
-//! using the slippy-map URL scheme `{base}/{z}/{x}/{y}.pbf`. The base
-//! URL and attribution are hardcoded: ttymap's map rendering assumes
-//! OSM-derived OpenMapTiles data, and mapscii.me is the only public
-//! server that serves it without an API key. Fixed worker pool pops
-//! from an internal queue, GETs bytes, and forwards the payload to
-//! the cache through an `mpsc` channel.
+//! HTTP `TileClient` — fetches MVT (`.pbf`) tiles over the slippy-map
+//! URL scheme `{base}/{z}/{x}/{y}.pbf`. ttymap's map rendering
+//! assumes OSM-derived OpenMapTiles data, and `mapscii.me` is the
+//! only public server that serves it without an API key, so the base
+//! URL is hardcoded for now. A fixed worker pool pops from an
+//! internal queue, GETs bytes, and forwards the payload to the cache
+//! through an `mpsc` channel.
 
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -30,12 +30,12 @@ struct SharedState {
     shutdown: AtomicBool,
 }
 
-pub struct MapsciiTileClient {
+pub struct HttpTileClient {
     shared: Arc<SharedState>,
     _workers: Vec<thread::JoinHandle<()>>,
 }
 
-impl MapsciiTileClient {
+impl HttpTileClient {
     pub fn new(tx: mpsc::Sender<(TileKey, Vec<u8>)>) -> Self {
         let shared = Arc::new(SharedState {
             queue: Mutex::new(PriorityQueue::new()),
@@ -59,14 +59,14 @@ impl MapsciiTileClient {
             }));
         }
 
-        MapsciiTileClient {
+        HttpTileClient {
             shared,
             _workers: workers,
         }
     }
 }
 
-impl TileClient for MapsciiTileClient {
+impl TileClient for HttpTileClient {
     /// Enqueue a tile for fetching. Skips if already queued or in-flight.
     fn enqueue(&self, key: &TileKey, priority: TilePriority) {
         {
@@ -120,7 +120,7 @@ impl TileClient for MapsciiTileClient {
     }
 }
 
-impl Drop for MapsciiTileClient {
+impl Drop for HttpTileClient {
     fn drop(&mut self) {
         self.shared.shutdown.store(true, Ordering::Relaxed);
         self.shared.condvar.notify_all();
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn test_enqueue_dedup_in_flight() {
         let (tx, _rx) = mpsc::channel();
-        let client = MapsciiTileClient::new(tx);
+        let client = HttpTileClient::new(tx);
         let key = TileKey::new(0, 0, 0);
 
         // Manually mark as in-flight

--- a/src/map/tile/fetch/mod.rs
+++ b/src/map/tile/fetch/mod.rs
@@ -1,17 +1,17 @@
 //! Tile fetch subsystem — backends that populate the cache.
 //!
-//! Today the only backend is `mapscii` (MVT over HTTP against
+//! Today the only backend is `http` (MVT over HTTP, default base
 //! `mapscii.me`). Additional backends (mbtiles, pmtiles, local dirs,
 //! mocks for tests) plug in as new modules whose entry type
 //! `impl TileClient`. When a second backend lands, route selection
 //! (from config or from the file extension of a user-supplied path)
 //! lives here.
 
-pub mod mapscii;
+pub mod http;
 pub mod priority;
 pub mod queue;
 
-pub use mapscii::MapsciiTileClient;
+pub use http::HttpTileClient;
 pub use priority::TilePriority;
 
 use crate::map::tile::cache::TileKey;


### PR DESCRIPTION
## Summary

The fetch backend is generic MVT-over-HTTP — `mapscii.me` is just the default base URL, not a protocol or product. Naming the file and struct after the URL it happens to point to misled anyone reading the module map for the first time, and got in the way as the tile subsystem prepares for additional backends (mbtiles, pmtiles, local dirs) where each will live in its own file under `fetch/`.

**Behavior change: zero.** Pure rename:

- `src/map/tile/fetch/mapscii.rs` → `src/map/tile/fetch/http.rs`
- `MapsciiTileClient` → `HttpTileClient`
- `pub mod mapscii` / `pub use mapscii::MapsciiTileClient` updated in `fetch/mod.rs`
- `app::build_tile_cache` and the module docstring updated to match
- README architecture map: \"mapscii backend\" → \"http backend\"

This is the first of several mechanical prereqs (TileKey relocation, decode.rs split) before the substantive `TileFetcher` / `FetchLane` trait redesign and the decode-lane refactor that lets us push decode off the render thread.

## Test plan

- [x] `cargo test` — 260/260 pass.
- [x] `cargo clippy` clean.
- [x] `cargo fmt --check` clean (pre-commit hook enforced).
- Pure rename — no behavioural test possible / needed.