### PR TITLE
refactor(app): collapse AppMsg::Jump into Action::Jump

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -233,10 +233,6 @@ impl App {
                     self.request_map_redraw();
                 }
             }
-            AppMsg::Jump(loc) => {
-                self.map.jump_to(loc);
-                self.request_map_redraw();
-            }
             AppMsg::SetTheme(new_id) => self.apply_theme(new_id),
             AppMsg::CursorMoved(col, row) => {
                 self.cursor = Some((col, row));

--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -8,7 +8,7 @@
 //!
 //! In GoF Command-pattern terms this is the **Command** role expressed
 //! as a closed algebraic type: each variant is an imperative intent
-//! (`Map`, `Jump`, `CycleFocus`) that the Receiver ([`super::App`])
+//! (`Map`, `CycleFocus`, `SetTheme`) that the Receiver ([`super::App`])
 //! executes in [`App::dispatch`](super::App::dispatch). Invokers
 //! (keymap, palette, plugins) **return `Vec<AppMsg>`** and never
 //! execute anything themselves — the dispatcher is the sole
@@ -26,7 +26,6 @@
 //! off `AppMsg` means the focus state machine isn't coupled to the
 //! dispatch table.
 
-use crate::geo::LonLat;
 use crate::map::Action;
 use crate::theme::ThemeId;
 
@@ -43,11 +42,8 @@ use crate::theme::ThemeId;
 /// delegate to.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AppMsg {
-    /// Dispatch a map-state action (pan, zoom, reset, quit, ...).
+    /// Dispatch a map-state action (pan, zoom, reset, quit, jump, ...).
     Map(Action),
-    /// Jump the map to a specific location — produced by search /
-    /// here-plugin / any future picker that yields a `LonLat`.
-    Jump(LonLat),
     /// Switch the running theme. Cross-cutting: rebuilds the styler
     /// (on the render thread) and the UI colour cache.
     SetTheme(ThemeId),

--- a/src/compositor/window.rs
+++ b/src/compositor/window.rs
@@ -8,7 +8,7 @@
 //!     if ev.code == KeyCode::Esc {
 //!         win.close();
 //!     } else if enter_with_selection {
-//!         win.emit(AppMsg::Jump(loc));
+//!         win.emit(AppMsg::Map(Action::Jump(loc)));
 //!         win.close();
 //!     } else if ev.code == KeyCode::Char('/') {
 //!         win.close();

--- a/src/lua/component.rs
+++ b/src/lua/component.rs
@@ -109,9 +109,9 @@ pub struct LuaComponent {
     footer_hints: Vec<(&'static str, &'static str)>,
     /// Receiver for `host:jump(lon, lat)` requests. The Lua side
     /// pushes a `LonLat`; we drain after each `poll` /
-    /// `handle_event` and emit `AppMsg::Jump` through the host
-    /// `Window`. Keeps the Lua call site decoupled from when a
-    /// `Window` is actually available.
+    /// `handle_event` and emit `AppMsg::Map(Action::Jump)` through
+    /// the host `Window`. Keeps the Lua call site decoupled from
+    /// when a `Window` is actually available.
     jump_rx: mpsc::Receiver<LonLat>,
     /// Receiver for `host:close()` requests. Same pattern as
     /// `jump_rx`: the Lua side fires-and-forgets; we drain after
@@ -189,11 +189,11 @@ impl LuaComponent {
 
     /// Drain any `host:jump(...)` requests the Lua side queued
     /// during the most recent callback and emit them as
-    /// `AppMsg::Jump`. Called after `dispatch_event` /
+    /// `AppMsg::Map(Action::Jump)`. Called after `dispatch_event` /
     /// `dispatch_poll` while we still hold a `Window`.
     fn drain_jumps(&self, win: &mut Window) {
         while let Ok(ll) = self.jump_rx.try_recv() {
-            win.emit(AppMsg::Jump(ll));
+            win.emit(AppMsg::Map(crate::map::Action::Jump(ll)));
         }
     }
 
@@ -984,7 +984,7 @@ mod tests {
     fn host_jump_drains_into_window_emit() {
         // A handler that requests a jump but doesn't return any
         // host action — the jump should still surface as an
-        // AppMsg::Jump on the next drain.
+        // AppMsg::Map(Action::Jump) on the next drain.
         let mut c = LuaComponent::from_source(
             r#"return {
                 name = "jumper",
@@ -1014,7 +1014,7 @@ mod tests {
             .msgs
             .iter()
             .filter_map(|m| match m {
-                AppMsg::Jump(ll) => Some(ll),
+                AppMsg::Map(crate::map::Action::Jump(ll)) => Some(ll),
                 _ => None,
             })
             .collect();

--- a/src/lua/host.rs
+++ b/src/lua/host.rs
@@ -7,9 +7,10 @@
 //! - `host:jump(lon, lat)` — fire-and-forget request to recentre
 //!   the map on the given coordinate. The Lua side just enqueues a
 //!   `LonLat`; [`LuaComponent`] drains the channel after each
-//!   `poll` / `handle_event` dispatch and emits `AppMsg::Jump`
-//!   through the host `Window`. This keeps the Lua call site
-//!   independent of when a `Window` is actually available.
+//!   `poll` / `handle_event` dispatch and emits
+//!   `AppMsg::Map(Action::Jump)` through the host `Window`. This
+//!   keeps the Lua call site independent of when a `Window` is
+//!   actually available.
 //! - `host:parse_json(s) -> value | nil` — turn a JSON string into
 //!   nested Lua tables. Objects become string-keyed tables, arrays
 //!   become 1-indexed tables, `null` is `nil`. Parse errors return
@@ -164,11 +165,12 @@ impl UserData for LuaHost {
         });
 
         // `host:jump(lon, lat)` — request the map recentre on the
-        // given coordinate. The actual `AppMsg::Jump` emit happens
-        // when the matching `LuaComponent` drains the channel after
-        // its current callback returns, so this is fire-and-forget
-        // from the Lua side. Send errors (channel disconnected)
-        // mean the component is being torn down — silently ignore.
+        // given coordinate. The actual `AppMsg::Map(Action::Jump)`
+        // emit happens when the matching `LuaComponent` drains the
+        // channel after its current callback returns, so this is
+        // fire-and-forget from the Lua side. Send errors (channel
+        // disconnected) mean the component is being torn down —
+        // silently ignore.
         methods.add_method("jump", |_, this, (lon, lat): (f64, f64)| {
             let _ = this.jump_tx.send(LonLat { lon, lat });
             Ok(())

--- a/src/lua/palette_provider.rs
+++ b/src/lua/palette_provider.rs
@@ -226,14 +226,14 @@ impl LuaPaletteProvider {
     /// Three accepted forms:
     /// - `nil` → Close
     /// - `{ close = true }` → Close
-    /// - host:jump(lon, lat) inside execute → Run([Jump(ll)])
+    /// - host:jump(lon, lat) inside execute → Run([Map(Action::Jump(ll))])
     fn action_from_lua(&self, value: mlua::Value) -> PaletteAction {
         // First check the in-execute jump channel — host:jump pushes
         // a LonLat that takes priority over any returned table since
         // the script's intent ("jump to this") is unambiguous.
         let mut jumps = Vec::new();
         while let Ok(ll) = self.jump_rx.try_recv() {
-            jumps.push(AppMsg::Jump(ll));
+            jumps.push(AppMsg::Map(crate::map::Action::Jump(ll)));
         }
         if !jumps.is_empty() {
             return PaletteAction::Run(jumps);
@@ -378,7 +378,7 @@ mod tests {
         match p.execute(0, &ctx()) {
             PaletteAction::Run(msgs) => {
                 assert_eq!(msgs.len(), 1);
-                assert!(matches!(msgs[0], AppMsg::Jump(_)));
+                assert!(matches!(msgs[0], AppMsg::Map(crate::map::Action::Jump(_))));
             }
             _ => panic!("expected Run([Jump])"),
         }

--- a/src/map/action.rs
+++ b/src/map/action.rs
@@ -6,6 +6,8 @@
 //! and are invoked directly by the keyboard handler, so `Action`
 //! never carries UI-widget names.
 
+use crate::geo::LonLat;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Action {
     None,
@@ -35,6 +37,10 @@ pub enum Action {
         anchor_dy: f64,
         zoom_in: bool,
     },
+    /// Re-centre the map on a specific location. Produced by search,
+    /// the here-plugin, and `host:jump` from any Lua plugin — anything
+    /// that yields a `LonLat` and wants to move the view there.
+    Jump(LonLat),
 }
 
 impl Action {
@@ -60,7 +66,7 @@ impl Action {
             Action::ZoomToWorld => "Zoom to world",
             Action::ResetPosition => "Reset position",
             Action::Redraw => "Redraw",
-            Action::PanCells(..) | Action::ZoomAt { .. } => "",
+            Action::PanCells(..) | Action::ZoomAt { .. } | Action::Jump(_) => "",
         }
     }
 

--- a/src/map/state.rs
+++ b/src/map/state.rs
@@ -147,6 +147,10 @@ impl MapState {
                 self.zoom_towards(*anchor_dx, *anchor_dy, delta);
                 self.zoom != old_zoom || self.center != old_center
             }
+            Action::Jump(loc) => {
+                self.jump_to(*loc);
+                true
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `Action::Jump(LonLat)` and handle it in `MapState::process_action` (always returns true → redraw, matching the previous unconditional `request_map_redraw` behaviour).
- Drop `AppMsg::Jump` from `app/msg.rs` and its dispatch arm in `app/mod.rs`.
- Lua bridge keeps the same fire-and-forget shape; only the emitted message changes from `AppMsg::Jump(ll)` to `AppMsg::Map(Action::Jump(ll))`. No Lua-script-visible change.
- Doc-comments updated in `host.rs`, `component.rs`, `compositor/window.rs`.

Closes #156.

## Test plan
- [x] `cargo build`
- [x] `cargo test` — 328/328 pass (incl. `host_jump_drains_into_window_emit`, `execute_jump_returns_run_with_jump`)
- [x] `cargo clippy -- -D warnings` (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)