### PR TITLE
feat(lua): bundle hello.lua + opt-in registrar wiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ Key modules:
 - **`src/geo.rs`**: Web Mercator projection math — lon/lat ↔ tile coordinates, distance calculations.
 - **`src/map/render/label.rs`**: Collision-free label placement buffer.
 - **`src/plugin/`**: Plugins (aircraft, attribution, export, help, here, info, iss, quake, scalebar, search, wiki) — composable UI panels with async work via `poll()`. Built-in chrome (info / scalebar / attribution) is structured as plugins too. Search is the unusual one: instead of being a `Component`, it's a `PaletteProvider` (in `src/plugin/search/mod.rs`) — its `register()` binds `/` to push the palette pre-loaded with the provider.
+- **`src/lua/`**: Lua scripted plugins (mlua + Lua 5.4 vendored). `LuaComponent` (`component.rs`) implements `Component` by dispatching to a Lua module table; `register()` (in `mod.rs`) wires bundled scripts in `scripts/*.lua` into the registrar. **Opt-in only** — `app::build_registrar` calls it solely when `[lua] enabled = true` is set in config, because today's bundled scripts (`hello.lua`) are demos, not features. See `docs/lua-bridge-surface.md` for the bridge surface scope.
 
 ## Rust Edition
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ src/
 │   ├── search/          forward-geocode (Nominatim) — registers a palette provider, no Component
 │   └── wiki/            nearby Wikipedia panel
 │
+├── lua/                 Lua scripted plugins (mlua + Lua 5.4, opt-in via `[lua] enabled = true`)
+│   ├── mod.rs           shared VM + register() for bundled scripts
+│   ├── component.rs     LuaComponent — Component impl backed by a Lua module
+│   └── scripts/         bundled .lua sources (hello.lua: demo / template)
+│
 ├── plugin_api/          plugin-author surface — services + helpers + prelude
 │   ├── mod.rs           re-exports + `prelude` glob
 │   ├── map_api.rs       MapApi — world-space + screen-space draw primitives for paint_on_map
@@ -390,6 +395,12 @@ timeout_ms = 2000
 [keymap]
 zoom_in = ["i", "+"]
 quit = ["q", "C-q"]
