### PR TITLE
feat(lua): poll dispatch + host:fetch_url(url) — Lua async work

### DIFF
--- a/src/lua/component.rs
+++ b/src/lua/component.rs
@@ -13,8 +13,8 @@
 //! Bridge surface so far: `name`, `render` (text lines wrapped in a
 //! framed Paragraph), `handle_event` (Lua-side keymap → close /
 //! ignore / silent consume), `paint_on_map` (Lua draws map markers
-//! via [`MapApi`]). `poll` and the wider widget / map vocabulary
-//! land in follow-ups.
+//! via [`MapApi`]), `poll` (Lua-side tick + `host:fetch_url(url)`).
+//! Wider widget / map vocabulary lands in follow-ups.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mlua::{Lua, RegistryKey, Table};
@@ -46,6 +46,15 @@ impl LuaComponent {
     /// file name (or any identifier) so backtraces are readable.
     pub fn from_source(source: &str, chunk_name: &str) -> mlua::Result<Self> {
         let lua = super::new_lua();
+
+        // Persistent host services (HTTP fetch etc.) are exposed as
+        // a global so plugins can reach them from any callback. Set
+        // *before* loading the source so a top-level `host:foo()`
+        // call in the chunk would see it (none today, but cheap).
+        let host = super::host::LuaHost::new("lua-host");
+        let host_ud = lua.create_userdata(host)?;
+        lua.globals().set("host", host_ud)?;
+
         let module: Table = lua.load(source).set_name(chunk_name).eval()?;
         let raw_name: String = module.get("name").unwrap_or_else(|_| "lua".to_string());
         let name: &'static str = Box::leak(raw_name.into_boxed_str());
@@ -102,6 +111,24 @@ impl LuaComponent {
                 log::warn!("lua[{}]: handle_event() failed: {}", self.name, e);
                 KeyAction::Consume
             }
+        }
+    }
+
+    /// Run the Lua side of `poll`. The plugin's `poll()` function
+    /// gets no arguments today — async work is reached through the
+    /// `host` global (`host:fetch_url(url)` etc.). Missing function
+    /// is a no-op; runtime errors are logged + recovered.
+    fn dispatch_poll(&self) {
+        let result: mlua::Result<()> = (|| {
+            let module: Table = self.lua.registry_value(&self.module)?;
+            let poll: Option<mlua::Function> = module.get("poll").ok();
+            let Some(poll) = poll else {
+                return Ok(());
+            };
+            poll.call(())
+        })();
+        if let Err(e) = result {
+            log::warn!("lua[{}]: poll() failed: {}", self.name, e);
         }
     }
 
