### PR TITLE
feat(lua): host:center() + aircraft uses bbox + heading arrows

### DIFF
--- a/src/lua/component.rs
+++ b/src/lua/component.rs
@@ -16,7 +16,7 @@
 //! via [`MapApi`]), `poll` (Lua-side tick + `host:fetch_url(url)`).
 //! Wider widget / map vocabulary lands in follow-ups.
 
-use std::sync::mpsc;
+use std::sync::{Arc, Mutex, mpsc};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mlua::{Lua, RegistryKey, Table};
@@ -101,6 +101,10 @@ pub struct LuaComponent {
     /// `Window`. Keeps the Lua call site decoupled from when a
     /// `Window` is actually available.
     jump_rx: mpsc::Receiver<LonLat>,
+    /// Map centre cell shared with the host so `host:center()` can
+    /// return the latest value. We refresh it at the start of every
+    /// dispatch path that carries a `Window` / `MapApi`.
+    center: Arc<Mutex<LonLat>>,
 }
 
 #[allow(dead_code)] // mirrors the LuaComponent struct attribute; same reason
@@ -117,7 +121,7 @@ impl LuaComponent {
         // a global so plugins can reach them from any callback. Set
         // *before* loading the source so a top-level `host:foo()`
         // call in the chunk would see it (none today, but cheap).
-        let (host, jump_rx) = super::host::LuaHost::new("lua-host");
+        let (host, jump_rx, center) = super::host::LuaHost::new("lua-host");
         let host_ud = lua.create_userdata(host)?;
         lua.globals().set("host", host_ud)?;
 
@@ -132,7 +136,19 @@ impl LuaComponent {
             name,
             layout,
             jump_rx,
+            center,
         })
+    }
+
+    /// Refresh the host-shared map centre. Called at the start of
+    /// every dispatch path that has access to a current centre
+    /// (poll / handle_event via `Window::ctx()`, paint_on_map via
+    /// `MapApi::center()`) so `host:center()` returns up-to-date
+    /// values without each callback having to take it as an arg.
+    fn update_center(&self, center: LonLat) {
+        if let Ok(mut cell) = self.center.lock() {
+            *cell = center;
+        }
     }
 
     /// Drain any `host:jump(...)` requests the Lua side queued
