### PR TITLE
refactor(app): drop the dual attribution-passing path

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -63,7 +63,7 @@ impl App {
             cols, rows, width, height
         );
 
-        let (tile_cache, attribution, wake_rx) = build_tile_cache(&config);
+        let (tile_cache, wake_rx) = build_tile_cache(&config);
         let keymap = KeyMap::with_overrides(&config.keymap);
         let theme_id = ThemeId::from_name(&config.render.style);
         // `_lua_shared` is kept alive on the App so every Lua plugin's
@@ -72,7 +72,7 @@ impl App {
         let BuiltRegistrar {
             registrar,
             plugin_hints,
-        } = build_registrar(&config, attribution, &keymap);
+        } = build_registrar(&config, tile_cache.attribution(), &keymap);
         let ui_theme = UiTheme::from_palette(theme_id.palette());
         let styler = Arc::new(Styler::new(theme_id));
         let pipeline = RenderPipeline::new(
@@ -319,19 +319,13 @@ impl App {
 /// the cache are backend-agnostic.
 pub(crate) fn build_tile_cache(
     config: &Config,
-) -> (
-    crate::map::tile::TileCache,
-    Option<String>,
-    crossbeam_channel::Receiver<()>,
-) {
+) -> (crate::map::tile::TileCache, crossbeam_channel::Receiver<()>) {
     use directories::ProjectDirs;
     use std::fs;
 
     use crate::map::tile::cache::DiskFastPath;
     use crate::map::tile::decoder;
-    use crate::map::tile::fetch::{
-        DiskCachedFetcher, FetchLane, HttpFetcher, TileFetchLane, TileFetcher,
-    };
+    use crate::map::tile::fetch::{DiskCachedFetcher, FetchLane, HttpFetcher, TileFetchLane};
 
     /// Worker count for the HTTP backend. HTTP is I/O-bound, so a
     /// small pool covers the typical visible-tile + prefetch fan-out
@@ -350,10 +344,6 @@ pub(crate) fn build_tile_cache(
 
     let (bytes_tx, bytes_rx) = std::sync::mpsc::channel();
     let http = HttpFetcher::new();
-    let attribution = {
-        let s = http.attribution();
-        (!s.is_empty()).then(|| s.to_string())
-    };
 
     // The lane wraps an HTTP fetcher; if disk cache is enabled, layer
     // a `DiskCachedFetcher` decorator on top so worker-side hits
@@ -383,7 +373,6 @@ pub(crate) fn build_tile_cache(
             config.cache.memory_tiles,
             disk_fast_path,
         ),
-        attribution,
         wake_rx,
     )
 }

--- a/src/commands/snap.rs
+++ b/src/commands/snap.rs
@@ -128,7 +128,7 @@ pub fn run(args: SnapArgs) -> io::Result<()> {
     // build_tile_cache spawns 6 worker threads fetching tiles in
     // parallel — they run independently of us, so we can drive the
     // pipeline synchronously and just poll for completed tiles.
-    let (tile_cache, _attribution, _wake_rx) = app::build_tile_cache(&config);
+    let (tile_cache, _wake_rx) = app::build_tile_cache(&config);
     let theme_id = ThemeId::from_name(&config.render.style);
     let styler = Arc::new(Styler::new(theme_id));
     let mut pipeline = RenderPipeline::new(

--- a/src/map/tile/cache.rs
+++ b/src/map/tile/cache.rs
@@ -103,6 +103,16 @@ impl TileCache {
         self.client.is_idle()
     }
 
+    /// Active tile backend's attribution string (typically
+    /// "© OpenStreetMap …"). `None` when the backend has nothing to
+    /// display. Single source of truth so `App` and the Lua bridge
+    /// don't fork the lookup against the inner fetcher's value
+    /// directly.
+    pub fn attribution(&self) -> Option<String> {
+        let s = self.client.attribution();
+        (!s.is_empty()).then(|| s.to_string())
+    }
+
     /// Drain decoded-tile arrivals into the memory LRU. Returns true
     /// if any current-zoom tile arrived (i.e. the render thread
     /// should redraw).


### PR DESCRIPTION
## Summary
- Add `TileCache::attribution() -> Option<String>` that delegates to `TileFetchLane::attribution()`.
- Drop the `Option<String>` middle field from `build_tile_cache`'s return tuple — the value flowed in only to be threaded back out, so it's redundant.
- `App::new` now reads `tile_cache.attribution()` directly when calling `build_registrar`. Single source of truth: a future MBTiles/PMTiles backend can't disagree with itself about which attribution is "real".

Closes #158.

## Test plan
- [x] `cargo build`
- [x] `cargo test` — 328/328 pass
- [x] `cargo clippy -- -D warnings` + `cargo fmt -- --check` (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)