### PR TITLE
refactor(geo): unify tile-grid wraparound shift into geo::tile_grid_size

### DIFF
--- a/src/geo.rs
+++ b/src/geo.rs
@@ -133,6 +133,15 @@ pub fn base_zoom(zoom: f64) -> u32 {
     zoom.floor().clamp(0.0, 14.0) as u32
 }
 
+/// Tile-grid size at zoom `z`: the number of tiles along one axis
+/// (i.e. `2^z`), saturating at `i32::MAX` for `z >= 31`. Used as the
+/// modulus for x-axis wraparound (slippy maps wrap longitude but not
+/// latitude). Centralised so every call site has the same overflow
+/// story.
+pub fn tile_grid_size(z: u32) -> i32 {
+    1i32.checked_shl(z).unwrap_or(i32::MAX)
+}
+
 /// Return the effective tile size (in screen pixels / units) at a fractional
 /// zoom level.  A tile is 256 units at every integer zoom; sub-tile zooming
 /// scales it up.

--- a/src/map/render/pipeline.rs
+++ b/src/map/render/pipeline.rs
@@ -84,7 +84,7 @@ impl RenderPipeline {
         // z+1: every visible tile's four children.
         if z < 14 {
             let child_z = z + 1;
-            let child_grid = (1u64 << child_z) as i32;
+            let child_grid = crate::geo::tile_grid_size(child_z);
             for vt in &visible {
                 let bx = vt.x * 2;
                 let by = vt.y * 2;
@@ -105,7 +105,7 @@ impl RenderPipeline {
         // parents, so dedupe).
         if z > 0 {
             let parent_z = z - 1;
-            let parent_grid = (1u64 << parent_z) as i32;
+            let parent_grid = crate::geo::tile_grid_size(parent_z);
             let mut seen: std::collections::HashSet<(i32, i32)> = std::collections::HashSet::new();
             for vt in &visible {
                 let py = vt.y / 2;

--- a/src/map/render/view.rs
+++ b/src/map/render/view.rs
@@ -25,7 +25,7 @@ pub fn visible_tiles(
     let z = geo::base_zoom(zoom);
     let center = geo::ll2tile(center_lon, center_lat, z);
     let tile_size = geo::tile_size_at_zoom(zoom);
-    let grid_size = (1u64 << z) as i32;
+    let grid_size = geo::tile_grid_size(z);
 
     let mut tiles = Vec::new();
 
@@ -107,7 +107,7 @@ mod tests {
         // Near north pole — some y tiles should be skipped
         let tiles = visible_tiles(0.0, 85.0, 2.0, 400, 400);
         for t in &tiles {
-            let grid = (1u64 << t.z) as i32;
+            let grid = geo::tile_grid_size(t.z);
             assert!(
                 t.y >= 0 && t.y < grid,
                 "tile y={} out of grid {}",

--- a/src/map/tile/cache.rs
+++ b/src/map/tile/cache.rs
@@ -88,7 +88,7 @@ impl TileCache {
         // so the antimeridian wrap is correct for same-z keys. Cross-z
         // scoring is approximate but `zoom_diff` already dominates the
         // composite priority.
-        let grid_size = 1i32.checked_shl(cz).unwrap_or(i32::MAX);
+        let grid_size = crate::geo::tile_grid_size(cz);
 
         self.client.update_view(&|key: &TileKey| TilePriority {
             zoom_diff: key.z.abs_diff(cz),
@@ -151,7 +151,7 @@ impl TileCache {
             return self.memory_cache.get(&key);
         }
 
-        let grid_size = 1i32.checked_shl(self.current_z).unwrap_or(i32::MAX);
+        let grid_size = crate::geo::tile_grid_size(self.current_z);
         let priority = TilePriority {
             zoom_diff: key.z.abs_diff(self.current_z),
             distance_sq: tile_distance_sq(&key, self.center_x, self.center_y, grid_size),
@@ -164,7 +164,7 @@ impl TileCache {
     pub fn prefetch(&mut self, center_lon: f64, center_lat: f64, zoom: f64) {
         let z = crate::geo::base_zoom(zoom);
         let center = crate::geo::ll2tile(center_lon, center_lat, z);
-        let grid_size = (1u64 << z) as i32;
+        let grid_size = crate::geo::tile_grid_size(z);
         let cx = center.x.floor() as i32;
         let cy = center.y.floor() as i32;
 
@@ -190,7 +190,7 @@ impl TileCache {
         // already-warm tiles regardless of which quadrant the view
         // fractionally sits on.
         if z < 14 {
-            let g = (1u64 << (z + 1)) as i32;
+            let g = crate::geo::tile_grid_size(z + 1);
             let base_x = cx * 2;
             let base_y = cy * 2;
             for dy in 0..2 {
@@ -208,7 +208,7 @@ impl TileCache {
         // z-1 center
         if z > 0 {
             let c = crate::geo::ll2tile(center_lon, center_lat, z - 1);
-            let g = (1u64 << (z - 1)) as i32;
+            let g = crate::geo::tile_grid_size(z - 1);
             let tx = (c.x.floor() as i32).rem_euclid(g);
             let ty = c.y.floor() as i32;
             if ty >= 0 && ty < g {


### PR DESCRIPTION
## Summary
- Add `geo::tile_grid_size(z) -> i32` that returns `1i32.checked_shl(z).unwrap_or(i32::MAX)`.
- Replace the 9 `(1u64 << z) as i32` / `1i32.checked_shl(z).unwrap_or(i32::MAX)` callsites in `cache`, `pipeline`, and `view` with the helper.
- Pure mechanical refactor; no behaviour change. The `as f64` projection sites in `geo.rs` and `state.rs` are deliberately left alone — they compute `n = 2^z` for projection math, not a grid modulus, and don't share the i32-overflow story.

Closes #157.

## Test plan
- [x] `cargo build`
- [x] `cargo test` — 328/328 pass
- [x] `cargo clippy -- -D warnings` (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)