### PR TITLE
feat(lua): host:jump(lon, lat) — Lua plugins recentre the map

### DIFF
--- a/src/lua/component.rs
+++ b/src/lua/component.rs
@@ -16,11 +16,15 @@
 //! via [`MapApi`]), `poll` (Lua-side tick + `host:fetch_url(url)`).
 //! Wider widget / map vocabulary lands in follow-ups.
 
+use std::sync::mpsc;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mlua::{Lua, RegistryKey, Table};
 
+use crate::app::AppMsg;
 use crate::compositor::Component;
 use crate::compositor::window::{RenderWindow, Window};
+use crate::geo::LonLat;
 use crate::plugin_api::MapApi;
 use crate::widget::{self, Line, Span, StyleKind};
 
@@ -35,6 +39,12 @@ pub struct LuaComponent {
     /// `&'static str`. Leaked once per component; total cost is a
     /// few dozen bytes for the lifetime of the program.
     name: &'static str,
+    /// Receiver for `host:jump(lon, lat)` requests. The Lua side
+    /// pushes a `LonLat`; we drain after each `poll` /
+    /// `handle_event` and emit `AppMsg::Jump` through the host
+    /// `Window`. Keeps the Lua call site decoupled from when a
+    /// `Window` is actually available.
+    jump_rx: mpsc::Receiver<LonLat>,
 }
 
 #[allow(dead_code)] // mirrors the LuaComponent struct attribute; same reason