@@ -219,6 +246,10 @@ impl Component for LuaComponent {
 
     fn paint_on_map(&self, p: &mut MapApi<'_>) {
         self.dispatch_paint(p);
+    }
+
+    fn poll(&mut self, _win: &mut Window) {
+        self.dispatch_poll();
     }
 
     fn render(&self, win: &mut RenderWindow) {
@@ -472,6 +503,95 @@ mod tests {
         let mut api = MapApi::new(&mut buf, area, &frame, &theme, None);
         // No panic; warning is logged.
         c.dispatch_paint(&mut api);
+    }
+
+    // ── poll ────────────────────────────────────────────────────
+
+    #[test]
+    fn poll_missing_handler_is_no_op() {
+        let c = LuaComponent::from_source(r#"return { name = "static" }"#, "static").expect("load");
+        // Should not panic, no warning meaningful enough to assert.
+        c.dispatch_poll();
+    }
+
+    #[test]
+    fn poll_runs_lua_handler_each_call() {
+        // Counter side-effect: each dispatch_poll bumps it. Using a
+        // module field rather than a global so we can read it back
+        // through the registry-held module table.
+        let c = LuaComponent::from_source(
+            r#"return {
+                name = "ticker",
+                ticks = 0,
+                poll = function()
+                    -- Re-read the module table from the closure's
+                    -- captured upvalue path; simplest is to bump a
+                    -- global counter we can inspect from Rust.
+                    _G.lua_test_ticks = (_G.lua_test_ticks or 0) + 1
+                end,
+            }"#,
+            "ticker",
+        )
+        .expect("load");
+        c.dispatch_poll();
+        c.dispatch_poll();
+        c.dispatch_poll();
+        let n: i64 = c
+            .lua
+            .globals()
+            .get("lua_test_ticks")
+            .expect("global set by lua");
+        assert_eq!(n, 3);
+    }
+
+    #[test]
+    fn poll_runtime_error_is_recovered() {
+        let c = LuaComponent::from_source(
+            r#"return {
+                name = "broken",
+                poll = function() error("kaboom") end,
+            }"#,
+            "broken",
+        )
+        .expect("load");
+        // Should not panic.
+        c.dispatch_poll();
+    }
+
+    #[test]
+    fn host_global_is_set_for_plugins() {
+        // A poll handler that errors out only if `host` is missing —
+        // proves the global is wired and reachable from Lua.
+        let c = LuaComponent::from_source(
+            r#"return {
+                name = "checker",
+                poll = function()
+                    assert(host ~= nil, "host must be set")
+                    assert(type(host.fetch_url) == "function", "host:fetch_url must exist")
+                end,
+            }"#,
+            "checker",
+        )
+        .expect("load");
+        // If the assertions fail, dispatch_poll would log a warning;
+        // the test passes either way (we'd need a stub log capture
+        // to fail loudly). Round-trip via a Lua-side flag instead:
+        let _: () = c
+            .lua
+            .load(
+                r#"
+                _G.checker_ok = false
+                local ok = pcall(function()
+                    assert(host ~= nil)
+                    assert(type(host.fetch_url) == "function")
+                end)
+                _G.checker_ok = ok
+                "#,
+            )
+            .exec()
+            .expect("exec");
+        let ok: bool = c.lua.globals().get("checker_ok").expect("get");
+        assert!(ok, "host global must be present and have fetch_url");
     }
 
     #[test]

