### PR TITLE
Lua bridge cleanup: dead code, footer plugin hints, url_encode, label prefix

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,11 +7,9 @@
 //! Focus/modal state lives on [`Compositor`] — a stack of
 //! [`Component`]s that replaced the old `FocusManager` + `Plugin`
 //! trilogy. Components render map overlays through
-//! `Component::paint_on_map`. Headless async jobs (here plugin's
-//! geoip) live in a [`Task`] list. Neither channel carries a
-//! concrete plugin type — they contain only `Box<dyn Component>` /
-//! `Box<dyn Task>`, populated by each plugin's `register` function
-//! at composition time.
+//! `Component::paint_on_map`. The compositor never names a concrete
+//! plugin type — it carries only `Box<dyn Component>`s populated by
+//! the Lua dispatcher at composition time.
 
 mod mouse;
 pub mod msg;
@@ -24,7 +22,7 @@ use std::sync::Arc;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use log::{debug, info};
 
-use crate::compositor::{BaseLayer, Compositor, Context, Registrar, Task};
+use crate::compositor::{BaseLayer, Compositor, Context, Registrar};
 use crate::config::Config;
 use crate::keymap::KeyMap;
 use crate::map::render::frame::MapFrame;
@@ -45,7 +43,6 @@ pub struct App {
     map_frame: Option<MapFrame>,
     mouse: MouseAdapter,
     compositor: Compositor,
-    tasks: Vec<Box<dyn Task>>,
     theme_id: ThemeId,
     ui_theme: UiTheme,
     /// Latest mouse cursor position in absolute terminal cells.
@@ -125,7 +122,6 @@ impl App {
             map_frame: None,
             mouse: MouseAdapter::default(),
             compositor,
-            tasks: registrar.tasks,
             theme_id,
             ui_theme,
             cursor: None,
@@ -148,16 +144,12 @@ impl App {
                 self.map_frame = Some(frame);
             }
 
-            // Drain per-tick messages: compositor components first,
-            // then tasks. Both borrow &mut self transitively through
-            // dispatch, so collect into a Vec first.
+            // Drain per-tick messages from compositor components.
+            // Borrows &mut self transitively through dispatch, so
+            // collect into a Vec first.
             let ctx = self.context();
             let compositor_msgs = self.compositor.poll(&ctx);
             for msg in compositor_msgs {
-                self.dispatch(msg);
-            }
-            let task_msgs: Vec<AppMsg> = self.tasks.iter_mut().flat_map(|t| t.poll()).collect();
-            for msg in task_msgs {
                 self.dispatch(msg);
             }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -72,7 +72,10 @@ impl App {
         // `_lua_shared` is kept alive on the App so every Lua plugin's
         // host accessor (`host:plugin_palette_entries()` etc.) keeps
         // reading the live snapshot for the program lifetime.
-        let registrar = build_registrar(&config, attribution, &keymap);
+        let BuiltRegistrar {
+            registrar,
+            plugin_hints,
+        } = build_registrar(&config, attribution, &keymap);
         let ui_theme = UiTheme::from_palette(theme_id.palette());
         let styler = Arc::new(Styler::new(theme_id));
         let pipeline = RenderPipeline::new(
@@ -99,20 +102,6 @@ impl App {
         // activation dispatch) at index 0. Every subsequent modal is
         // pushed on top.
         let mut compositor = Compositor::new();
-        // Harvest non-empty palette hints into a `&'static str` pair
-        // list so the BaseLayer's footer can show plugin keybinds
-        // without hardcoding them. Leaking is bounded — at most one
-        // pair per registered plugin per program lifetime.
-        let plugin_hints: Vec<(&'static str, &'static str)> = registrar
-            .palette_entries
-            .iter()
-            .filter(|e| !e.hint.is_empty())
-            .map(|e| {
-                let key: &'static str = Box::leak(e.hint.clone().into_boxed_str());
-                let label: &'static str = Box::leak(plugin_hint_label(&e.label).into_boxed_str());
-                (key, label)
-            })
-            .collect();
         compositor.push(Box::new(BaseLayer::new(
             keymap,
             registrar.activations,
@@ -416,7 +405,20 @@ pub(crate) fn build_tile_cache(
 /// plugin-agnostic. Order matters: the palette is installed last so
 /// its default provider can harvest every other plugin's palette
 /// entries.
-fn build_registrar(config: &Config, attribution: Option<String>, keymap: &KeyMap) -> Registrar {
+/// Tuple-struct carrier so [`App::new`] can keep the plugin hints
+/// alive across the call to [`build_registrar`]. The hints would
+/// otherwise be unreachable, since [`crate::palette::install`]
+/// `mem::take`s `Registrar.palette_entries` before returning.
+struct BuiltRegistrar {
+    registrar: Registrar,
+    plugin_hints: Vec<(&'static str, &'static str)>,
+}
+
+fn build_registrar(
+    config: &Config,
+    attribution: Option<String>,
+    keymap: &KeyMap,
+) -> BuiltRegistrar {
     use std::sync::Arc;
 
     let mut r = Registrar::default();
@@ -456,7 +458,21 @@ fn build_registrar(config: &Config, attribution: Option<String>, keymap: &KeyMap
         .filter(|e| !e.hint.is_empty())
         .map(|e| (e.hint.clone(), e.label.clone()))
         .collect();
-    shared.set_palette_entries(palette_entries);
+    shared.set_palette_entries(palette_entries.clone());
+
+    // Harvest the BaseLayer's footer hints from the same snapshot.
+    // Has to happen *before* `palette::install` because that call
+    // `mem::take`s `r.palette_entries`. Leak each pair once so they
+    // satisfy `Component::footer_hints`'s `&'static str` contract —
+    // bounded by the plugin count.
+    let plugin_hints: Vec<(&'static str, &'static str)> = palette_entries
+        .into_iter()
+        .map(|(hint, label)| {
+            let key: &'static str = Box::leak(hint.into_boxed_str());
+            let label: &'static str = Box::leak(plugin_hint_label(&label).into_boxed_str());
+            (key, label)
+        })
+        .collect();
 
     // Palette is a built-in, not a plugin. `install` drains every
     // palette_entry contributed above and bakes them into the default
@@ -467,7 +483,10 @@ fn build_registrar(config: &Config, attribution: Option<String>, keymap: &KeyMap
     // / LuaPaletteProvider — dropping it here is fine.
     drop(shared);
 
-    r
+    BuiltRegistrar {
+        registrar: r,
+        plugin_hints,
+    }
 }
 
 /// Boil a palette label down to the short form shown in the footer.

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -431,15 +431,6 @@ impl Default for Compositor {
     }
 }
 
-// ── Async tasks (headless plugins) ─────────────────────────────────
-
-/// Headless async job — the shape `here` (geoip lookup → `Jump`)
-/// needs. Polled every tick by `App`; may emit messages when
-/// background work completes. No UI, no focus, no component.
-pub trait Task {
-    fn poll(&mut self) -> Vec<AppMsg>;
-}
-
 // ── Plugin self-registration (App is plugin-agnostic) ──────────────
 
 /// Factory closure producing a fresh [`Component`] when the user
@@ -448,12 +439,6 @@ pub trait Task {
 /// (e.g. palette seeds its "(current)" theme hint from `theme_id`)
 /// can do so without a separate lifecycle hook.
 pub type SpawnComponent = Box<dyn Fn(&Context) -> Box<dyn Component>>;
-
-/// Closure that kicks off a headless action (typically: start an
-/// async `Task` or emit one-shot `AppMsg`s) when a palette entry is
-/// selected. Receives `Context` for the same reason as
-/// [`SpawnComponent`].
-pub type RunAction = Box<dyn Fn(&Context) -> Vec<AppMsg>>;
 
 /// One activation entry — "when this key is pressed while nothing
 /// modal is above the bottom layer, invoke `spawn` and push the
@@ -473,12 +458,6 @@ pub enum PaletteKind {
     /// selection, but closes the existing instance on re-selection.
     /// Used by palette labels of the form "Toggle X".
     Toggle(SpawnComponent),
-    /// Fire-and-forget action — selection dispatches `Vec<AppMsg>`
-    /// without pushing a component. No in-tree caller after the
-    /// plugin migration; kept as an extension point for future
-    /// bridges that emit AppMsg directly from a palette entry.
-    #[allow(dead_code)]
-    Run(RunAction),
 }
 
 /// Palette entry description owned by the registrar.
@@ -488,17 +467,13 @@ pub struct PaletteEntry {
     pub kind: PaletteKind,
 }
 
-/// Collector passed to each plugin's `register` function. Every
-/// channel is optional — headless plugins add only a task + palette
-/// entry; visual plugins add an activation + palette entry; wiki's
-/// map markers live on the component itself (via
-/// [`Component::paint_on_map`]) so they flow through activations,
-/// not a separate registrar field.
+/// Collector passed to each plugin's `register` function. Plugins
+/// add an activation, a palette entry, and / or an overlay; the
+/// compositor stays agnostic of any specific plugin.
 #[derive(Default)]
 pub struct Registrar {
     pub activations: Vec<Activation>,
     pub palette_entries: Vec<PaletteEntry>,
-    pub tasks: Vec<Box<dyn Task>>,
     /// Always-on overlay factories — invoked once at app init and
     /// pushed into [`Compositor::overlays`]. Used for chrome that's
     /// always on screen (info bar, scale bar, attribution).
@@ -511,13 +486,6 @@ impl Registrar {
     }
     pub fn add_palette_entry(&mut self, e: PaletteEntry) {
         self.palette_entries.push(e);
-    }
-    /// Register a background task polled every tick. No in-tree
-    /// caller after the plugin migration; kept as an extension
-    /// point for future Lua bridge work or Rust-only plugins.
-    #[allow(dead_code)]
-    pub fn add_task(&mut self, t: Box<dyn Task>) {
-        self.tasks.push(t);
     }
 
     // ── Convenience builders ───────────────────────────────────────────────
@@ -577,22 +545,6 @@ impl Registrar {
             kind: PaletteKind::Spawn(Box::new(move |ctx| {
                 Box::new(factory(ctx)) as Box<dyn Component>
             })),
-        });
-    }
-
-    /// Add a fire-and-forget palette entry — selecting it returns
-    /// `Vec<AppMsg>` to dispatch, no component pushed. No in-tree
-    /// caller after the plugin migration; kept as an extension
-    /// point for future bridges.
-    #[allow(dead_code)]
-    pub fn add_run<F>(&mut self, label: impl Into<String>, hint: impl Into<String>, action: F)
-    where
-        F: Fn(&Context) -> Vec<AppMsg> + 'static,
-    {
-        self.add_palette_entry(PaletteEntry {
-            label: label.into(),
-            hint: hint.into(),
-            kind: PaletteKind::Run(Box::new(action)),
         });
     }
 

--- a/src/lua/component.rs
+++ b/src/lua/component.rs
@@ -129,21 +129,7 @@ pub struct LuaComponent {
 
 #[allow(dead_code)] // mirrors the LuaComponent struct attribute; same reason
 impl LuaComponent {
-    /// Load `source` as a Lua chunk and capture its returned table as
-    /// the component's module.
-    ///
-    /// `chunk_name` is used in Lua error messages — pass the source
-    /// file name (or any identifier) so backtraces are readable.
-    /// Convenience constructor for tests / standalone Lua use that
-    /// don't need real runtime data. Wraps [`Self::from_source_full`]
-    /// with an empty [`LuaHostShared`]; production callers should use
-    /// `from_source_full` directly.
-    #[cfg(test)]
-    pub fn from_source(source: &str, chunk_name: &str) -> mlua::Result<Self> {
-        Self::from_source_full(source, chunk_name, super::host::LuaHostShared::empty())
-    }
-
-    pub fn from_source_full(
+    pub fn from_source(
         source: &str,
         chunk_name: &str,
         shared: Arc<LuaHostShared>,
@@ -594,7 +580,12 @@ mod tests {
     #[test]
     fn name_falls_back_when_module_omits_it() {
         // Module with no `name` field — adapter substitutes "lua".
-        let c = LuaComponent::from_source("return {}", "anon").expect("load");
+        let c = LuaComponent::from_source(
+            "return {}",
+            "anon",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
         assert_eq!(c.name(), "lua");
     }
 
@@ -603,6 +594,7 @@ mod tests {
         let c = LuaComponent::from_source(
             r#"return { name = "hello", render = function() return {} end }"#,
             "named",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         assert_eq!(c.name(), "hello");
@@ -616,6 +608,7 @@ mod tests {
                 render = function() return { "alpha", "beta", "gamma" } end,
             }"#,
             "demo",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         let lines = c.render_lines();
@@ -633,6 +626,7 @@ mod tests {
                 render = function() error("kaboom") end,
             }"#,
             "broken",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         // Should not panic — error is logged, we get an empty result.
@@ -641,7 +635,12 @@ mod tests {
 
     #[test]
     fn render_lines_recovers_when_field_is_missing() {
-        let c = LuaComponent::from_source(r#"return { name = "noop" }"#, "noop").expect("load");
+        let c = LuaComponent::from_source(
+            r#"return { name = "noop" }"#,
+            "noop",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
         // No `render` key → graceful fallback.
         assert!(c.render_lines().is_empty());
     }
@@ -662,6 +661,7 @@ mod tests {
                 end,
             }"#,
             "styled",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         let lines = c.render_lines();
@@ -677,7 +677,11 @@ mod tests {
 
     #[test]
     fn loading_invalid_lua_returns_error() {
-        let err = LuaComponent::from_source("this is not lua syntax !", "bad");
+        let err = LuaComponent::from_source(
+            "this is not lua syntax !",
+            "bad",
+            super::super::host::LuaHostShared::empty(),
+        );
         assert!(err.is_err());
     }
 
@@ -687,7 +691,12 @@ mod tests {
 
     #[test]
     fn missing_handler_dispatches_to_ignore() {
-        let c = LuaComponent::from_source(r#"return { name = "noop" }"#, "noop").expect("load");
+        let c = LuaComponent::from_source(
+            r#"return { name = "noop" }"#,
+            "noop",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
         assert_eq!(c.dispatch_event(key(KeyCode::Esc)), KeyAction::Ignore);
     }
 
@@ -699,6 +708,7 @@ mod tests {
                 handle_event = function(_) return nil end,
             }"#,
             "modal",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         assert_eq!(
@@ -718,6 +728,7 @@ mod tests {
                 end,
             }"#,
             "esc",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         assert_eq!(c.dispatch_event(key(KeyCode::Esc)), KeyAction::Close);
@@ -735,6 +746,7 @@ mod tests {
                 handle_event = function(_) return { ignore = true } end,
             }"#,
             "passthrough",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         assert_eq!(c.dispatch_event(key(KeyCode::Char('q'))), KeyAction::Ignore);
@@ -757,6 +769,7 @@ mod tests {
                 end,
             }"#,
             "echo",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         // Use the recovery branch as a poor man's assertion: a
@@ -778,6 +791,7 @@ mod tests {
                 handle_event = function(_) error("kaboom") end,
             }"#,
             "broken",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         // Should not panic, should not leak as Ignore (we don't want
@@ -797,6 +811,7 @@ mod tests {
                 handle_event = function(_) return "yolo" end,
             }"#,
             "weird",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         assert_eq!(
@@ -828,7 +843,12 @@ mod tests {
 
     #[test]
     fn paint_on_map_missing_handler_is_no_op() {
-        let c = LuaComponent::from_source(r#"return { name = "blank" }"#, "blank").expect("load");
+        let c = LuaComponent::from_source(
+            r#"return { name = "blank" }"#,
+            "blank",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
         let (mut buf, area, frame, theme) = map_fixture(20, 5);
         let mut api = MapApi::new(&mut buf, area, &frame, &theme, None);
         // Should not panic; nothing is written.
@@ -843,6 +863,7 @@ mod tests {
                 paint_on_map = function(_) error("kaboom") end,
             }"#,
             "boom",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         let (mut buf, area, frame, theme) = map_fixture(20, 5);
@@ -855,7 +876,12 @@ mod tests {
 
     #[test]
     fn poll_missing_handler_is_no_op() {
-        let c = LuaComponent::from_source(r#"return { name = "static" }"#, "static").expect("load");
+        let c = LuaComponent::from_source(
+            r#"return { name = "static" }"#,
+            "static",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
         // Should not panic, no warning meaningful enough to assert.
         c.dispatch_poll();
     }
@@ -877,6 +903,7 @@ mod tests {
                 end,
             }"#,
             "ticker",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         c.dispatch_poll();
@@ -898,6 +925,7 @@ mod tests {
                 poll = function() error("kaboom") end,
             }"#,
             "broken",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         // Should not panic.
@@ -908,7 +936,12 @@ mod tests {
 
     #[test]
     fn layout_falls_back_when_module_omits_it() {
-        let c = LuaComponent::from_source(r#"return { name = "noop" }"#, "noop").expect("load");
+        let c = LuaComponent::from_source(
+            r#"return { name = "noop" }"#,
+            "noop",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
         // Default fallback: TopLeft, 32x10. Asserting on the
         // resolved sub-rect inside a 100x40 outer is the cleanest
         // proxy for "didn't paint over the map".
@@ -929,6 +962,7 @@ mod tests {
                 layout = { anchor = "right", width = 24, height = 8 },
             }"#,
             "configured",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         assert_eq!(c.layout.anchor, PanelAnchor::Right);
@@ -944,6 +978,7 @@ mod tests {
                 layout = { anchor = "norkeast" },
             }"#,
             "typo",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         // Default fallback anchor is TopLeft (see LuaLayout::fallback).
@@ -964,6 +999,7 @@ mod tests {
                 end,
             }"#,
             "jumper",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
 
@@ -1005,6 +1041,7 @@ mod tests {
                 end,
             }"#,
             "checker",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         // If the assertions fail, dispatch_poll would log a warning;
@@ -1038,6 +1075,7 @@ mod tests {
                 end,
             }"#,
             "marker",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         let (mut buf, area, frame, theme) = map_fixture(20, 5);
@@ -1068,6 +1106,7 @@ mod tests {
                 end,
             }"#,
             "marker",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         let (mut buf, area, frame, theme) = map_fixture(20, 5);

--- a/src/lua/host.rs
+++ b/src/lua/host.rs
@@ -219,6 +219,16 @@ impl UserData for LuaHost {
             Ok(())
         });
 
+        // `host:url_encode(s) -> string` — percent-encode a query
+        // string per RFC 3986: unreserved (A-Za-z0-9-_.~) pass
+        // through, space becomes `+`, everything else `%HH`. Wired
+        // here so plugins constructing URLs (search query, wiki
+        // titles) don't need to reinvent it — the Lua versions that
+        // did mishandled `?` / `#` / non-ASCII titles.
+        methods.add_method("url_encode", |_, _this, s: String| {
+            Ok(crate::shared::http::url::urlencoded(&s))
+        });
+
         // `host:attribution() -> string | nil` — active TileClient's
         // attribution string (typically "© OpenStreetMap …"). The
         // attribution overlay paints this; other plugins may use it
@@ -383,6 +393,27 @@ mod tests {
         let ll = jump_rx.try_recv().expect("jump must be queued");
         assert!((ll.lon - 139.7595).abs() < 1e-9);
         assert!((ll.lat - 35.6828).abs() < 1e-9);
+    }
+
+    #[test]
+    fn url_encode_round_trips_query_chars() {
+        let lua = mlua::Lua::new();
+        let (host, _handles) = LuaHost::new("lua-test", LuaHostShared::empty());
+        lua.globals()
+            .set("host", lua.create_userdata(host).unwrap())
+            .unwrap();
+        // Spaces become `+`, reserved chars become `%HH`, unicode is
+        // percent-encoded byte by byte.
+        let encoded: String = lua
+            .load(r#"return host:url_encode("São Paulo?")"#)
+            .eval()
+            .expect("eval");
+        assert_eq!(encoded, "S%C3%A3o+Paulo%3F");
+        let plain: String = lua
+            .load(r#"return host:url_encode("abc-_.~")"#)
+            .eval()
+            .expect("eval");
+        assert_eq!(plain, "abc-_.~");
     }
 
     #[test]

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -218,7 +218,7 @@ fn register_component(
 ) {
     // Validate up front so a syntax error surfaces as one log line
     // instead of a noisy first-toggle failure.
-    if let Err(e) = LuaComponent::from_source_full(source, name, shared.clone()) {
+    if let Err(e) = LuaComponent::from_source(source, name, shared.clone()) {
         log::warn!("lua[{}]: failed to load, plugin skipped: {}", name, e);
         return;
     }
@@ -269,7 +269,7 @@ fn register_provider(
     shared: Arc<host::LuaHostShared>,
     r: &mut Registrar,
 ) {
-    if let Err(e) = LuaPaletteProvider::from_source_full(source, name, shared.clone()) {
+    if let Err(e) = LuaPaletteProvider::from_source(source, name, shared.clone()) {
         log::warn!("lua[{}]: failed to load, plugin skipped: {}", name, e);
         return;
     }
@@ -280,15 +280,11 @@ fn register_provider(
     let make = {
         let shared = shared.clone();
         move || -> crate::palette::PaletteComponent {
-            let provider = LuaPaletteProvider::from_source_full(source, name, shared.clone())
+            let provider = LuaPaletteProvider::from_source(source, name, shared.clone())
                 .unwrap_or_else(|e| {
                     log::warn!("lua[{}]: re-load failed: {}", name, e);
-                    LuaPaletteProvider::from_source_full(
-                        "return {}",
-                        "lua-fallback",
-                        shared.clone(),
-                    )
-                    .expect("trivial provider always loads")
+                    LuaPaletteProvider::from_source("return {}", "lua-fallback", shared.clone())
+                        .expect("trivial provider always loads")
                 });
             crate::palette::PaletteComponent::with_provider(provider)
         }
@@ -311,9 +307,9 @@ fn component_or_placeholder(
     source: &'static str,
     shared: Arc<host::LuaHostShared>,
 ) -> LuaComponent {
-    LuaComponent::from_source_full(source, name, shared.clone()).unwrap_or_else(|e| {
+    LuaComponent::from_source(source, name, shared.clone()).unwrap_or_else(|e| {
         log::warn!("lua[{}]: re-load failed: {}", name, e);
-        LuaComponent::from_source_full("return {}", name, shared)
+        LuaComponent::from_source("return {}", name, shared)
             .expect("trivial Lua module always loads")
     })
 }
@@ -426,44 +422,41 @@ mod tests {
         Ok(())
     }
 
-    /// All bundled scripts must parse cleanly. Subscript- and
-    /// activation-specific behaviour is covered by the unified
-    /// dispatcher tests below.
+    /// Every bundled script must register cleanly through the same
+    /// dispatcher production uses. Asserts each plugin shows up in
+    /// some registrar slot (overlay / palette / key bind) — the
+    /// dispatcher itself decides which based on `module.activation`,
+    /// so this round-trips the parse + meta + wire path. Set-
+    /// membership rather than counts so adding a builtin doesn't
+    /// require updating magic numbers.
     #[test]
-    fn every_bundled_script_parses() {
-        for (name, source) in BUILTIN_SCRIPTS {
-            // Some scripts (search) are providers, not components —
-            // detect via `kind = "provider"` and dispatch.
-            let kind_is_provider = source.contains(r#"kind = "provider""#);
-            if kind_is_provider {
-                LuaPaletteProvider::from_source(source, name)
-                    .unwrap_or_else(|e| panic!("{}.lua should parse: {}", name, e));
-            } else {
-                LuaComponent::from_source(source, name)
-                    .unwrap_or_else(|e| panic!("{}.lua should parse: {}", name, e));
-            }
-        }
-    }
-
-    /// `register_builtin_plugins` should install every script. The
-    /// exact counts are: 3 overlays (info, scalebar, attribution),
-    /// the rest land as palette entries (some with key binds). A
-    /// regression that drops any single plugin would shift these.
-    #[test]
-    fn register_builtin_plugins_installs_every_bundled_script() {
+    fn every_bundled_script_registers() {
         let shared = host::LuaHostShared::empty();
         let mut r = Registrar::default();
         register_builtin_plugins(shared, &mut r);
 
-        // Exactly 3 always-on overlays today: info, scalebar, attribution.
-        assert_eq!(r.overlays.len(), 3, "overlays count");
+        let palette: std::collections::HashSet<String> = r
+            .palette_entries
+            .iter()
+            .map(|e| e.label.to_lowercase())
+            .collect();
+        // `r.overlays` doesn't carry a name; we sanity-check the
+        // count of always-on overlays separately (info / scalebar /
+        // attribution are the only three today; any builtin
+        // declaring `activation = "overlay"` would trip this).
+        let overlay_count = r.overlays.len();
 
-        // Bundled palette entries: aircraft, iss, quake, wiki, here,
-        // export, help, search → 8.
-        assert_eq!(r.palette_entries.len(), 8, "palette entries count");
-
-        // Key binds: wiki ('i'), help ('?'), search ('/') → 3.
-        assert_eq!(r.activations.len(), 3, "activation key binds count");
+        // Toggles + spawns: each leaves a palette entry whose label
+        // contains the plugin's stem (lowercased).
+        for stem in [
+            "aircraft", "iss", "quake", "wiki", "here", "export", "help", "search",
+        ] {
+            assert!(
+                palette.iter().any(|l| l.contains(stem)),
+                "expected `{stem}` palette entry, got {palette:?}",
+            );
+        }
+        assert_eq!(overlay_count, 3, "info/scalebar/attribution overlays");
     }
 
     /// Module metadata: defaults, overrides, kind/activation flips.

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -106,7 +106,7 @@ struct ModuleMeta {
     /// Plugin flavour. Components push onto the compositor stack;
     /// providers seed the universal palette picker.
     kind: Kind,
-    /// Palette label. Defaults to `"Toggle Lua: <name>"` for toggles,
+    /// Palette label. Defaults to `"Toggle <name>"` for toggles,
     /// `<name>` for spawns. Empty for overlays (no palette entry).
     label: String,
     /// Optional activation key — for `toggle`/`spawn`, also binds
@@ -145,7 +145,7 @@ impl ModuleMeta {
                 return Self {
                     activation: Activation::Toggle,
                     kind: Kind::Component,
-                    label: format!("Toggle Lua: {}", name),
+                    label: format!("Toggle {}", name),
                     key: None,
                     enabled: true,
                 };
@@ -171,7 +171,7 @@ impl ModuleMeta {
             Ok(mlua::Value::Boolean(false))
         );
         let default_label = match activation {
-            Activation::Toggle => format!("Toggle Lua: {}", name),
+            Activation::Toggle => format!("Toggle {}", name),
             Activation::Spawn => name.to_string(),
             Activation::Overlay => String::new(),
         };
@@ -472,7 +472,7 @@ mod tests {
         let meta = ModuleMeta::parse(r#"return { name = "x" }"#, "x");
         assert!(matches!(meta.activation, Activation::Toggle));
         assert!(matches!(meta.kind, Kind::Component));
-        assert_eq!(meta.label, "Toggle Lua: x");
+        assert_eq!(meta.label, "Toggle x");
         assert!(meta.key.is_none());
         assert!(meta.enabled);
     }

--- a/src/lua/palette_provider.rs
+++ b/src/lua/palette_provider.rs
@@ -42,14 +42,7 @@ pub struct LuaPaletteProvider {
 }
 
 impl LuaPaletteProvider {
-    /// Convenience for tests / standalone use. Production callers
-    /// thread the live [`LuaHostShared`] through `from_source_full`.
-    #[cfg(test)]
-    pub fn from_source(source: &'static str, chunk_name: &str) -> mlua::Result<Box<Self>> {
-        Self::from_source_full(source, chunk_name, super::host::LuaHostShared::empty())
-    }
-
-    pub fn from_source_full(
+    pub fn from_source(
         source: &'static str,
         chunk_name: &str,
         shared: Arc<LuaHostShared>,
@@ -257,27 +250,45 @@ mod tests {
 
     #[test]
     fn prompt_falls_back_to_colon_when_module_omits_it() {
-        let p = LuaPaletteProvider::from_source("return {}", "anon").expect("load");
+        let p = LuaPaletteProvider::from_source(
+            "return {}",
+            "anon",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
         assert_eq!(p.prompt(), ":");
     }
 
     #[test]
     fn prompt_picks_up_module_value() {
-        let p =
-            LuaPaletteProvider::from_source(r#"return { prompt = "/" }"#, "named").expect("load");
+        let p = LuaPaletteProvider::from_source(
+            r#"return { prompt = "/" }"#,
+            "named",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
         assert_eq!(p.prompt(), "/");
     }
 
     #[test]
     fn submit_mode_defaults_on_each_key() {
-        let p = LuaPaletteProvider::from_source("return {}", "anon").expect("load");
+        let p = LuaPaletteProvider::from_source(
+            "return {}",
+            "anon",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
         assert!(matches!(p.submit_mode(), SubmitMode::OnEachKey));
     }
 
     #[test]
     fn submit_mode_string_debounced_uses_default_ms() {
-        let p = LuaPaletteProvider::from_source(r#"return { submit_mode = "debounced" }"#, "anon")
-            .expect("load");
+        let p = LuaPaletteProvider::from_source(
+            r#"return { submit_mode = "debounced" }"#,
+            "anon",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
         match p.submit_mode() {
             SubmitMode::Debounced(d) => assert_eq!(d, Duration::from_millis(400)),
             _ => panic!("expected Debounced"),
@@ -289,6 +300,7 @@ mod tests {
         let p = LuaPaletteProvider::from_source(
             r#"return { submit_mode = { kind = "debounced", ms = 250 } }"#,
             "anon",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         match p.submit_mode() {
@@ -314,6 +326,7 @@ mod tests {
             }
             "#,
             "round-trip",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         p.filter("hi");
@@ -334,6 +347,7 @@ mod tests {
             }
             "#,
             "exec-jump",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         match p.execute(0, &ctx()) {
@@ -350,6 +364,7 @@ mod tests {
         let mut p = LuaPaletteProvider::from_source(
             r#"return { execute = function(_) return { close = true } end }"#,
             "exec-close",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         assert!(matches!(p.execute(0, &ctx()), PaletteAction::Close));
@@ -357,7 +372,12 @@ mod tests {
 
     #[test]
     fn is_loading_defaults_false() {
-        let p = LuaPaletteProvider::from_source("return {}", "anon").expect("load");
+        let p = LuaPaletteProvider::from_source(
+            "return {}",
+            "anon",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
         assert!(!p.is_loading());
     }
 
@@ -366,6 +386,7 @@ mod tests {
         let p = LuaPaletteProvider::from_source(
             r#"return { is_loading = function() return true end }"#,
             "loading",
+            super::super::host::LuaHostShared::empty(),
         )
         .expect("load");
         assert!(p.is_loading());

--- a/src/lua/scripts/search.lua
+++ b/src/lua/scripts/search.lua
@@ -20,29 +20,9 @@ local state = {
     candidates = {},  -- list of { name, lon, lat }
 }
 
--- Percent-encode RFC 3986 unreserved characters and pass everything
--- else through. Mirrors the Rust `urlencoded` helper used by the
--- original NominatimClient.
-local function urlencode(s)
-    local out = {}
-    for i = 1, #s do
-        local b = s:byte(i)
-        local ch = string.char(b)
-        if (b >= 0x30 and b <= 0x39)            -- 0-9
-            or (b >= 0x41 and b <= 0x5A)        -- A-Z
-            or (b >= 0x61 and b <= 0x7A)        -- a-z
-            or ch == "-" or ch == "_" or ch == "." or ch == "~" then
-            table.insert(out, ch)
-        else
-            table.insert(out, string.format("%%%02X", b))
-        end
-    end
-    return table.concat(out)
-end
-
 local function search_url(query)
     return string.format("%s?q=%s&format=json&limit=%d",
-        SEARCH_URL, urlencode(query), LIMIT)
+        SEARCH_URL, host:url_encode(query), LIMIT)
 end
 
 local function parse_results(payload)

--- a/src/lua/scripts/wiki.lua
+++ b/src/lua/scripts/wiki.lua
@@ -35,18 +35,19 @@ local function geosearch_url(lat, lon)
 end
 
 local function extracts_url(titles)
-    -- Wikipedia accepts pipe-separated titles. Caller is responsible
-    -- for URL-encoding pipes and ampersands within titles; for our
-    -- limit of ~50 entries the URL fits well under the host's path
-    -- length limits.
-    local joined = table.concat(titles, "|")
-    -- Encode | as %7C and & as %26 — the only two characters in our
-    -- input that would otherwise corrupt the query.
-    joined = joined:gsub("%%", "%%25"):gsub("|", "%%7C"):gsub("&", "%%26")
+    -- Wikipedia accepts pipe-separated titles. Encode each title
+    -- individually (host:url_encode handles spaces / non-ASCII /
+    -- reserved chars) and join with a literal `|`, which the API
+    -- treats as the separator. For our ~50-entry limit the URL
+    -- fits well under the host's path length limits.
+    local encoded = {}
+    for _, t in ipairs(titles) do
+        table.insert(encoded, host:url_encode(t))
+    end
     return string.format(
         "https://%s.wikipedia.org/w/api.php?action=query&prop=extracts"
         .. "&exintro=1&explaintext=1&exsentences=5&titles=%s&format=json",
-        LANGUAGE, joined
+        LANGUAGE, table.concat(encoded, "|")
     )
 end
 

--- a/src/palette/provider/command.rs
+++ b/src/palette/provider/command.rs
@@ -155,7 +155,6 @@ impl PaletteProvider for CommandProvider {
                 match &entry.kind {
                     PaletteKind::Spawn(spawn) => PaletteAction::Push(spawn(ctx)),
                     PaletteKind::Toggle(spawn) => PaletteAction::Toggle(spawn(ctx)),
-                    PaletteKind::Run(run) => PaletteAction::Run(run(ctx)),
                 }
             }
             Kind::OpenThemeProvider(current) => {

--- a/src/plugin_api/layout.rs
+++ b/src/plugin_api/layout.rs
@@ -1,26 +1,10 @@
 //! Panel layout helpers for plugin-side rendering.
 //!
-//! Two pieces:
-//!
-//! - [`PanelAnchor`] — where to anchor a panel within the map area
-//!   (left / right / corner / centre).
-//! - [`LayoutConfig`] — a small struct plugins flatten into their
-//!   own `XxxConfig` so users can adjust position and size from
-//!   `config.toml` without leaving the plugin's section:
-//!
-//!   ```toml
-//!   [wiki]
-//!   language = "en"
-//!   limit    = 50
-//!   anchor   = "right"   # ← layout override
-//!   width    = 30
-//!   ```
-//!
-//! Plugins call [`LayoutConfig::resolve`] at render time with their
-//! preferred defaults; the user's overrides win when set.
+//! [`PanelAnchor`] is the anchor vocabulary the Lua bridge maps
+//! `module.layout.anchor` strings into. Each variant places a
+//! `width × height` panel inside an outer `Rect` via [`PanelAnchor::rect`].
 
 use crate::widget::Rect;
-use serde::Deserialize;
 
 /// Anchor for a panel inside the map area. Side anchors place
 /// full-height stripes; corner anchors place a fixed-size box;
@@ -79,48 +63,6 @@ impl PanelAnchor {
     }
 }
 
-/// User-overridable layout knobs for a panel. Designed to be
-/// `#[serde(flatten)]`'d into a plugin's own config struct so the
-/// fields surface at the top level of the plugin's TOML section.
-///
-/// Every field is optional; absent fields fall back to the plugin's
-/// hardcoded defaults supplied to [`Self::resolve`].
-///
-/// No in-tree caller after the plugin migration (Lua scripts read
-/// their own `layout = {...}` field directly into [`super::super::lua::component::LuaLayout`]).
-/// Kept as an extension point for future Rust-side helpers.
-#[allow(dead_code)]
-#[derive(Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-pub struct LayoutConfig {
-    pub anchor: Option<String>,
-    pub width: Option<u16>,
-    pub height: Option<u16>,
-}
-
-#[allow(dead_code)]
-impl LayoutConfig {
-    /// Resolve the panel rectangle by combining plugin defaults with
-    /// any user-supplied overrides. Unknown anchor strings are
-    /// silently ignored (default anchor wins).
-    pub fn resolve(
-        &self,
-        outer: Rect,
-        default_anchor: PanelAnchor,
-        default_width: u16,
-        default_height: u16,
-    ) -> Rect {
-        let anchor = self
-            .anchor
-            .as_deref()
-            .and_then(PanelAnchor::from_str)
-            .unwrap_or(default_anchor);
-        let width = self.width.unwrap_or(default_width);
-        let height = self.height.unwrap_or(default_height);
-        anchor.rect(outer, width, height)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -151,38 +93,5 @@ mod tests {
         let r = PanelAnchor::Center.rect(outer(), 20, 10);
         assert_eq!(r.x, 40); // (100-20)/2
         assert_eq!(r.y, 15); // (40-10)/2
-    }
-
-    #[test]
-    fn config_overrides_default_anchor_when_present() {
-        let cfg = LayoutConfig {
-            anchor: Some("left".to_string()),
-            ..Default::default()
-        };
-        let r = cfg.resolve(outer(), PanelAnchor::Right, 20, 30);
-        assert_eq!(r.x, 1); // left edge with 1-cell margin
-    }
-
-    #[test]
-    fn config_falls_back_to_default_when_unknown_anchor() {
-        let cfg = LayoutConfig {
-            anchor: Some("middle".to_string()),
-            ..Default::default()
-        };
-        let r = cfg.resolve(outer(), PanelAnchor::TopLeft, 25, 5);
-        assert_eq!(r.x, 1);
-        assert_eq!(r.y, 1);
-    }
-
-    #[test]
-    fn config_overrides_dimensions() {
-        let cfg = LayoutConfig {
-            width: Some(40),
-            height: Some(8),
-            ..Default::default()
-        };
-        let r = cfg.resolve(outer(), PanelAnchor::TopLeft, 20, 4);
-        assert_eq!(r.width, 40);
-        assert_eq!(r.height, 8);
     }
 }

--- a/src/plugin_api/mod.rs
+++ b/src/plugin_api/mod.rs
@@ -3,9 +3,8 @@
 //! Two crate-internal pieces:
 //!
 //! - [`map_api::MapApi`] — drawing facade for `paint_on_map`.
-//! - [`layout::PanelAnchor`] / [`layout::LayoutConfig`] — anchor
-//!   vocabulary for `module.layout` in scripts and for centred
-//!   modal popups (help).
+//! - [`layout::PanelAnchor`] — anchor vocabulary for `module.layout` in
+//!   scripts and for centred modal popups (help).
 //!
 //! The Rust-plugin author prelude that lived here previously was
 //! retired together with the in-tree Rust plugins; everything in


### PR DESCRIPTION
## Summary

Five small fixes / cleanups identified by the post-migration audit. One bug (footer plugin hints), one correctness fix (wiki URL encoding), three refactors that remove migration-era leftovers.

### Commits

1. **refactor(lua): drop "Toggle Lua:" prefix from default label** — leftover from the migration era. `plugin_hint_label` already strips `"Toggle "` but not `"Toggle Lua: "`, so the footer label was reading just `"Lua:"` for plugins relying on the default. Default toggle label is now `"Toggle <name>"`.
2. **fix(lua): add `host:url_encode`, fix wiki extracts URL on non-ASCII titles** — `wiki.lua`'s inline encoder only handled `%`, `|`, `&` and broke on titles containing `?` / `#` / space / non-ASCII (e.g. `"São Paulo"`). `search.lua` had a separate, full RFC 3986 implementation in Lua. Both now go through one host accessor backed by the existing Rust `shared::http::url::urlencoded` helper.
3. **refactor(lua): drop `from_source` shim, route `every_bundled_script` through `register_one`** — collapses the `#[cfg(test)] from_source` 2-arg shim + `from_source_full` 3-arg pair into one `from_source(source, name, shared)`. Replaces the test that branched on a literal `r#"kind = "provider""#` source-string match with a `register_builtin_plugins`-driven test that asserts set membership rather than magic-number counts.
4. **fix(footer): plugin hints actually surface now** — `palette::install` `mem::take`s `Registrar.palette_entries` before returning. `App::new` was harvesting the BaseLayer's footer hints *after* `build_registrar` returned, so the entries were always empty by then and the BaseLayer footer never showed any plugin keys (`i wiki`, `? help`, `/ search`). Move the harvest into `build_registrar` before the install drain and return both the registrar and the leaked pair list via a `BuiltRegistrar` carrier.
5. **refactor(compositor): drop dead extension points** — every code path the audit flagged as `#[allow(dead_code)]` removed: `Task` trait + `Registrar.tasks` + `add_task` + `App.tasks` field + the per-tick polling loop; `PaletteKind::Run` + `RunAction` + `Registrar::add_run` + the `Run` match arm in the command provider; `LayoutConfig` + `resolve` + 3 tests. Both `PaletteAction::Run` (different enum) and `PanelAnchor::rect` stay — they have live callers.

## Test plan

- [x] `cargo test` (342 passing, 0 failures — the count drop from 345 is the 3 deleted `LayoutConfig` tests)
- [x] `cargo clippy --all-targets`, `cargo fmt --check` (pre-commit hook)
- [x] `cargo run -- --help`
- [ ] Manual: footer reads `hjkl pan | a/z zoom | : cmd | i wiki | ? help | / search | q quit` with focus on map
- [ ] Manual: wiki search resolves a non-ASCII title without breaking the API call