### PR TITLE
feat(lua): paint_on_map dispatch — Lua plugins draw map markers

### DIFF
--- a/src/lua/component.rs
+++ b/src/lua/component.rs
@@ -12,14 +12,16 @@
 //!
 //! Bridge surface so far: `name`, `render` (text lines wrapped in a
 //! framed Paragraph), `handle_event` (Lua-side keymap → close /
-//! ignore / silent consume). `paint_on_map`, `poll`, and the wider
-//! widget / map vocabulary land in follow-ups.
+//! ignore / silent consume), `paint_on_map` (Lua draws map markers
+//! via [`MapApi`]). `poll` and the wider widget / map vocabulary
+//! land in follow-ups.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mlua::{Lua, RegistryKey, Table};
 
 use crate::compositor::Component;
 use crate::compositor::window::{RenderWindow, Window};
+use crate::plugin_api::MapApi;
 use crate::widget::{self, Line, Span, StyleKind};
 
 /// A Component implemented in Lua.
@@ -100,6 +102,30 @@ impl LuaComponent {
                 log::warn!("lua[{}]: handle_event() failed: {}", self.name, e);
                 KeyAction::Consume
             }
+        }
+    }
+
+    /// Run the Lua side of `paint_on_map`. Errors are logged and
+    /// recovered: a buggy painter must not corrupt the rest of the
+    /// frame.
+    ///
+    /// `MapApi` borrows the ratatui buffer for one frame, so the
+    /// Lua-facing handle is built inside `Lua::scope` (closures
+    /// over a `RefCell` of the ref) and torn down before this
+    /// method returns.
+    fn dispatch_paint(&self, p: &mut MapApi<'_>) {
+        let cell = std::cell::RefCell::new(p);
+        let result: mlua::Result<()> = self.lua.scope(|scope| {
+            let module: Table = self.lua.registry_value(&self.module)?;
+            let painter: Option<mlua::Function> = module.get("paint_on_map").ok();
+            let Some(painter) = painter else {
+                return Ok(());
+            };
+            let map_table = super::map_api::make_map_table(&self.lua, scope, &cell)?;
+            painter.call::<()>(map_table)
+        });
+        if let Err(e) = result {
+            log::warn!("lua[{}]: paint_on_map() failed: {}", self.name, e);
         }
     }
 
@@ -189,6 +215,10 @@ impl Component for LuaComponent {
             KeyAction::Ignore => win.ignore(),
             KeyAction::Consume => {}
         }
+    }
+
+    fn paint_on_map(&self, p: &mut MapApi<'_>) {
+        self.dispatch_paint(p);
     }
 
     fn render(&self, win: &mut RenderWindow) {
@@ -396,5 +426,77 @@ mod tests {
             c.dispatch_event(key(KeyCode::Char('z'))),
             KeyAction::Consume
         );
+    }
+
+    // ── paint_on_map ─────────────────────────────────────────────
+
+    use crate::map::render::frame::MapFrame;
+    use crate::theme::{DARK, UiTheme};
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+
+    fn map_fixture(w: u16, h: u16) -> (Buffer, Rect, MapFrame, UiTheme) {
+        let area = Rect::new(0, 0, w, h);
+        let buf = Buffer::empty(area);
+        let frame = MapFrame {
+            cells: Vec::new(),
+            cols: w,
+            rows: h,
+            center: crate::geo::LonLat { lon: 0.0, lat: 0.0 },
+            zoom: 1.0,
+        };
+        let theme = UiTheme::from_palette(&DARK);
+        (buf, area, frame, theme)
+    }
+
+    #[test]
+    fn paint_on_map_missing_handler_is_no_op() {
+        let c = LuaComponent::from_source(r#"return { name = "blank" }"#, "blank").expect("load");
+        let (mut buf, area, frame, theme) = map_fixture(20, 5);
+        let mut api = MapApi::new(&mut buf, area, &frame, &theme, None);
+        // Should not panic; nothing is written.
+        c.dispatch_paint(&mut api);
+    }
+
+    #[test]
+    fn paint_on_map_runtime_error_is_recovered() {
+        let c = LuaComponent::from_source(
+            r#"return {
+                name = "boom",
+                paint_on_map = function(_) error("kaboom") end,
+            }"#,
+            "boom",
+        )
+        .expect("load");
+        let (mut buf, area, frame, theme) = map_fixture(20, 5);
+        let mut api = MapApi::new(&mut buf, area, &frame, &theme, None);
+        // No panic; warning is logged.
+        c.dispatch_paint(&mut api);
+    }
+
+    #[test]
+    fn paint_on_map_point_writes_into_the_buffer() {
+        let c = LuaComponent::from_source(
+            r#"return {
+                name = "marker",
+                paint_on_map = function(map)
+                    map:point(0.0, 0.0, "*", "accent")
+                end,
+            }"#,
+            "marker",
+        )
+        .expect("load");
+        let (mut buf, area, frame, theme) = map_fixture(20, 5);
+        {
+            let mut api = MapApi::new(&mut buf, area, &frame, &theme, None);
+            c.dispatch_paint(&mut api);
+        }
+        // Confirm at least one cell got the marker glyph. Don't
+        // pin the exact projected coord — the Web-Mercator rounding
+        // for centre=(0,0), zoom=1 is implementation detail.
+        let written = (0..area.width)
+            .flat_map(|x| (0..area.height).map(move |y| (x, y)))
+            .any(|(x, y)| buf[(x, y)].symbol() == "*");
+        assert!(written, "expected at least one '*' in the buffer");
     }
 }

