### PR TITLE
refactor(plugin-hint): use module.name as footer slug (#160)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -435,19 +435,22 @@ fn build_registrar(
         .filter(|e| !e.hint.is_empty())
         .map(|e| (e.hint.clone(), e.label.clone()))
         .collect();
-    shared.set_palette_entries(palette_entries.clone());
+    shared.set_palette_entries(palette_entries);
 
-    // Harvest the BaseLayer's footer hints from the same snapshot.
-    // Has to happen *before* `palette::install` because that call
-    // `mem::take`s `r.palette_entries`. Leak each pair once so they
-    // satisfy `Component::footer_hints`'s `&'static str` contract —
-    // bounded by the plugin count.
-    let plugin_hints: Vec<(&'static str, &'static str)> = palette_entries
-        .into_iter()
-        .map(|(hint, label)| {
-            let key: &'static str = Box::leak(hint.into_boxed_str());
-            let label: &'static str = Box::leak(plugin_hint_label(&label).into_boxed_str());
-            (key, label)
+    // Harvest the BaseLayer's footer hints. Has to happen *before*
+    // `palette::install` because that call `mem::take`s
+    // `r.palette_entries`. The footer slot is `[<key> <name>]` —
+    // built directly from each entry's keybinding and `module.name`.
+    // No keybinding ⇒ no footer slot. Leak the key string once to
+    // satisfy [`Component::footer_hints`]'s `&'static str` contract;
+    // `name` is already `&'static`.
+    let plugin_hints: Vec<(&'static str, &'static str)> = r
+        .palette_entries
+        .iter()
+        .filter(|e| !e.hint.is_empty())
+        .map(|e| {
+            let key: &'static str = Box::leak(e.hint.clone().into_boxed_str());
+            (key, e.name)
         })
         .collect();
 
@@ -464,26 +467,6 @@ fn build_registrar(
         registrar: r,
         plugin_hints,
     }
-}
-
-/// Boil a palette label down to the short form shown in the footer.
-/// `"Toggle wiki"` → `"wiki"`; `"Search location"` → `"search"`. Plain
-/// labels without a leading verb pass through unchanged.
-fn plugin_hint_label(label: &str) -> String {
-    let trimmed = label.trim();
-    for verb in ["Toggle ", "Show ", "Open "] {
-        if let Some(rest) = trimmed.strip_prefix(verb) {
-            return rest.to_string();
-        }
-    }
-    // Multi-word labels (e.g. "Search location", "Jump to here
-    // (current location)") get squeezed to the first word so the
-    // footer doesn't get crowded.
-    trimmed
-        .split_whitespace()
-        .next()
-        .unwrap_or(trimmed)
-        .to_lowercase()
 }
 
 /// Build the `(key-binding, action-label)` pairs that the help plugin

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -464,6 +464,9 @@ pub enum PaletteKind {
 pub struct PaletteEntry {
     pub label: String,
     pub hint: String,
+    /// Plugin's canonical short name (`module.name`). Used as the
+    /// footer slug paired with `hint` (`[<hint> <name>]`).
+    pub name: &'static str,
     pub kind: PaletteKind,
 }
 
@@ -517,6 +520,7 @@ impl Registrar {
         &mut self,
         label: impl Into<String>,
         hint: impl Into<String>,
+        name: &'static str,
         factory: F,
     ) where
         F: Fn(&Context) -> C + 'static,
@@ -525,6 +529,7 @@ impl Registrar {
         self.add_palette_entry(PaletteEntry {
             label: label.into(),
             hint: hint.into(),
+            name,
             kind: PaletteKind::Toggle(Box::new(move |ctx| {
                 Box::new(factory(ctx)) as Box<dyn Component>
             })),
@@ -534,14 +539,20 @@ impl Registrar {
     /// Add a palette entry that spawns a fresh instance every time —
     /// no toggle dedup. Use when the component is meant to be rebuilt
     /// per open (search, palette sub-modes).
-    pub fn add_spawn<F, C>(&mut self, label: impl Into<String>, hint: impl Into<String>, factory: F)
-    where
+    pub fn add_spawn<F, C>(
+        &mut self,
+        label: impl Into<String>,
+        hint: impl Into<String>,
+        name: &'static str,
+        factory: F,
+    ) where
         F: Fn(&Context) -> C + 'static,
         C: Component + 'static,
     {
         self.add_palette_entry(PaletteEntry {
             label: label.into(),
             hint: hint.into(),
+            name,
             kind: PaletteKind::Spawn(Box::new(move |ctx| {
                 Box::new(factory(ctx)) as Box<dyn Component>
             })),

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -245,7 +245,7 @@ fn register_component(
         }
         Activation::Toggle => {
             let shared_for_toggle = shared.clone();
-            r.add_toggle(label, key_hint, move |_| {
+            r.add_toggle(label, key_hint, name, move |_| {
                 component_or_placeholder(name, source, shared_for_toggle.clone())
             });
             if let Some(key) = meta.key {
@@ -258,7 +258,7 @@ fn register_component(
         }
         Activation::Spawn => {
             let shared_for_spawn = shared.clone();
-            r.add_spawn(label, key_hint, move |_| {
+            r.add_spawn(label, key_hint, name, move |_| {
                 component_or_placeholder(name, source, shared_for_spawn.clone())
             });
             if let Some(key) = meta.key {
@@ -300,7 +300,7 @@ fn register_provider(
         }
     };
 
-    r.add_spawn(label, key_hint, {
+    r.add_spawn(label, key_hint, name, {
         let make = make.clone();
         move |_| make()
     });


### PR DESCRIPTION
## Summary

- Replace `plugin_hint_label`'s Toggle/Show/Open verb-strip + first-word-of-label heuristic with a direct `[<key> <module.name>]` pairing. No derivation, no guessing.
- `PaletteEntry` carries `name: &'static str` (the plugin's canonical short identifier from `module.name`). `Registrar::add_toggle` / `add_spawn` take it as a 4th param so the Lua bridge threads through the script's name (already `&'static` at register-time).
- The verb-strip happened to produce the same slug as the plugin name for every bundled plugin that surfaces in the footer (`help`, `search`, `wiki`) — switching to `name` is exact for those and extends cleanly to plugins whose `label` doesn't start with the hardcoded English verb list.

**BREAKING (Registrar API)**: `add_toggle` / `add_spawn` gain a `name` parameter. Only the Lua bridge calls these in-tree. Pre-1.0, no release shipped with the old signature.

Closes #160. Supersedes the earlier #176 (closed).

## Test plan

- [x] `cargo test` (328 passed)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Manual TTY check: `cargo run`, confirm footer shows `[? help]`, `[/ search]`, `[i wiki]` exactly as before; key-less plugins (`aircraft`, `iss`, `quakes`, `here`, `export`) produce no footer slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)