@@ -320,6 +336,7 @@ fn key_code_to_lua(code: KeyCode) -> (&'static str, Option<char>) {
 
 impl Component for LuaComponent {
     fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
+        self.update_center(win.ctx().center);
         let action = self.dispatch_event(event);
         self.drain_jumps(win);
         match action {
@@ -330,10 +347,12 @@ impl Component for LuaComponent {
     }
 
     fn paint_on_map(&self, p: &mut MapApi<'_>) {
+        self.update_center(p.center());
         self.dispatch_paint(p);
     }
 
     fn poll(&mut self, win: &mut Window) {
+        self.update_center(win.ctx().center);
         self.dispatch_poll();
         self.drain_jumps(win);
     }

--- a/src/lua/host.rs
+++ b/src/lua/host.rs
@@ -15,12 +15,16 @@
 //!   become 1-indexed tables, `null` is `nil`. Parse errors return
 //!   `nil` and log a warning, so a flaky upstream doesn't crash a
 //!   plugin.
+//! - `host:center() -> lon, lat` — current map centre. The host
+//!   refreshes the value at the start of every dispatch path that
+//!   carries a `Window` / `MapApi`, so callbacks see the latest
+//!   centre without threading anything through their signatures.
 //!
 //! Both [`LuaHost`] and [`LuaJob`] are `'static`, so they go through
 //! mlua's regular `UserData` mechanism (no `Lua::scope` gymnastics
 //! like `MapApi`).
 
-use std::sync::mpsc;
+use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 
 use mlua::UserData;
@@ -31,24 +35,32 @@ use crate::shared::http::HttpClient;
 /// Per-component host handle. Owns the `HttpClient` used by
 /// `fetch_url` and a sender for jump requests. The matching
 /// `Receiver` lives on the `LuaComponent` so it can drain pending
-/// jumps after a callback returns.
+/// jumps after a callback returns. The `center` is shared with
+/// the component so `host:center()` can return the current map
+/// centre even though the userdata itself never sees a `Window`.
 pub struct LuaHost {
     http: HttpClient,
     jump_tx: mpsc::Sender<LonLat>,
+    center: Arc<Mutex<LonLat>>,
 }
 
 impl LuaHost {
-    /// Build a fresh host + the matching jump-channel receiver.
-    /// The receiver belongs on the [`LuaComponent`] that owns this
-    /// `LuaHost`'s Lua state.
-    pub fn new(tag: &'static str) -> (Self, mpsc::Receiver<LonLat>) {
+    /// Build a fresh host along with the channel ends the
+    /// [`LuaComponent`] needs to drive it: the jump-request
+    /// receiver and the shared centre cell. The component refreshes
+    /// the centre at the start of each dispatch path that carries
+    /// a `Window` / `MapApi`.
+    pub fn new(tag: &'static str) -> (Self, mpsc::Receiver<LonLat>, Arc<Mutex<LonLat>>) {
         let (jump_tx, jump_rx) = mpsc::channel();
+        let center = Arc::new(Mutex::new(LonLat { lon: 0.0, lat: 0.0 }));
         (
             Self {
                 http: HttpClient::new(tag),
                 jump_tx,
+                center: center.clone(),
             },
             jump_rx,
+            center,
         )
     }
 }
@@ -91,6 +103,15 @@ impl UserData for LuaHost {
                 }
             },
         );
+
+        // `host:center() -> lon, lat` — current map centre, kept
+        // fresh by the LuaComponent before each dispatch. Plugins
+        // use this to scope upstream queries (e.g. an OpenSky
+        // bounding box around the user's view).
+        methods.add_method("center", |_, this, _: ()| {
+            let ll = *this.center.lock().expect("center mutex poisoned");
+            Ok((ll.lon, ll.lat))
+        });
     }
 }
 
