### PR TITLE
refactor(keymap): replace KeybindingOverrides struct + macro with data-driven HashMap (#163)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -207,9 +207,12 @@ quit = ["Q", "C-q"]
         assert!(cfg.cache.tiles);
 
         // Keymap overrides are stored raw; resolution to KeyMap is in app.rs.
-        assert_eq!(cfg.keymap.zoom_in.as_deref(), Some(&["i".to_string()][..]));
         assert_eq!(
-            cfg.keymap.quit.as_deref(),
+            cfg.keymap.get("zoom_in").map(|v| v.as_slice()),
+            Some(&["i".to_string()][..])
+        );
+        assert_eq!(
+            cfg.keymap.get("quit").map(|v| v.as_slice()),
             Some(&["Q".to_string(), "C-q".to_string()][..])
         );
     }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -12,8 +12,9 @@
 //! [`Window::open`](crate::compositor::window::Window) / `toggle`
 //! queue, applied atomically after the `BaseLayer` hook returns.)
 
+use std::collections::HashMap;
+
 use crossterm::event::{KeyCode, KeyModifiers};
-use serde::Deserialize;
 
 use crate::app::AppMsg;
 use crate::map::Action;
@@ -104,31 +105,17 @@ impl KeyMap {
     }
 
     /// Default bindings with user `[keymap]` overrides applied on top.
+    /// Each entry's key is the `Action::config_name` (e.g. `"pan_left"`);
+    /// unknown names are logged and skipped so a stale config can't
+    /// crash startup.
     pub fn with_overrides(overrides: &KeybindingOverrides) -> Self {
         let mut km = Self::default();
-
-        macro_rules! rebind {
-            ($field:ident, $action:expr) => {
-                if let Some(keys) = &overrides.$field {
-                    km.set_bindings(AppMsg::Map($action), keys);
-                }
-            };
+        for (name, keys) in overrides {
+            match Action::from_config_name(name) {
+                Some(action) => km.set_bindings(AppMsg::Map(action), keys),
+                None => log::warn!("unknown [keymap] entry: {:?}", name),
+            }
         }
-
-        rebind!(pan_left, Action::PanLeft);
-        rebind!(pan_right, Action::PanRight);
-        rebind!(pan_up, Action::PanUp);
-        rebind!(pan_down, Action::PanDown);
-        rebind!(pan_left_fast, Action::PanLeftFast);
-        rebind!(pan_right_fast, Action::PanRightFast);
-        rebind!(pan_up_half, Action::PanUpHalf);
-        rebind!(pan_down_half, Action::PanDownHalf);
-        rebind!(zoom_in, Action::ZoomIn);
-        rebind!(zoom_out, Action::ZoomOut);
-        rebind!(zoom_to_world, Action::ZoomToWorld);
-        rebind!(reset_position, Action::ResetPosition);
-        rebind!(quit, Action::Quit);
-
         km
     }
 }
@@ -165,25 +152,13 @@ impl Default for KeyMap {
 }
 
 /// Raw keybinding overrides from the `[keymap]` section of
-/// `config.toml`. Each field names a map `Action`; the listed key
-/// strings replace the default bindings for that action (wrapped as
-/// `AppMsg::Map` internally). Applied via `KeyMap::with_overrides`.
-#[derive(Deserialize, Default, Clone)]
-pub struct KeybindingOverrides {
-    pub pan_left: Option<Vec<String>>,
-    pub pan_right: Option<Vec<String>>,
-    pub pan_up: Option<Vec<String>>,
-    pub pan_down: Option<Vec<String>>,
-    pub pan_left_fast: Option<Vec<String>>,
-    pub pan_right_fast: Option<Vec<String>>,
-    pub pan_up_half: Option<Vec<String>>,
-    pub pan_down_half: Option<Vec<String>>,
-    pub zoom_in: Option<Vec<String>>,
-    pub zoom_out: Option<Vec<String>>,
-    pub zoom_to_world: Option<Vec<String>>,
-    pub reset_position: Option<Vec<String>>,
-    pub quit: Option<Vec<String>>,
-}
+/// `config.toml`. Keys are `Action::config_name` strings (e.g.
+/// `"pan_left"`); values replace the default bindings for that
+/// action (wrapped as `AppMsg::Map` internally). Applied via
+/// `KeyMap::with_overrides`. Adding a new bindable `Action` only
+/// requires extending `Action::all_listed` + `Action::config_name`
+/// — the data shape here is unchanged.
+pub type KeybindingOverrides = HashMap<String, Vec<String>>;
 
 // ── Key binding parser ────────────────────────────────────────────────────────
 
