### PR TITLE
refactor(tile): move TileKey out of cache.rs into tile/key.rs

### DIFF
--- a/src/map/tile/cache.rs
+++ b/src/map/tile/cache.rs
@@ -14,25 +14,7 @@ use lru::LruCache;
 
 use super::decode::{self, DecodedTile};
 use super::fetch::{TileClient, TilePriority};
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TileKey {
-    pub z: u32,
-    pub x: i32,
-    pub y: i32,
-}
-
-impl TileKey {
-    pub fn new(z: u32, x: i32, y: i32) -> Self {
-        Self { z, x, y }
-    }
-}
-
-impl std::fmt::Display for TileKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}/{}", self.z, self.x, self.y)
-    }
-}
+use super::key::TileKey;
 
 pub struct TileCache {
     client: Box<dyn TileClient>,
@@ -276,11 +258,6 @@ mod tests {
 
     use super::super::fetch::queue::PriorityFn;
     use super::*;
-
-    #[test]
-    fn test_tile_key_display() {
-        assert_eq!(TileKey::new(5, 17, 10).to_string(), "5/17/10");
-    }
 
     #[test]
     fn test_tile_distance_sq() {

--- a/src/map/tile/fetch/http.rs
+++ b/src/map/tile/fetch/http.rs
@@ -16,7 +16,7 @@ use log::debug;
 use super::TileClient;
 use super::priority::TilePriority;
 use super::queue::{PriorityFn, PriorityQueue};
-use crate::map::tile::cache::TileKey;
+use crate::map::tile::key::TileKey;
 use crate::shared::http::HttpClient;
 
 const NUM_WORKERS: usize = 6;

--- a/src/map/tile/fetch/mod.rs
+++ b/src/map/tile/fetch/mod.rs
@@ -14,7 +14,7 @@ pub mod queue;
 pub use http::HttpTileClient;
 pub use priority::TilePriority;
 
-use crate::map::tile::cache::TileKey;
+use crate::map::tile::key::TileKey;
 use queue::PriorityFn;
 
 /// Abstract tile-fetch backend. Cache owns a `Box<dyn TileClient>` and

--- a/src/map/tile/key.rs
+++ b/src/map/tile/key.rs
@@ -1,0 +1,35 @@
+//! `TileKey` — the universal `(z, x, y)` slippy-map tile identifier.
+//!
+//! Lives at the top of the tile subsystem because every layer below
+//! (cache, fetch backends, decoder) speaks in these keys. Keeping the
+//! type out of `cache.rs` avoids the awkwardness of fetch backends
+//! reaching back into the cache module just for the address type.
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TileKey {
+    pub z: u32,
+    pub x: i32,
+    pub y: i32,
+}
+
+impl TileKey {
+    pub fn new(z: u32, x: i32, y: i32) -> Self {
+        Self { z, x, y }
+    }
+}
+
+impl std::fmt::Display for TileKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}/{}", self.z, self.x, self.y)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_uses_zxy_form() {
+        assert_eq!(TileKey::new(5, 17, 10).to_string(), "5/17/10");
+    }
+}

--- a/src/map/tile/mod.rs
+++ b/src/map/tile/mod.rs
@@ -1,6 +1,7 @@
 //! Tile subsystem — fetching, caching, decoding, and view calculations.
 //!
 //! Responsibilities:
+//!   key.rs       — `TileKey` (z, x, y) universal address
 //!   cache.rs     — memory + disk storage, decode, stale detection, prefetch
 //!   fetch/       — backends that populate the cache (HTTP today, more later)
 //!   decode.rs    — MVT protobuf decoding
@@ -9,8 +10,10 @@
 pub mod cache;
 pub mod decode;
 pub mod fetch;
+pub mod key;
 pub mod property;
 
 pub use cache::TileCache;
 pub use decode::Feature;
+pub use key::TileKey;
 pub use property::PropertyValue;


### PR DESCRIPTION
## Summary

Every layer below cache (fetch backends, eventually the decoder lane) speaks in `TileKey`s, so having the type live inside `cache.rs` made `fetch/*.rs` reach back into a sibling module just for the address type. With the upcoming three-layer pipe (backend → decoder → cache), the cache module is one of several consumers — not the owner.

Move `TileKey` to its own `tile/key.rs` and re-export from `tile/mod.rs`.

**Behavior change: zero.** Pure type relocation:

- New file `src/map/tile/key.rs` holds the `TileKey` struct + `new` + `Display` impl + the in-module test (renamed `display_uses_zxy_form` to match the file's own idiom).
- `fetch/mod.rs`, `fetch/http.rs` switch from `cache::TileKey` to `key::TileKey`.
- `cache.rs` imports `TileKey` from `super::key`.
- `tile/mod.rs` adds `pub mod key;` and `pub use key::TileKey;`.

Second of three mechanical prereqs (after the http rename, before the decode.rs split) before the substantive `TileFetcher` / `FetchLane` redesign.

## Test plan

- [x] `cargo test` — 260/260 pass (the moved test now reports as `map::tile::key::tests::display_uses_zxy_form`).
- [x] `cargo clippy` clean.
- [x] `cargo fmt --check` clean (pre-commit hook enforced).
- Pure relocation — no behavioural test possible / needed.