--- a/src/lua/map_api.rs
+++ b/src/lua/map_api.rs
@@ -1,0 +1,67 @@
+//! Lua-side bridge for [`MapApi`].
+//!
+//! Plugin authors call `map:point(lon, lat, glyph, color)` from Lua.
+//! `color` is a theme-aware string keyword today (`"accent"` |
+//! `"accent_alt"`); raw integer / RGB support comes later if a
+//! plugin actually needs it.
+//!
+//! `MapApi` carries a non-`'static` lifetime (it borrows the
+//! ratatui buffer for one frame), so we can't use mlua's
+//! `Scope::create_userdata_ref_mut` (which requires `T: 'static`).
+//! Instead we build a per-frame Lua table whose methods are
+//! `scope.create_function`-wrapped closures over a `RefCell` of the
+//! `MapApi` ref. The table mimics a userdata to the script — same
+//! `map:method(...)` syntax — but avoids the lifetime restriction.
+
+use std::cell::RefCell;
+
+use mlua::{Lua, Scope, Table};
+
+use crate::geo::LonLat;
+use crate::plugin_api::MapApi;
+
+/// Build the Lua-facing `map` table for a single `paint_on_map`
+/// call. The closures borrow `cell` for `'scope`; once the host's
+/// `Lua::scope` returns the closures are dropped and the borrow is
+/// released, so it's safe to take the ratatui buffer back out.
+pub(super) fn make_map_table<'scope, 'lua_scope>(
+    lua: &Lua,
+    scope: &'scope Scope<'scope, 'lua_scope>,
+    cell: &'scope RefCell<&mut MapApi<'_>>,
+) -> mlua::Result<Table>
+where
+    'lua_scope: 'scope,
+{
+    let table = lua.create_table()?;
+    table.set("point", scope.create_function(|_, args| point(cell, args))?)?;
+    Ok(table)
+}
+
+// First param is the receiver from Lua's `map:point(...)` colon
+// syntax — `map:point(a, b, c)` desugars to `map.point(map, a, b, c)`,
+// so the closure sees the map table itself as its first argument.
+// We discard it; the actual `MapApi` handle is the captured `cell`.
+fn point(
+    cell: &RefCell<&mut MapApi<'_>>,
+    (_self, lon, lat, glyph, color_name): (
+        mlua::Table,
+        f64,
+        f64,
+        mlua::String,
+        Option<mlua::String>,
+    ),
+) -> mlua::Result<()> {
+    let glyph_str = glyph.to_str()?;
+    let glyph_char = glyph_str.chars().next().unwrap_or(' ');
+    let mut p = cell.borrow_mut();
+    let color = match color_name.as_ref().and_then(|s| s.to_str().ok()) {
+        Some(s) if &*s == "accent_alt" => p.accent_alt_color(),
+        // Unknown keyword: fall back to the primary accent rather
+        // than erroring. A typo-y plugin still renders; the bad
+        // colour name surfaces visually as "wrong colour" instead
+        // of a stack trace.
+        _ => p.accent_color(),
+    };
+    p.point(LonLat { lon, lat }, glyph_char, color);
+    Ok(())
+}

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -14,6 +14,7 @@
 //!   `log::warn!` + recovery default.
 
 pub mod component;
