### PR TITLE
feat(lua): aircraft port (PoC, opt-in side-by-side with Rust)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Key modules:
 - **`src/geo.rs`**: Web Mercator projection math — lon/lat ↔ tile coordinates, distance calculations.
 - **`src/map/render/label.rs`**: Collision-free label placement buffer.
 - **`src/plugin/`**: Plugins (aircraft, attribution, export, help, here, info, iss, quake, scalebar, search, wiki) — composable UI panels with async work via `poll()`. Built-in chrome (info / scalebar / attribution) is structured as plugins too. Search is the unusual one: instead of being a `Component`, it's a `PaletteProvider` (in `src/plugin/search/mod.rs`) — its `register()` binds `/` to push the palette pre-loaded with the provider.
-- **`src/lua/`**: Lua scripted plugins (mlua + Lua 5.4 vendored). `LuaComponent` (`component.rs`) implements `Component` by dispatching to a Lua module table; `register()` (in `mod.rs`) wires bundled scripts in `scripts/*.lua` into the registrar. **Opt-in only** — `app::build_registrar` calls it solely when `[lua] enabled = true` is set in config, because today's bundled scripts (`hello.lua`) are demos, not features. See `docs/lua-bridge-surface.md` for the bridge surface scope.
+- **`src/lua/`**: Lua scripted plugins (mlua + Lua 5.4 vendored). `LuaComponent` (`component.rs`) implements `Component` by dispatching to a Lua module table. `host` (`host.rs`) is a per-component global exposing `host:fetch_url(url)`, `host:jump(lon, lat)`, `host:parse_json(s)`. `MapApi` is bridged via a per-frame Lua table built inside `Lua::scope` (`map_api.rs`). Bundled scripts in `scripts/*.lua` register through per-script entry points (`register_hello`, `register_aircraft`); each is **opt-in** via its own `[<name>] enabled = true` block in config. See `docs/lua-bridge-surface.md` for the bridge surface scope.
 
 ## Rust Edition
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ src/
 ├── lua/                 Lua scripted plugins (mlua + Lua 5.4, opt-in via `[lua] enabled = true`)
 │   ├── mod.rs           shared VM + register() for bundled scripts
 │   ├── component.rs     LuaComponent — Component impl backed by a Lua module
-│   └── scripts/         bundled .lua sources (hello.lua: demo / template)
+│   └── scripts/         bundled .lua sources (hello.lua, aircraft.lua)
 │
 ├── plugin_api/          plugin-author surface — services + helpers + prelude
 │   ├── mod.rs           re-exports + `prelude` glob

--- a/config.example.toml
+++ b/config.example.toml
@@ -100,9 +100,18 @@
 # enabled = false      # turns off the top-right cursor / centre / zoom readout
 
 # ── Lua scripted plugins (opt-in) ───────────────────────────────────
-# Loads bundled scripts under src/lua/scripts/. Today: a `hello`
-# demo. Off by default because the bundled scripts are demos /
-# templates, not user-facing features. See docs/lua-bridge-surface.md
-# for the bridge surface.
+# Each Lua plugin is gated by its own `[<name>] enabled = true`
+# block. Default off because they're being validated against the
+# Rust counterparts; flip on to dogfood. See
+# docs/lua-bridge-surface.md for the bridge surface.
+
+# `hello` — demo / template for new Lua plugin authors.
 # [lua]
+# enabled = true
+
+# `aircraft` (Lua port) — runs side by side with the Rust
+# `[aircraft]` plugin during the migration. Disable the Rust one
+# (`[aircraft] enabled = false`) when comparing, or both will
+# show up under the same "Toggle aircraft" palette label.
+# [lua_aircraft]
 # enabled = true

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -445,19 +445,25 @@ fn build_registrar(
         crate::plugin::quake::register(config, &mut r);
     }
 