--- a/src/lua/host.rs
+++ b/src/lua/host.rs
@@ -1,0 +1,137 @@
+//! Lua-side host services: persistent state a Lua plugin can reach
+//! at any time via the `host` global.
+//!
+//! Today: `host:fetch_url(url) -> Job` — kicks off a background HTTP
+//! GET (UTF-8 text response) and returns a [`LuaJob`] handle. The
+//! plugin polls the job each frame:
+//!
+//! ```lua
+//! local job = host:fetch_url("https://example.com/")
+//! -- ...later, in poll():
+//! local body = job:try_take()
+//! if body then ... end
+//! ```
+//!
+//! Both [`LuaHost`] and [`LuaJob`] are `'static`, so they go through
+//! mlua's regular `UserData` mechanism (no `Lua::scope` gymnastics
+//! like `MapApi`).
+
+use std::sync::mpsc;
+use std::thread;
+
+use mlua::UserData;
+
+use crate::shared::http::HttpClient;
+
+/// Per-component host handle. Holds the `HttpClient` used by
+/// `fetch_url` so Lua plugins don't have to thread a reference
+/// through every call.
+pub struct LuaHost {
+    http: HttpClient,
+}
+
+impl LuaHost {
+    pub fn new(tag: &'static str) -> Self {
+        Self {
+            http: HttpClient::new(tag),
+        }
+    }
+}
+
+impl UserData for LuaHost {
+    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
+        // `host:fetch_url(url)` — spawn a background GET and return a
+        // Job. Body is decoded as UTF-8; non-text or fetch errors
+        // surface as the Job never producing a result (try_take
+        // keeps returning nil).
+        methods.add_method(
+            "fetch_url",
+            |_, this, (_self, url): (mlua::Value, String)| {
+                // The first arg is the receiver (`host` itself) from
+                // Lua's colon syntax `host:fetch_url(url)` — discard.
+                let _ = _self;
+                Ok(LuaJob::spawn(&this.http, url))
+            },
+        );
+    }
+}
+
+/// One-shot fetch handle. Stays alive in the Lua state until the
+/// plugin drops its reference (or until the Lua state itself is
+/// dropped, which happens when the LuaComponent is rebuilt).
+pub struct LuaJob {
+    rx: mpsc::Receiver<String>,
+}
+
+impl LuaJob {
+    fn spawn(http: &HttpClient, url: String) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let http = http.clone();
+        thread::spawn(move || {
+            // Errors are silent for now: a Lua plugin that needs
+            // error visibility can poll a deadline of its own. We
+            // log so offline debugging has a hook.
+            match http.get_bytes(&url) {
+                Ok(bytes) => match String::from_utf8(bytes) {
+                    Ok(body) => {
+                        let _ = tx.send(body);
+                    }
+                    Err(e) => log::warn!("lua-host: fetch_url {}: not utf-8: {}", url, e),
+                },
+                Err(e) => log::warn!("lua-host: fetch_url {}: {}", url, e),
+            }
+        });
+        Self { rx }
+    }
+}
+
+impl UserData for LuaJob {
+    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
+        // `job:try_take() -> string | nil` — non-blocking. Returns
+        // the body once it arrives, or nil while the fetch is
+        // still in flight (or has failed).
+        methods.add_method_mut("try_take", |_, this, _: mlua::Variadic<mlua::Value>| {
+            Ok(this.rx.try_recv().ok())
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_userdata_can_be_constructed() {
+        let lua = mlua::Lua::new();
+        let host = LuaHost::new("lua-test");
+        let ud = lua.create_userdata(host).expect("create_userdata");
+        // Just confirm we can set it as a global and round-trip the
+        // userdata reference back out — fetch_url itself hits the
+        // network and isn't safe to call in a unit test.
+        lua.globals().set("host", ud).expect("set global");
+        let _: mlua::AnyUserData = lua.globals().get("host").expect("get global");
+    }
+
+    #[test]
+    fn job_try_take_returns_nil_before_send() {
+        // Build a job by hand (skip the HTTP path) so we can
+        // assert try_take's non-blocking behaviour.
+        let (tx, rx) = mpsc::channel::<String>();
+        let job = LuaJob { rx };
+        let lua = mlua::Lua::new();
+        let ud = lua.create_userdata(job).expect("create_userdata");
+        let result: Option<String> = lua
+            .load("return select(1, ...):try_take()")
+            .call(ud.clone())
+            .expect("call");
+        assert!(result.is_none(), "try_take should be nil before send");
+
+        // Send a value and the next try_take returns it.
+        tx.send("hi".to_string()).unwrap();
+        let result: Option<String> = lua
+            .load("return select(1, ...):try_take()")
+            .call(ud)
+            .expect("call");
+        assert_eq!(result.as_deref(), Some("hi"));
+    }
+}

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -14,6 +14,7 @@
 //!   `log::warn!` + recovery default.
 
 pub mod component;
+pub mod host;
 pub mod map_api;
 
 pub use component::LuaComponent;

--- a/src/lua/scripts/hello.lua
+++ b/src/lua/scripts/hello.lua
@@ -35,7 +35,12 @@
 -- Bridge surface today is text + keys + map markers; async fetch
 -- and richer widgets land in follow-ups (see docs/lua-bridge-surface.md).
 
-local state = { ticks = 0 }
+-- Throttled to one bump per wall-clock second: poll() runs at the
+-- main loop's tick rate (~250 Hz today), and mutating the render
+-- output every tick would force terminal redraws at that rate. Real
+-- plugins update only on meaningful events (fetch arrival, user
+-- input, etc.) — see `os.time()` resolution as a stand-in.
+local state = { ticks = 0, last_second = 0 }
 
 return {
     name = "hello",
@@ -54,7 +59,11 @@ return {
     end,
 
     poll = function()
-        state.ticks = state.ticks + 1
+        local now = os.time()
+        if now ~= state.last_second then
+            state.last_second = now
+            state.ticks = state.ticks + 1
+        end
     end,
 
     handle_event = function(key)

--- a/src/lua/scripts/hello.lua
+++ b/src/lua/scripts/hello.lua
@@ -4,6 +4,13 @@
 -- `render()` is called every frame; return a list of strings and the
 -- host wraps them in a framed Paragraph titled with `name`.
 --
+-- `poll()` is optional. The host calls it every tick (regardless of
+-- focus). Use it to advance counters, drain async fetches, etc.
+-- Persistent host services hang off the `host` global:
+--
+--   host:fetch_url(url) -> Job   -- spawns a background HTTP GET
+--   job:try_take()      -> string | nil  -- non-blocking
+--
 -- `handle_event(key)` is optional. The host calls it for every key
 -- press while this component owns focus. The `key` table looks like:
 --
@@ -28,6 +35,8 @@
 -- Bridge surface today is text + keys + map markers; async fetch
 -- and richer widgets land in follow-ups (see docs/lua-bridge-surface.md).
 
+local state = { ticks = 0 }
+
 return {
     name = "hello",
 
@@ -38,8 +47,14 @@ return {
             "This panel is rendered by",
             "src/lua/scripts/hello.lua",
             "",
+            "ticks: " .. tostring(state.ticks),
+            "",
             "Press Esc or q to close.",
         }
+    end,
+
+    poll = function()
+        state.ticks = state.ticks + 1
     end,
 
     handle_event = function(key)


### PR DESCRIPTION
## Summary

Sixth slice of the Lua bridge (after #135 / #136 / #137 / #138 / #139). Lua plugins can now run async work:

- Optional \`poll()\` callback — host calls every tick, regardless of focus.
- Persistent \`host\` global with \`host:fetch_url(url) -> Job\`. The Job has \`job:try_take() -> string | nil\` for non-blocking result drain.

This is the missing piece for porting a real fetch+render plugin to Lua.

## Typical usage

\`\`\`lua
local job = nil
local data = nil

function module.poll()
    if not job and not data then
        job = host:fetch_url("https://api.example.com/data")
    end
    if job then
        local body = job:try_take()
        if body then data = body; job = nil end
    end
end
\`\`\`

## Design

- \`LuaHost\` (host.rs) is \`'static\` — holds an \`HttpClient\` and is set as the \`host\` global at \`LuaComponent\` construction. Plain mlua \`UserData\` impl, no \`Lua::scope\` gymnastics needed (unlike \`MapApi\`).
- \`LuaJob\` wraps \`mpsc::Receiver<String>\`. \`fetch_url\` spawns a thread that GETs the URL, decodes UTF-8, and sends the body. \`try_take\` is \`recv.try_recv().ok()\`.
- Errors (network, HTTP status, non-UTF8 body) silently never produce a result — \`try_take\` keeps returning nil. A \`log::warn!\` lands in the file log for offline debugging. Matches the audit's "errors are logged, not propagated" rule.

## What's in this PR

- \`src/lua/host.rs\` — \`LuaHost\` + \`LuaJob\` + 2 unit tests
- \`src/lua/component.rs\` — host global wiring in \`from_source\`, \`dispatch_poll\`, \`Component::poll\` impl, 4 unit tests
- \`src/lua/scripts/hello.lua\` — adds a tick counter to the panel via \`poll\`. Inline doc covers \`poll\` + \`host:fetch_url\` for future plugin authors

## What's not in this PR

- Typed \`host:jump(lat, lon)\` shorthand for \`Window::emit(AppMsg::Jump)\` — needed for selection → jump flows
- Wider widget surface (Span styling, Table)
- Aircraft port (depends on \`host:jump\` + maybe more \`MapApi\`)
- Per audit §8

## Test plan
- [x] \`cargo test\` — 342 passed (336 + 6 new)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\`
- [ ] Manual: \`[lua] enabled = true\`; toggle hello panel; the "ticks: N" line increments visibly