+
+# Opt-in: load bundled Lua plugins (today: hello). Adds a "Toggle
+# Lua: hello" entry to the `:` palette. Disabled by default because
+# bundled scripts are demos, not features.
+[lua]
+enabled = true
 ```
 
 See `config.example.toml` for all options. Every section and field is optional; omitted values fall back to built-in defaults.

--- a/config.example.toml
+++ b/config.example.toml
@@ -98,3 +98,11 @@
 
 # [info]
 # enabled = false      # turns off the top-right cursor / centre / zoom readout
+
+# ── Lua scripted plugins (opt-in) ───────────────────────────────────
+# Loads bundled scripts under src/lua/scripts/. Today: a `hello`
+# demo. Off by default because the bundled scripts are demos /
+# templates, not user-facing features. See docs/lua-bridge-surface.md
+# for the bridge surface.
+# [lua]
+# enabled = true

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -436,6 +436,21 @@ fn build_registrar(
         crate::plugin::quake::register(config, &mut r);
     }
 
+    // Lua scripted plugins. Opt-in via `[lua] enabled = true` —
+    // unlike the rest of the plugins, default is *false* because
+    // these are demo / dogfood, not user-facing features. The
+    // detection inlines the lookup so we don't perturb
+    // `Config::plugin_enabled`'s default-true semantics.
+    let lua_enabled = config
+        .extras
+        .get("lua")
+        .and_then(|v| v.get("enabled"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if lua_enabled {
+        crate::lua::register(&mut r);
+    }
+
     // Help needs to know the other plugins' activation hints, so build
     // its text after them (but before palette install, since palette
     // harvests help's palette entry too).

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -15,16 +15,53 @@
 
 pub mod component;
 
-#[allow(unused_imports)] // re-export becomes load-bearing once a plugin registers
 pub use component::LuaComponent;
 
 use mlua::Lua;
 
+use crate::compositor::Registrar;
+
 /// Build a fresh Lua state. Sandboxing / standard-library trimming
 /// would happen here; for now we hand back the unmodified VM.
-#[allow(dead_code)] // exercised by component.rs tests; first non-test caller lands when LuaComponent is registered.
 pub fn new_lua() -> Lua {
     Lua::new()
+}
+
+/// Bundled `hello` plugin source — a tiny demo that doubles as the
+/// reference template for future Lua plugin authors.
+const HELLO_LUA: &str = include_str!("scripts/hello.lua");
+
+/// Wire the bundled Lua plugins into the registrar. Today that's
+/// just `hello`. New bundled plugins go in `scripts/<name>.lua` and
+/// register here alongside `hello`.
+///
+/// Lua failures (parse error, missing fields) are logged and the
+/// plugin is silently skipped rather than aborting startup — the
+/// host always boots even with a broken Lua plugin.
+pub fn register(r: &mut Registrar) {
+    register_script("hello", HELLO_LUA, r);
+}
+
+fn register_script(name: &'static str, source: &'static str, r: &mut Registrar) {
+    // Validate the script up front so a syntax error surfaces as one
+    // log line instead of a noisy first-toggle failure.
+    if let Err(e) = LuaComponent::from_source(source, name) {
+        log::warn!("lua[{}]: failed to load, plugin skipped: {}", name, e);
+        return;
+    }
+    let label = format!("Toggle Lua: {}", name);
+    r.add_toggle(label, "", move |_| {
+        // Re-load on every toggle so the plugin gets fresh state.
+        // If it parsed once at startup it should parse again, but
+        // recover gracefully if it doesn't.
+        LuaComponent::from_source(source, name).unwrap_or_else(|e| {
+            log::warn!("lua[{}]: re-load failed: {}", name, e);
+            // Synthesize a minimal placeholder so the toggle still
+            // produces a Component. Empty source still parses and
+            // exposes a no-op render.
+            LuaComponent::from_source("return {}", name).expect("trivial Lua module always loads")
+        })
+    });
 }
 
 #[cfg(test)]
@@ -59,5 +96,27 @@ mod tests {
         assert_eq!(name, "hi");
         assert_eq!(n, 3);
         Ok(())
+    }
+
+    #[test]
+    fn bundled_hello_script_parses() {
+        // The script is in-tree; if this ever fails, the include_str!
+        // is pointing at something broken.
+        LuaComponent::from_source(HELLO_LUA, "hello").expect("hello.lua should parse");
+    }
+
+    #[test]
+    fn register_adds_a_palette_entry_for_hello() {
+        let mut r = Registrar::default();
+        register(&mut r);
+        // We don't need to assert the count exactly — just that the
+        // bundled hello plugin produced *some* palette entry. The
+        // label substring guards against silent regressions.
+        let labels: Vec<&str> = r.palette_entries.iter().map(|e| e.label.as_str()).collect();
+        assert!(
+            labels.iter().any(|l| l.contains("hello")),
+            "expected a 'hello' palette entry, got {:?}",
+            labels,
+        );
     }
 }

--- a/src/lua/scripts/hello.lua
+++ b/src/lua/scripts/hello.lua
@@ -1,0 +1,25 @@
+-- ttymap built-in Lua plugin demo.
+--
+-- A plugin module is just a table with at least `name` and `render`
+-- fields. `render()` is called every frame; return a list of strings
+-- and the host wraps them in a framed Paragraph titled with `name`.
+--
+-- Future plugin authors: copy this file as a starting template.
+-- Bridge surface today is intentionally tiny (text lines only); see
+-- docs/lua-bridge-surface.md for what's coming.
+
+return {
+    name = "hello",
+    render = function()
+        return {
+            "Hello from Lua!",
+            "",
+            "This panel is rendered by",
+            "src/lua/scripts/hello.lua",
+            "",
+            "Enable in config:",
+            "  [lua]",
+            "  enabled = true",
+        }
+    end,
+}


### PR DESCRIPTION
## Summary

Third slice of the Lua plugin migration (after #135 scaffold and #136 LuaComponent adapter). The bundled \`hello.lua\` script becomes a real palette entry: with \`[lua] enabled = true\` in \`config.toml\`, the \`:\` palette grows a "Toggle Lua: hello" item that toggles a \`LuaComponent\` rendering the script's panel.

## What's in this PR

- \`src/lua/scripts/hello.lua\` — minimal demo + reference template for future Lua plugin authors
- \`src/lua/mod.rs::register()\` — \`include_str!\`s the script, validates parse, wires it via \`Registrar::add_toggle\`. Parse errors at startup → log + skip (host still boots). Re-load failures at toggle time → fall back to a trivial empty module so the toggle still yields a Component.
- \`app/mod.rs\` — calls \`crate::lua::register\` only when \`[lua] enabled = true\`. **Default false:** bundled scripts are demo / dogfood, not features. The lookup is inlined so \`Config::plugin_enabled\`'s default-true semantics stay intact.
- 2 new tests: bundled script parses, registrar gets a \`hello\` palette entry.
- Doc sync: \`CLAUDE.md\`, \`README.md\`, \`config.example.toml\`.

## Try it

\`\`\`toml
# ~/.config/ttymap/config.toml
[lua]
enabled = true
\`\`\`

Then \`:\` → "Toggle Lua: hello".

## What's not in this PR

- \`handle_event\` / \`paint_on_map\` / \`poll\` dispatch (follow-ups)
- Wider widget surface (Span styling, multi-line layout) and MapApi bindings (per audit §8)
- File-system plugin loading (\`~/.config/ttymap/plugins/*.lua\`) — bundled-only for now

## Test plan
- [x] \`cargo test\` — 326 passed (324 + 2 new)
- [x] \`cargo clippy -- -D warnings\` — clean
- [x] \`cargo fmt --check\`
- [x] Manual: \`cargo run\` with \`[lua] enabled = true\`, \`:\` palette shows "Toggle Lua: hello", selecting it opens the panel