@@ -282,9 +257,9 @@ mod tests {
 
     #[test]
     fn with_overrides_applies_rebinds() {
-        let mut overrides = KeybindingOverrides::default();
-        overrides.zoom_in = Some(vec!["i".to_string()]);
-        overrides.quit = Some(vec!["Q".to_string(), "C-q".to_string()]);
+        let mut overrides = KeybindingOverrides::new();
+        overrides.insert("zoom_in".to_string(), vec!["i".to_string()]);
+        overrides.insert("quit".to_string(), vec!["Q".to_string(), "C-q".to_string()]);
 
         let km = KeyMap::with_overrides(&overrides);
 
@@ -304,7 +279,20 @@ mod tests {
 
     #[test]
     fn with_overrides_keeps_unoverridden_defaults() {
-        let km = KeyMap::with_overrides(&KeybindingOverrides::default());
+        let km = KeyMap::with_overrides(&KeybindingOverrides::new());
+        assert_eq!(
+            km.lookup(KeyCode::Char('h'), KeyModifiers::NONE),
+            Some(&map(Action::PanLeft))
+        );
+    }
+
+    #[test]
+    fn with_overrides_skips_unknown_entries() {
+        let mut overrides = KeybindingOverrides::new();
+        overrides.insert("not_an_action".to_string(), vec!["x".to_string()]);
+        // Defaults survive an unknown entry — it must not poison the
+        // rest of the table.
+        let km = KeyMap::with_overrides(&overrides);
         assert_eq!(
             km.lookup(KeyCode::Char('h'), KeyModifiers::NONE),
             Some(&map(Action::PanLeft))

--- a/src/map/action.rs
+++ b/src/map/action.rs
@@ -92,4 +92,39 @@ impl Action {
             Action::Quit,
         ]
     }
+
+    /// Stable, snake_case name used as the TOML key in `[keymap]`
+    /// (e.g. `pan_left = ["h", "Left"]`). Mouse-only variants and
+    /// `None` / `Jump` return `""` since they cannot be rebound from
+    /// config. Exhaustive so adding a variant is a compile error.
+    pub fn config_name(&self) -> &'static str {
+        match self {
+            Action::None => "",
+            Action::Quit => "quit",
+            Action::PanUp => "pan_up",
+            Action::PanDown => "pan_down",
+            Action::PanLeft => "pan_left",
+            Action::PanRight => "pan_right",
+            Action::PanLeftFast => "pan_left_fast",
+            Action::PanRightFast => "pan_right_fast",
+            Action::PanUpHalf => "pan_up_half",
+            Action::PanDownHalf => "pan_down_half",
+            Action::ZoomIn => "zoom_in",
+            Action::ZoomOut => "zoom_out",
+            Action::ZoomToWorld => "zoom_to_world",
+            Action::ResetPosition => "reset_position",
+            Action::Redraw => "redraw",
+            Action::PanCells(..) | Action::ZoomAt { .. } | Action::Jump(_) => "",
+        }
+    }
+
+    /// Reverse of [`config_name`]: resolve a TOML key back to its
+    /// `Action`. Only listed (rebindable) variants match; unknown
+    /// names yield `None`.
+    pub fn from_config_name(name: &str) -> Option<Action> {
+        Self::all_listed()
+            .iter()
+            .find(|a| a.config_name() == name)
+            .cloned()
+    }
 }


### PR DESCRIPTION
## Summary

- `KeybindingOverrides` の 13-field struct と `with_overrides` の 13-arm `rebind!` macro を撤去 → `HashMap<String, Vec<String>>` 型 alias + データ駆動ループに置換
- `Action` に `config_name()` (snake_case 名の exhaustive match) と `from_config_name()` を追加。Action ↔ TOML key の対応を一元化
- 不明な `[keymap]` entry は warn log を出してスキップ (古い config が startup を壊さない)

## Why

Bindable な `Action` を追加するときの修正箇所が enum / `label()` / `all_listed()` / struct field / macro arm の 5 箇所同期だった。後ろ 2 つは `all_listed()` を別形で再記述しただけで、忘れても compile error が出ない silent footgun。

改修後は enum + `label()` + `all_listed()` + `config_name()` の 4 箇所、すべて exhaustive match なので忘れたら build break する。

副次効果: `Action::Redraw` (元から `all_listed()` 入りだが struct field がなく rebind 不可だった) が `[keymap]` から rebind 可能化。issue 文言「Adding a new Action means just updating Action::all_listed」と整合。

TOML wire shape (`pan_left = ["h", "Left"]`) は不変、既存 `config.toml` 互換。

Closes #163.

## Test plan

- [x] `cargo test` (331 passed)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `with_overrides_skips_unknown_entries` を追加 — 不明 entry が他の override を巻き込まずスキップされることを確認
- [x] 既存 `with_overrides_applies_rebinds` / config 側 partial-TOML テストも HashMap 形に追従

🤖 Generated with [Claude Code](https://claude.com/claude-code)