-    // Lua scripted plugins. Opt-in via `[lua] enabled = true` —
-    // unlike the rest of the plugins, default is *false* because
-    // these are demo / dogfood, not user-facing features. The
-    // detection inlines the lookup so we don't perturb
-    // `Config::plugin_enabled`'s default-true semantics.
-    let lua_enabled = config
-        .extras
-        .get("lua")
-        .and_then(|v| v.get("enabled"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    if lua_enabled {
-        crate::lua::register(&mut r);
+    // Lua scripted plugins. Each is opt-in via its own `[<name>]
+    // enabled = true` block — unlike the rest of the plugin set,
+    // default is *false* because these are still being validated
+    // against their Rust counterparts. The detection inlines the
+    // lookup so we don't perturb `Config::plugin_enabled`'s
+    // default-true semantics.
+    let opt_in = |name: &str| -> bool {
+        config
+            .extras
+            .get(name)
+            .and_then(|v| v.get("enabled"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    };
+    if opt_in("lua") {
+        crate::lua::register_hello(&mut r);
+    }
+    if opt_in("lua_aircraft") {
+        crate::lua::register_aircraft(&mut r);
     }
 
     // Help needs to know the other plugins' activation hints, so build

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -33,17 +33,27 @@ pub fn new_lua() -> Lua {
 /// reference template for future Lua plugin authors.
 const HELLO_LUA: &str = include_str!("scripts/hello.lua");
 
-/// Wire the bundled Lua plugins into the registrar. Today that's
-/// just `hello`. New bundled plugins go in `scripts/<name>.lua` and
-/// register here alongside `hello`.
-///
-/// Lua failures (parse error, missing fields) are logged and the
-/// plugin is silently skipped rather than aborting startup — the
-/// host always boots even with a broken Lua plugin.
-pub fn register(r: &mut Registrar) {
+/// Aircraft plugin (Lua port). Opt-in side-by-side with the Rust
+/// version during the migration; once validated the Rust plugin
+/// goes away and this becomes the only aircraft implementation.
+const AIRCRAFT_LUA: &str = include_str!("scripts/aircraft.lua");
+
+/// Wire the `hello` demo plugin. Called from `app::build_registrar`
+/// when `[lua] enabled = true`.
+pub fn register_hello(r: &mut Registrar) {
     register_script("hello", HELLO_LUA, r);
 }
 
+/// Wire the Lua port of the aircraft plugin. Called from
+/// `app::build_registrar` when `[lua_aircraft] enabled = true`.
+pub fn register_aircraft(r: &mut Registrar) {
+    register_script("aircraft", AIRCRAFT_LUA, r);
+}
+
+/// Validate + register one bundled script. Lua failures (parse
+/// error, missing fields) are logged and the plugin is silently
+/// skipped rather than aborting startup — the host always boots
+/// even with a broken Lua plugin.
 fn register_script(name: &'static str, source: &'static str, r: &mut Registrar) {
     // Validate the script up front so a syntax error surfaces as one
     // log line instead of a noisy first-toggle failure.
@@ -110,14 +120,28 @@ mod tests {
     #[test]
     fn register_adds_a_palette_entry_for_hello() {
         let mut r = Registrar::default();
-        register(&mut r);
-        // We don't need to assert the count exactly — just that the
-        // bundled hello plugin produced *some* palette entry. The
-        // label substring guards against silent regressions.
+        register_hello(&mut r);
         let labels: Vec<&str> = r.palette_entries.iter().map(|e| e.label.as_str()).collect();
         assert!(
             labels.iter().any(|l| l.contains("hello")),
             "expected a 'hello' palette entry, got {:?}",
+            labels,
+        );
+    }
+
+    #[test]
+    fn bundled_aircraft_script_parses() {
+        LuaComponent::from_source(AIRCRAFT_LUA, "aircraft").expect("aircraft.lua should parse");
+    }
+
+    #[test]
+    fn register_aircraft_adds_a_palette_entry() {
+        let mut r = Registrar::default();
+        register_aircraft(&mut r);
+        let labels: Vec<&str> = r.palette_entries.iter().map(|e| e.label.as_str()).collect();
+        assert!(
+            labels.iter().any(|l| l.contains("aircraft")),
+            "expected an 'aircraft' palette entry, got {:?}",
             labels,
         );
     }

--- a/src/lua/scripts/aircraft.lua
+++ b/src/lua/scripts/aircraft.lua
@@ -1,0 +1,125 @@
+-- aircraft (Lua port) — live ADS-B markers + side panel.
+--
+-- Proof-of-concept port of `src/plugin/aircraft/` to validate the
+-- Lua bridge end-to-end. Opt-in via [lua_aircraft] enabled = true
+-- so it can run side by side with the Rust plugin during the
+-- transition.
+--
+-- Source: OpenSky Network REST API
+--   https://opensky-network.org/api/states/all
+-- Anonymous; the call costs 4 credits without a bbox. We refresh
+-- once every 12 seconds, same cadence as the Rust plugin.
+--
+-- State-vector indices follow the OpenSky doc:
+--   1 = icao24, 2 = callsign, 6 = lon, 7 = lat,
+--   8 = baro_altitude, 9 = on_ground, 10 = velocity, 11 = true_track
+-- (Lua arrays are 1-indexed; OpenSky's docs are 0-indexed.)
+
+local URL = "https://opensky-network.org/api/states/all"
+local INTERVAL_SEC = 12
+
+local state = {
+    aircraft = {},      -- list of { callsign, lon, lat, on_ground, alt }
+    selected = 1,       -- 1-based index
+    job = nil,          -- pending fetch
+    last_fetch_sec = 0, -- wall-clock second of last fetch start
+}
+
+local function trim(s)
+    return (s or ""):gsub("^%s+", ""):gsub("%s+$", "")
+end
+
+local function parse_states(payload)
+    local out = {}
+    if not payload or not payload.states then return out end
+    for _, s in ipairs(payload.states) do
+        -- s is the state-vector array. Skip rows missing lon/lat
+        -- (fresh tracks before first position lock).
+        local lon, lat = s[6], s[7]
+        if type(lon) == "number" and type(lat) == "number" then
+            table.insert(out, {
+                callsign  = trim(s[2]),
+                lon       = lon,
+                lat       = lat,
+                on_ground = s[9] == true,
+                alt       = s[8],
+            })
+        end
+    end
+    return out
+end
+
+local function fmt_aircraft(a, selected)
+    local prefix = selected and "→ " or "  "
+    local cs     = a.callsign ~= "" and a.callsign or "(no callsign)"
+    local alt    = ""
+    if type(a.alt) == "number" then
+        alt = string.format(" %dm", math.floor(a.alt))
+    end
+    local ground = a.on_ground and " (ground)" or ""
+    return prefix .. cs .. alt .. ground
+end
+
+return {
+    name = "aircraft",
+
+    render = function()
+        if #state.aircraft == 0 then
+            return { "Loading aircraft data...", "(OpenSky takes ~12s)" }
+        end
+        local lines = {}
+        for i, a in ipairs(state.aircraft) do
+            table.insert(lines, fmt_aircraft(a, i == state.selected))
+        end
+        return lines
+    end,
+
+    paint_on_map = function(map)
+        for i, a in ipairs(state.aircraft) do
+            local color = (i == state.selected) and "accent_alt" or "accent"
+            map:point(a.lon, a.lat, "✈", color)
+        end
+    end,
+
+    handle_event = function(key)
+        if key.code == "Esc" then return { close = true } end
+        if key.code == "Char" and key.char == "q" then return { close = true } end
+
+        local n = #state.aircraft
+        if key.code == "Up" or (key.code == "Char" and key.char == "k") then
+            if n > 0 then
+                state.selected = state.selected > 1 and state.selected - 1 or n
+            end
+        elseif key.code == "Down" or (key.code == "Char" and key.char == "j") then
+            if n > 0 then
+                state.selected = state.selected < n and state.selected + 1 or 1
+            end
+        elseif key.code == "Enter" then
+            local a = state.aircraft[state.selected]
+            if a then host:jump(a.lon, a.lat) end
+        end
+        -- Modal feel: consume otherwise.
+        return nil
+    end,
+
+    poll = function()
+        -- Drain any in-flight fetch.
+        if state.job then
+            local body = state.job:try_take()
+            if body then
+                local payload = host:parse_json(body)
+                state.aircraft = parse_states(payload)
+                if state.selected > #state.aircraft then
+                    state.selected = math.max(1, #state.aircraft)
+                end
+                state.job = nil
+            end
+        end
+        -- Schedule the next fetch when the interval has elapsed.
+        local now = os.time()
+        if not state.job and (now - state.last_fetch_sec) >= INTERVAL_SEC then
+            state.last_fetch_sec = now
+            state.job = host:fetch_url(URL)
+        end
+    end,
+}


### PR DESCRIPTION
## Summary

First real plugin migration. \`src/lua/scripts/aircraft.lua\` is a Lua reimplementation of \`src/plugin/aircraft/\` that drives the OpenSky Network REST API entirely through the Lua bridge (\`host:fetch_url\` + \`host:parse_json\` + \`map:point\` + \`host:jump\`).

\`\`\`
poll()         -> host:fetch_url + host:parse_json + parse_states
render()       -> formatted text lines with selection cursor
paint_on_map   -> map:point per aircraft (accent / accent_alt for selected)
handle_event   -> Esc/q close, j/k or arrows nav, Enter jump
\`\`\`

## Opt-in side-by-side

Gated by \`[lua_aircraft] enabled = true\`. Default off because we're running it side by side with the Rust plugin during validation. To compare cleanly:

\`\`\`toml
[aircraft]
enabled = false       # turn off the Rust one

[lua_aircraft]
enabled = true        # turn on the Lua one
\`\`\`

(Otherwise both register a "Toggle aircraft" palette entry and the user can't tell which is active.)

## Bridge plumbing

\`src/lua/mod.rs\` now exposes per-script entry points (\`register_hello\`, \`register_aircraft\`) instead of a single \`register\`. Each is independently config-gated in \`app::build_registrar\` via an inlined \`opt_in(name)\` helper. New bundled scripts add a \`register_xxx\` function and one config gate.

## What's not in this PR

- **LayoutConfig equivalent for Lua plugins** — aircraft.lua's panel fills the full map area today (cosmetic; functional). Adding a \`module.layout = { anchor, width, height }\` field is the next small PR.
- **Drop the Rust aircraft plugin** — separate PR after the Lua port validates in side-by-side use.
- **Bbox-restricted OpenSky calls** — Lua plugin doesn't yet know the map centre; we fetch globally (4 credits / call). \`host:center()\` is a follow-up.

## Test plan
- [x] \`cargo test\` — 351 passed (349 + 2 new for aircraft script parse + register palette entry)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\`
- [ ] Manual: \`[lua_aircraft] enabled = true\`, \`[aircraft] enabled = false\`; toggle aircraft from \`:\` palette; markers + panel populate after ~12s; j/k navigates; Enter jumps; Esc/q closes