@@ -180,7 +201,7 @@ mod tests {
     #[test]
     fn host_userdata_can_be_constructed() {
         let lua = mlua::Lua::new();
-        let (host, _jump_rx) = LuaHost::new("lua-test");
+        let (host, _jump_rx, _) = LuaHost::new("lua-test");
         let ud = lua.create_userdata(host).expect("create_userdata");
         // Just confirm we can set it as a global and round-trip the
         // userdata reference back out — fetch_url itself hits the
@@ -192,7 +213,7 @@ mod tests {
     #[test]
     fn host_jump_pushes_to_channel() {
         let lua = mlua::Lua::new();
-        let (host, jump_rx) = LuaHost::new("lua-test");
+        let (host, jump_rx, _) = LuaHost::new("lua-test");
         let ud = lua.create_userdata(host).expect("create_userdata");
         lua.globals().set("host", ud).expect("set global");
 
@@ -209,7 +230,7 @@ mod tests {
     #[test]
     fn parse_json_round_trips_primitives() {
         let lua = mlua::Lua::new();
-        let (host, _) = LuaHost::new("lua-test");
+        let (host, _, _) = LuaHost::new("lua-test");
         lua.globals()
             .set("host", lua.create_userdata(host).unwrap())
             .unwrap();
@@ -233,7 +254,7 @@ mod tests {
     #[test]
     fn parse_json_object_becomes_string_keyed_table() {
         let lua = mlua::Lua::new();
-        let (host, _) = LuaHost::new("lua-test");
+        let (host, _, _) = LuaHost::new("lua-test");
         lua.globals()
             .set("host", lua.create_userdata(host).unwrap())
             .unwrap();
@@ -253,7 +274,7 @@ mod tests {
     #[test]
     fn parse_json_array_is_one_indexed_in_lua() {
         let lua = mlua::Lua::new();
-        let (host, _) = LuaHost::new("lua-test");
+        let (host, _, _) = LuaHost::new("lua-test");
         lua.globals()
             .set("host", lua.create_userdata(host).unwrap())
             .unwrap();
@@ -275,7 +296,7 @@ mod tests {
     #[test]
     fn parse_json_invalid_returns_nil() {
         let lua = mlua::Lua::new();
-        let (host, _) = LuaHost::new("lua-test");
+        let (host, _, _) = LuaHost::new("lua-test");
         lua.globals()
             .set("host", lua.create_userdata(host).unwrap())
             .unwrap();
@@ -289,7 +310,7 @@ mod tests {
     #[test]
     fn parse_json_null_is_nil() {
         let lua = mlua::Lua::new();
-        let (host, _) = LuaHost::new("lua-test");
+        let (host, _, _) = LuaHost::new("lua-test");
         lua.globals()
             .set("host", lua.create_userdata(host).unwrap())
             .unwrap();

--- a/src/lua/scripts/aircraft.lua
+++ b/src/lua/scripts/aircraft.lua
@@ -1,40 +1,71 @@
 -- aircraft (Lua port) — live ADS-B markers + side panel.
 --
--- Proof-of-concept port of `src/plugin/aircraft/` to validate the
--- Lua bridge end-to-end. Opt-in via [lua_aircraft] enabled = true
--- so it can run side by side with the Rust plugin during the
--- transition.
---
 -- Source: OpenSky Network REST API
 --   https://opensky-network.org/api/states/all
--- Anonymous; the call costs 4 credits without a bbox. We refresh
--- once every 12 seconds, same cadence as the Rust plugin.
+-- Anonymous credit cost: 1 per call when a bbox is supplied (this
+-- file always supplies one — the user's view ± `BBOX_HALF_DEG`),
+-- 4 without. Refresh cadence matches the original Rust plugin
+-- (~12 s) so OpenSky's per-IP daily budget lasts.
 --
 -- State-vector indices follow the OpenSky doc:
 --   1 = icao24, 2 = callsign, 6 = lon, 7 = lat,
 --   8 = baro_altitude, 9 = on_ground, 10 = velocity, 11 = true_track
 -- (Lua arrays are 1-indexed; OpenSky's docs are 0-indexed.)
 
-local URL = "https://opensky-network.org/api/states/all"
-local INTERVAL_SEC = 12
+local BASE_URL       = "https://opensky-network.org/api/states/all"
+local INTERVAL_SEC   = 12
+local BBOX_HALF_DEG  = 5.0   -- half-side of the bbox sent per fetch
 
 local state = {
-    aircraft = {},      -- list of { callsign, lon, lat, on_ground, alt }
-    selected = 1,       -- 1-based index
-    job = nil,          -- pending fetch
-    last_fetch_sec = 0, -- wall-clock second of last fetch start
+    aircraft       = {},  -- list of { callsign, lon, lat, on_ground, alt, heading }
+    selected       = 1,   -- 1-based index
+    job            = nil, -- pending fetch
+    last_fetch_sec = 0,   -- wall-clock second of last fetch start
 }
 
 local function trim(s)
     return (s or ""):gsub("^%s+", ""):gsub("%s+$", "")
 end
 
+local function clamp(v, lo, hi)
+    if v < lo then return lo end
+    if v > hi then return hi end
+    return v
+end
+
+-- bbox URL around (lon, lat). Latitude clamps to [-90, 90],
+-- longitude to [-180, 180]; OpenSky doesn't accept antimeridian-
+-- wrapping bboxes so this just stops at the edge.
+local function bbox_url(lon, lat)
+    local lamin = clamp(lat - BBOX_HALF_DEG, -90.0, 90.0)
+    local lamax = clamp(lat + BBOX_HALF_DEG, -90.0, 90.0)
+    local lomin = clamp(lon - BBOX_HALF_DEG, -180.0, 180.0)
+    local lomax = clamp(lon + BBOX_HALF_DEG, -180.0, 180.0)
+    return string.format(
+        "%s?lamin=%f&lomin=%f&lamax=%f&lomax=%f",
+        BASE_URL, lamin, lomin, lamax, lomax
+    )
+end
+
+-- Map a true-track in degrees (0 = north, clockwise) to one of
+-- eight unicode arrows. Each arrow covers a 45° sector centred on
+-- its cardinal/intercardinal direction; e.g. north spans
+-- [337.5°, 22.5°). Mirrors the helper that lived in the Rust
+-- plugin before the takeover.
+local ARROWS = { "↑", "↗", "→", "↘", "↓", "↙", "←", "↖" }
+local function heading_arrow(deg)
+    local n = deg % 360
+    if n < 0 then n = n + 360 end
+    local sector = math.floor((n + 22.5) / 45) % 8
+    return ARROWS[sector + 1]
+end
+
 local function parse_states(payload)
     local out = {}
     if not payload or not payload.states then return out end
     for _, s in ipairs(payload.states) do
-        -- s is the state-vector array. Skip rows missing lon/lat
-        -- (fresh tracks before first position lock).
+        -- Skip rows missing lon/lat (fresh tracks before first
+        -- position lock).
         local lon, lat = s[6], s[7]
         if type(lon) == "number" and type(lat) == "number" then
             table.insert(out, {
@@ -43,6 +74,7 @@ local function parse_states(payload)
                 lat       = lat,
                 on_ground = s[9] == true,
                 alt       = s[8],
+                heading   = s[11],
             })
         end
     end
@@ -58,6 +90,12 @@ local function fmt_aircraft(a, selected)
     end
     local ground = a.on_ground and " (ground)" or ""
     return prefix .. cs .. alt .. ground
+end
+
+local function marker_for(a)
+    if a.on_ground then return "◇" end
+    if type(a.heading) == "number" then return heading_arrow(a.heading) end
+    return "◆"
 end
 
 return {
@@ -81,7 +119,7 @@ return {
     paint_on_map = function(map)
         for i, a in ipairs(state.aircraft) do
             local color = (i == state.selected) and "accent_alt" or "accent"
-            map:point(a.lon, a.lat, "✈", color)
+            map:point(a.lon, a.lat, marker_for(a), color)
         end
     end,
 
@@ -123,7 +161,8 @@ return {
         local now = os.time()
         if not state.job and (now - state.last_fetch_sec) >= INTERVAL_SEC then
             state.last_fetch_sec = now
-            state.job = host:fetch_url(URL)
+            local lon, lat = host:center()
+            state.job = host:fetch_url(bbox_url(lon, lat))
         end
     end,
 }


### PR DESCRIPTION
## Summary

Two pieces of feedback land together:

1. **Aircraft was fetching globally.** The OpenSky URL had no bbox, so the plugin downloaded the entire world's state vector every 12 s — a couple of thousand aircraft, of which none are visible past zoom-out. Restored the ±5° box around the map centre that the original Rust impl used. Anonymous credit cost drops from 4 to 1 per call as a side effect (OpenSky's documented pricing).

2. **Marker glyph is now heading-aware.** The Rust plugin used eight unicode arrows derived from \`true_track\`; the Lua port shipped with a static ✈. Ported the \`heading_arrow\` helper into Lua. On-ground aircraft render as \`◇\`, in-flight without a reported heading as \`◆\`, otherwise the matching \`↑↗→↘↓↙←↖\`.

## host:center()

Aircraft needs the current map centre to compute the bbox URL, which the Lua side didn't have access to. Add a fourth host method:

\`\`\`lua
local lon, lat = host:center()  -- current map centre
\`\`\`

Implementation: \`LuaHost\` holds an \`Arc<Mutex<LonLat>>\` shared with \`LuaComponent\`. The component refreshes the cell at the start of every dispatch path that carries a \`Window\` / \`MapApi\` (\`handle_event\`, \`poll\`, \`paint_on_map\`). Lua callbacks read the latest value without threading anything new through their signatures.

## What's not in this PR

- bbox-half-deg as a config knob. \`aircraft.lua\` hardcodes 5° because the \"plugin source is the config\" rule applies to bundled scripts too — restoring the \`[aircraft] fetch_half_deg\` Rust knob would mean adding a host-side TOML reader, and the user-facing answer is now \"edit the Lua constant\".

## Test plan
- [x] \`cargo test\` — 350 passed (no test changes; \`host:center\` will pick up coverage when the next plugin actually depends on the value)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean on changed paths
- [x] \`cargo fmt --check\`
- [ ] Manual: aircraft toggle now centres the OpenSky bbox on whatever the map is showing; arrows point the way each aircraft is heading