@@ -51,7 +61,7 @@ impl LuaComponent {
         // a global so plugins can reach them from any callback. Set
         // *before* loading the source so a top-level `host:foo()`
         // call in the chunk would see it (none today, but cheap).
-        let host = super::host::LuaHost::new("lua-host");
+        let (host, jump_rx) = super::host::LuaHost::new("lua-host");
         let host_ud = lua.create_userdata(host)?;
         lua.globals().set("host", host_ud)?;
 
@@ -59,7 +69,22 @@ impl LuaComponent {
         let raw_name: String = module.get("name").unwrap_or_else(|_| "lua".to_string());
         let name: &'static str = Box::leak(raw_name.into_boxed_str());
         let module = lua.create_registry_value(module)?;
-        Ok(Self { lua, module, name })
+        Ok(Self {
+            lua,
+            module,
+            name,
+            jump_rx,
+        })
+    }
+
+    /// Drain any `host:jump(...)` requests the Lua side queued
+    /// during the most recent callback and emit them as
+    /// `AppMsg::Jump`. Called after `dispatch_event` /
+    /// `dispatch_poll` while we still hold a `Window`.
+    fn drain_jumps(&self, win: &mut Window) {
+        while let Ok(ll) = self.jump_rx.try_recv() {
+            win.emit(AppMsg::Jump(ll));
+        }
     }
 
     /// Pull the `render()` lines from the Lua module. Returns an
@@ -237,7 +262,9 @@ fn key_code_to_lua(code: KeyCode) -> (&'static str, Option<char>) {
 
 impl Component for LuaComponent {
     fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
-        match self.dispatch_event(event) {
+        let action = self.dispatch_event(event);
+        self.drain_jumps(win);
+        match action {
             KeyAction::Close => win.close(),
             KeyAction::Ignore => win.ignore(),
             KeyAction::Consume => {}
@@ -248,8 +275,9 @@ impl Component for LuaComponent {
         self.dispatch_paint(p);
     }
 
-    fn poll(&mut self, _win: &mut Window) {
+    fn poll(&mut self, win: &mut Window) {
         self.dispatch_poll();
+        self.drain_jumps(win);
     }
 
     fn render(&self, win: &mut RenderWindow) {
@@ -556,6 +584,48 @@ mod tests {
         .expect("load");
         // Should not panic.
         c.dispatch_poll();
+    }
+
+    #[test]
+    fn host_jump_drains_into_window_emit() {
+        // A handler that requests a jump but doesn't return any
+        // host action — the jump should still surface as an
+        // AppMsg::Jump on the next drain.
+        let mut c = LuaComponent::from_source(
+            r#"return {
+                name = "jumper",
+                handle_event = function(key)
+                    host:jump(139.7595, 35.6828)
+                    return nil
+                end,
+            }"#,
+            "jumper",
+        )
+        .expect("load");
+
+        use crate::compositor::Context;
+        use crate::compositor::window::WindowOps;
+        const CTX: Context = Context {
+            center: LonLat { lon: 0.0, lat: 0.0 },
+            theme_id: crate::theme::ThemeId::Dark,
+            cursor: None,
+        };
+        let mut ops = WindowOps::default();
+        {
+            let mut win = Window::new(&mut ops, &CTX);
+            c.handle_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &mut win);
+        }
+        let jumps: Vec<&LonLat> = ops
+            .msgs
+            .iter()
+            .filter_map(|m| match m {
+                AppMsg::Jump(ll) => Some(ll),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(jumps.len(), 1);
+        assert!((jumps[0].lon - 139.7595).abs() < 1e-9);
+        assert!((jumps[0].lat - 35.6828).abs() < 1e-9);
     }
 
     #[test]

--- a/src/lua/host.rs
+++ b/src/lua/host.rs
@@ -1,16 +1,15 @@
 //! Lua-side host services: persistent state a Lua plugin can reach
 //! at any time via the `host` global.
 //!
-//! Today: `host:fetch_url(url) -> Job` — kicks off a background HTTP
-//! GET (UTF-8 text response) and returns a [`LuaJob`] handle. The
-//! plugin polls the job each frame:
-//!
-//! ```lua
-//! local job = host:fetch_url("https://example.com/")
-//! -- ...later, in poll():
-//! local body = job:try_take()
-//! if body then ... end
-//! ```
+//! Today:
+//! - `host:fetch_url(url) -> Job` — kicks off a background HTTP GET
+//!   (UTF-8 text). The plugin polls the [`LuaJob`] each frame.
+//! - `host:jump(lon, lat)` — fire-and-forget request to recentre
+//!   the map on the given coordinate. The Lua side just enqueues a
+//!   `LonLat`; [`LuaComponent`] drains the channel after each
+//!   `poll` / `handle_event` dispatch and emits `AppMsg::Jump`
+//!   through the host `Window`. This keeps the Lua call site
+//!   independent of when a `Window` is actually available.
 //!
 //! Both [`LuaHost`] and [`LuaJob`] are `'static`, so they go through
 //! mlua's regular `UserData` mechanism (no `Lua::scope` gymnastics
@@ -21,20 +20,31 @@ use std::thread;
 
 use mlua::UserData;
 
+use crate::geo::LonLat;
 use crate::shared::http::HttpClient;
 
-/// Per-component host handle. Holds the `HttpClient` used by
-/// `fetch_url` so Lua plugins don't have to thread a reference
-/// through every call.
+/// Per-component host handle. Owns the `HttpClient` used by
+/// `fetch_url` and a sender for jump requests. The matching
+/// `Receiver` lives on the `LuaComponent` so it can drain pending
+/// jumps after a callback returns.
 pub struct LuaHost {
     http: HttpClient,
+    jump_tx: mpsc::Sender<LonLat>,
 }
 
 impl LuaHost {
-    pub fn new(tag: &'static str) -> Self {
-        Self {
-            http: HttpClient::new(tag),
-        }
+    /// Build a fresh host + the matching jump-channel receiver.
+    /// The receiver belongs on the [`LuaComponent`] that owns this
+    /// `LuaHost`'s Lua state.
+    pub fn new(tag: &'static str) -> (Self, mpsc::Receiver<LonLat>) {
+        let (jump_tx, jump_rx) = mpsc::channel();
+        (
+            Self {
+                http: HttpClient::new(tag),
+                jump_tx,
+            },
+            jump_rx,
+        )
     }
 }
 
@@ -44,15 +54,23 @@ impl UserData for LuaHost {
         // Job. Body is decoded as UTF-8; non-text or fetch errors
         // surface as the Job never producing a result (try_take
         // keeps returning nil).
-        methods.add_method(
-            "fetch_url",
-            |_, this, (_self, url): (mlua::Value, String)| {
-                // The first arg is the receiver (`host` itself) from
-                // Lua's colon syntax `host:fetch_url(url)` — discard.
-                let _ = _self;
-                Ok(LuaJob::spawn(&this.http, url))
-            },
-        );
+        // `add_method` auto-extracts `self` from Lua's colon
+        // syntax, so the closure args are just the actual user
+        // params — `(url)` here.
+        methods.add_method("fetch_url", |_, this, url: String| {
+            Ok(LuaJob::spawn(&this.http, url))
+        });
+
+        // `host:jump(lon, lat)` — request the map recentre on the
+        // given coordinate. The actual `AppMsg::Jump` emit happens
+        // when the matching `LuaComponent` drains the channel after
+        // its current callback returns, so this is fire-and-forget
+        // from the Lua side. Send errors (channel disconnected)
+        // mean the component is being torn down — silently ignore.
+        methods.add_method("jump", |_, this, (lon, lat): (f64, f64)| {
+            let _ = this.jump_tx.send(LonLat { lon, lat });
+            Ok(())
+        });
     }
 }
 
@@ -103,13 +121,30 @@ mod tests {
     #[test]
     fn host_userdata_can_be_constructed() {
         let lua = mlua::Lua::new();
-        let host = LuaHost::new("lua-test");
+        let (host, _jump_rx) = LuaHost::new("lua-test");
         let ud = lua.create_userdata(host).expect("create_userdata");
         // Just confirm we can set it as a global and round-trip the
         // userdata reference back out — fetch_url itself hits the
         // network and isn't safe to call in a unit test.
         lua.globals().set("host", ud).expect("set global");
         let _: mlua::AnyUserData = lua.globals().get("host").expect("get global");
+    }
+
+    #[test]
+    fn host_jump_pushes_to_channel() {
+        let lua = mlua::Lua::new();
+        let (host, jump_rx) = LuaHost::new("lua-test");
+        let ud = lua.create_userdata(host).expect("create_userdata");
+        lua.globals().set("host", ud).expect("set global");
+
+        // Lua-side call: longitude first, then latitude.
+        lua.load("host:jump(139.7595, 35.6828)")
+            .exec()
+            .expect("exec");
+
+        let ll = jump_rx.try_recv().expect("jump must be queued");
+        assert!((ll.lon - 139.7595).abs() < 1e-9);
+        assert!((ll.lat - 35.6828).abs() < 1e-9);
     }
 
     #[test]

--- a/src/lua/scripts/hello.lua
+++ b/src/lua/scripts/hello.lua
@@ -10,6 +10,7 @@
 --
 --   host:fetch_url(url) -> Job   -- spawns a background HTTP GET
 --   job:try_take()      -> string | nil  -- non-blocking
+--   host:jump(lon, lat)            -- recentre the map (fire-and-forget)
 --
 -- `handle_event(key)` is optional. The host calls it for every key
 -- press while this component owns focus. The `key` table looks like:
@@ -72,6 +73,11 @@ return {
         end
         if key.code == "Char" and key.char == "q" then
             return { close = true }
+        end
+        if key.code == "Enter" then
+            -- Enter jumps to Tokyo so the map demo shows the
+            -- request flowing back through the host.
+            host:jump(139.7595, 35.6828)
         end
         -- Default: consume so the panel feels modal.
         return nil


### PR DESCRIPTION
## Summary

Bridge addition that closes the last gap before a real plugin port (aircraft etc.): Lua plugins can request the map recentre on a coordinate.

\`\`\`lua
host:jump(139.7595, 35.6828)  -- Tokyo
\`\`\`

## Design

\`AppMsg::Jump\` requires a \`Window\` to emit through, but \`Window\` isn't a thing on the Lua side — it's a per-callback Rust handle, not a \`'static\` service. So \`host:jump(lon, lat)\` just enqueues a \`LonLat\` on a channel; \`LuaComponent\` drains the channel after each \`dispatch_event\` / \`dispatch_poll\` and emits \`AppMsg::Jump\` through the live Window. The Lua call site is decoupled from when a Window is actually available.

\`mpsc::Sender\` lives on \`LuaHost\` (the \`host\` global), the matching \`Receiver\` lives on the \`LuaComponent\`. Drains run after both \`handle_event\` and \`poll\` (both have a Window). After \`paint_on_map\` (no Window) jumps would buffer until the next poll/event tick — fine, it's fire-and-forget anyway.

## Drive-by fix

Discovered that mlua's \`add_method\` auto-extracts \`self\` from Lua's colon syntax, so the existing \`(_self, url)\` signature on \`fetch_url\` was wrong — it would have failed if any plugin actually called it (none did). Simplified to just \`(url)\`. \`map_api.rs\` keeps its \`_self\` because it uses \`scope.create_function\`, which does NOT auto-extract self (different callable type, different rule).

## What's in this PR

- \`src/lua/host.rs\` — \`host:jump\` method, channel plumbing on \`LuaHost::new\`, fixed \`fetch_url\` signature, +1 unit test for the channel push
- \`src/lua/component.rs\` — \`jump_rx\` field, \`drain_jumps\` helper called after handle_event / poll, +1 integration test verifying Enter → AppMsg::Jump round-trip
- \`src/lua/scripts/hello.lua\` — Enter jumps to Tokyo, doc

## What's not in this PR

- Aircraft port (depends on selection patterns + maybe more MapApi / widget surface)
- Per audit §8

## Test plan
- [x] \`cargo test\` — 344 passed (342 + 2 new)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\`
- [ ] Manual: \`[lua] enabled = true\`, toggle hello, press Enter, map recentres on Tokyo