### PR TITLE
perf(app): raise event::poll timeout 4 ms → 16 ms (idle CPU)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -164,7 +164,16 @@ impl App {
                 )
             })?;
 
-            let mut poll_timeout = Duration::from_millis(4);
+            // Idle wake rate. crossterm's `event::poll` blocks
+            // until an input event arrives or this elapses, so the
+            // real cost is bounded latency for things that aren't
+            // event-driven: a freshly produced render frame (we
+            // drain those non-blockingly at the top of the loop)
+            // and any plugin whose `poll()` touches render output
+            // (e.g. a counter). 16 ms = 60 Hz, indistinguishable
+            // from instant for human perception, an order of
+            // magnitude less idle CPU than the previous 4 ms.
+            let mut poll_timeout = Duration::from_millis(16);
             while event::poll(poll_timeout)? {
                 poll_timeout = Duration::from_millis(0);
                 match event::read()? {


### PR DESCRIPTION
## Summary

Idle wake rate of the main event loop bumped from ~250 Hz to ~60 Hz.

The loop wakes on either input events (immediate via crossterm's \`event::poll\`) or after this timeout elapses. The timeout is the real cost only when nothing's happening: it bounds latency for things that aren't event-driven (a freshly produced render frame we drain at the top of the loop, and any plugin whose \`poll()\` mutates render output every tick).

## Why now

The Lua plugin tick demo merged in #140 made this visible — \`poll()\` running 250×/sec while mutating the panel forced a terminal redraw at the same rate, pegging a CPU core. The Lua side is now throttled, but the underlying loop rate is aggressive for any plugin that wants to update a counter / timer / progress bar in its panel.

## Trade-off

| | Before | After |
|---|---|---|
| Idle wake rate | 250 Hz | 60 Hz |
| Event response | instant | instant |
| Render-frame display latency (worst case) | 4 ms | 16 ms |

60 Hz is indistinguishable from instant for human perception, and any real input wakes the loop immediately regardless. Render frame latency change (4 → 16 ms) is well below the perceptual threshold for motion.

## Test plan
- [x] \`cargo test\` — 342 passed (no test changes needed; behaviour is timing-only)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\`
- [ ] Manual: pan / zoom / drag still feel instant; tile loads still appear smooth; idle CPU drops noticeably with the Lua hello panel open