+pub mod map_api;
 
 pub use component::LuaComponent;
 

--- a/src/lua/scripts/hello.lua
+++ b/src/lua/scripts/hello.lua
@@ -17,9 +17,16 @@
 --   { close  = true }    -- pop this component off the stack
 --   { ignore = true }    -- pass through to the base layer keymap
 --
+-- `paint_on_map(map)` is optional. The host calls it every frame to
+-- give the plugin a chance to draw world-space markers. Use:
+--
+--   map:point(lon, lat, glyph, color)
+--     -- glyph: single-cell character ("*", "@", "▲", ...)
+--     -- color: "accent" | "accent_alt"   (theme-aware)
+--
 -- Future plugin authors: copy this file as a starting template.
--- Bridge surface today is text + keys; map paint, async fetch, and
--- richer widgets land in follow-ups (see docs/lua-bridge-surface.md).
+-- Bridge surface today is text + keys + map markers; async fetch
+-- and richer widgets land in follow-ups (see docs/lua-bridge-surface.md).
 
 return {
     name = "hello",
@@ -44,5 +51,13 @@ return {
         end
         -- Default: consume so the panel feels modal.
         return nil
+    end,
+
+    paint_on_map = function(map)
+        -- Drop a couple of markers so the plugin is visible on the map
+        -- as well as in the panel.
+        map:point(139.7595,  35.6828, "*", "accent")     -- Tokyo
+        map:point( 13.4050,  52.5200, "*", "accent")     -- Berlin
+        map:point(-74.0060,  40.7128, "*", "accent_alt") -- New York
     end,
 }


### PR DESCRIPTION
## Summary

Fifth slice of the Lua bridge (after #135 / #136 / #137 / #138). Lua plugins can now declare \`paint_on_map(map)\` and plot world-space markers via \`map:point(lon, lat, glyph, color)\`.

## Bridge surface

\`\`\`lua
function module.paint_on_map(map)
    map:point(139.7595, 35.6828, "*", "accent")     -- Tokyo
    map:point(-74.0060, 40.7128, "*", "accent_alt") -- New York
end
\`\`\`

- \`color\`: theme keyword today — \`"accent"\` (default highlight) or \`"accent_alt"\` (focused / selected). Unknown keywords fall back to \`accent\` rather than erroring, so a typo-y plugin still renders.
- \`glyph\`: single-cell character; multi-char strings keep the first character (Lua doesn't have a \`char\` type).

## Lifetime story

\`MapApi\` borrows the ratatui buffer for one frame, so it can't be exposed via mlua's \`Scope::create_userdata_ref_mut\` (which requires \`T: 'static\`). Instead the bridge builds a per-frame Lua **table** whose methods are \`scope.create_function\`-wrapped closures over a \`RefCell<&mut MapApi>\`. The table mimics a userdata (same \`map:method(...)\` syntax) but lives only for the length of the \`Lua::scope\` call.

## What's in this PR

- \`src/lua/map_api.rs\` — \`make_map_table\` + \`point\` closure body
- \`src/lua/component.rs\` — \`dispatch_paint\` + \`Component::paint_on_map\` wiring; runtime errors logged + recovered
- \`src/lua/scripts/hello.lua\` — plots Tokyo / Berlin (accent) and NYC (accent_alt). Inline doc covers \`paint_on_map\` for future plugin authors.
- 3 new tests: missing handler is no-op, runtime error recovered, \`point()\` writes a glyph into the buffer

## What's not in this PR

- \`poll\` (Lua async / fetch) — next slice
- \`Window:emit\` typed \`host.jump(lat, lon)\` shorthand (selection → jump flows)
- More \`MapApi\` methods (\`line\`, \`label\`, \`text_anchored\`) — add when a Lua plugin actually wants them
- Per audit §8

## Test plan
- [x] \`cargo test\` — 336 passed (333 + 3 new)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\`
- [ ] Manual: \`[lua] enabled = true\`, toggle hello panel, see markers at Tokyo / Berlin / NYC