### PR TITLE
refactor(compositor): give overlays a narrower OverlayWindow (#127)

### DIFF
--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -139,6 +139,14 @@ pub trait Component: Any {
     /// and `win.close()` if the component should self-remove.
     fn poll(&mut self, _win: &mut Window) {}
 
+    /// Overlay counterpart to [`poll`](Self::poll). Called every tick
+    /// on every always-on overlay. The handle is narrower —
+    /// [`OverlayWindow`] only exposes `ctx` and `emit`, because
+    /// overlays don't live on the focusable stack and `close` /
+    /// `open` would have nothing to act on. Default no-op for
+    /// stack-only components that never register as overlays.
+    fn poll_overlay(&mut self, _win: &mut window::OverlayWindow) {}
+
     /// Footer hints shown while this component is on top.
     fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
         Vec::new()
@@ -153,7 +161,7 @@ pub trait Component: Any {
     }
 }
 
-use window::{Window, WindowOps};
+use window::{OverlayWindow, Window, WindowOps};
 
 // ── Compositor stack ───────────────────────────────────────────────
 
@@ -318,10 +326,10 @@ impl Compositor {
     /// Poll every component; drain all queued `win.emit(...)` /
     /// `win.close()` / `win.open(...)` ops and apply them in the
     /// same way [`handle_event`](Self::handle_event) does. Always-on
-    /// overlays poll too — they may have async work (geocoding,
-    /// throttle ticks) but the only ops they emit are
-    /// `win.emit(AppMsg)`; close/open are ignored on overlays
-    /// because they aren't on the focusable stack.
+    /// overlays poll through the narrower [`Component::poll_overlay`]
+    /// hook — they may have async work (geocoding, throttle ticks)
+    /// but only `emit` is exposed because overlays don't live on the
+    /// focusable stack.
     pub fn poll(&mut self, ctx: &Context) -> Vec<AppMsg> {
         // Walk in reverse so closing a component doesn't disturb
         // indices of later ones. Collect ops per index first; apply
@@ -338,14 +346,8 @@ impl Compositor {
             all_msgs.extend(msgs);
         }
         for c in self.overlays.iter_mut() {
-            let mut ops = WindowOps::default();
-            {
-                let mut win = Window::new(&mut ops, ctx);
-                c.poll(&mut win);
-            }
-            // Overlays only meaningfully emit; close/open are silently
-            // dropped because overlays don't live on the focusable stack.
-            all_msgs.extend(ops.msgs);
+            let mut win = OverlayWindow::new(&mut all_msgs, ctx);
+            c.poll_overlay(&mut win);
         }
         all_msgs
     }

--- a/src/compositor/window.rs
+++ b/src/compositor/window.rs
@@ -144,6 +144,44 @@ impl<'a> Window<'a> {
     }
 }
 
+// ── OverlayWindow: poll-time handle for always-on overlays ─────────
+
+/// Poll-time handle for [`Compositor`]'s always-on overlays
+/// (`info`, `scalebar`, `attribution`, …). Narrower than [`Window`]:
+/// overlays don't live on the focusable stack, so `close` / `open` /
+/// `toggle` / `ignore` would have nothing to act on. The only useful
+/// op is `emit` (queue an `AppMsg`), which is what this surface
+/// exposes — and what the compositor honours after the hook returns.
+///
+/// Splitting overlays out into their own handle moves "what the
+/// framework will silently drop" from a runtime concern (a comment in
+/// `Compositor::poll`) into a compile-time one — overlay code that
+/// tries to call `close()` simply won't typecheck.
+///
+/// Lua plugins are still one [`Component`] impl that may be either an
+/// overlay or a stack component; that adapter has its own runtime
+/// story for `host:close()` from an overlay (drain + log).
+pub struct OverlayWindow<'a> {
+    msgs: &'a mut Vec<AppMsg>,
+    ctx: &'a Context,
+}
+
+impl<'a> OverlayWindow<'a> {
+    pub(crate) fn new(msgs: &'a mut Vec<AppMsg>, ctx: &'a Context) -> Self {
+        Self { msgs, ctx }
+    }
+
+    /// App-level snapshot for this hook (map center, theme id).
+    pub fn ctx(&self) -> &Context {
+        self.ctx
+    }
+
+    /// Queue `msg` for `App::dispatch`.
+    pub fn emit(&mut self, msg: AppMsg) {
+        self.msgs.push(msg);
+    }
+}
+
 // ── RenderWindow: draw-time handle ─────────────────────────────────
 
 /// Render-time companion to [`Window`]. Carries the ratatui

--- a/src/lua/component.rs
+++ b/src/lua/component.rs
@@ -25,7 +25,7 @@ use ratatui::widgets::Paragraph;
 
 use crate::app::AppMsg;
 use crate::compositor::layout::PanelAnchor;
-use crate::compositor::window::{RenderWindow, Window};
+use crate::compositor::window::{OverlayWindow, RenderWindow, Window};
 use crate::compositor::{Component, MapApi};
 use crate::geo::LonLat;
 use crate::lua::host::LuaHostShared;
@@ -202,13 +202,17 @@ impl LuaComponent {
         }
     }
 
-    /// Drain any `host:jump(...)` requests the Lua side queued
-    /// during the most recent callback and emit them as
-    /// `AppMsg::Map(Action::Jump)`. Called after `dispatch_event` /
-    /// `dispatch_poll` while we still hold a `Window`.
-    fn drain_jumps(&self, win: &mut Window) {
+    /// Drain any `host:jump(...)` and `host:export_frame()` requests
+    /// the Lua side queued during the most recent callback. Calls
+    /// `emit` once per queued request; the caller wires this to the
+    /// active window's `emit` (works for both [`Window`] and
+    /// [`OverlayWindow`]).
+    fn drain_emits(&self, mut emit: impl FnMut(AppMsg)) {
         while let Ok(ll) = self.jump_rx.try_recv() {
-            win.emit(AppMsg::Map(crate::map::Action::Jump(ll)));
+            emit(AppMsg::Map(crate::map::Action::Jump(ll)));
+        }
+        while self.export_rx.try_recv().is_ok() {
+            emit(AppMsg::ExportFrame);
         }
     }
 
@@ -225,12 +229,18 @@ impl LuaComponent {
         }
     }
 
-    /// Drain any `host:export_frame()` requests and emit one
-    /// `AppMsg::ExportFrame` per request. Multiple requests in
-    /// the same dispatch each emit (App::dispatch handles each).
-    fn drain_export(&self, win: &mut Window) {
-        while self.export_rx.try_recv().is_ok() {
-            win.emit(AppMsg::ExportFrame);
+    /// Overlay counterpart to [`drain_close`]. Overlays don't live on
+    /// the focusable stack, so a `host:close()` from one has nothing
+    /// to pop. Drain the channel anyway (it's unbounded; left
+    /// undrained it would grow forever) and warn so a misuse is
+    /// visible.
+    fn drain_close_overlay(&self) {
+        if self.close_rx.try_recv().is_ok() {
+            while self.close_rx.try_recv().is_ok() {}
+            log::warn!(
+                "lua[{}]: host:close() ignored — overlay components don't live on the focusable stack",
+                self.name
+            );
         }
     }
 
@@ -510,8 +520,7 @@ impl Component for LuaComponent {
     fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
         self.update_center(win.ctx().center);
         let action = self.dispatch_event(event);
-        self.drain_jumps(win);
-        self.drain_export(win);
+        self.drain_emits(|m| win.emit(m));
         self.drain_close(win);
         match action {
             KeyAction::Close => win.close(),
@@ -528,9 +537,15 @@ impl Component for LuaComponent {
     fn poll(&mut self, win: &mut Window) {
         self.update_center(win.ctx().center);
         self.dispatch_poll();
-        self.drain_jumps(win);
-        self.drain_export(win);
+        self.drain_emits(|m| win.emit(m));
         self.drain_close(win);
+    }
+
+    fn poll_overlay(&mut self, win: &mut OverlayWindow) {
+        self.update_center(win.ctx().center);
+        self.dispatch_poll();
+        self.drain_emits(|m| win.emit(m));
+        self.drain_close_overlay();
     }
 
     fn render(&self, win: &mut RenderWindow) {
@@ -1036,6 +1051,89 @@ mod tests {
         assert_eq!(jumps.len(), 1);
         assert!((jumps[0].lon - 139.7595).abs() < 1e-9);
         assert!((jumps[0].lat - 35.6828).abs() < 1e-9);
+    }
+
+    #[test]
+    fn poll_overlay_drains_host_jump_into_emit() {
+        // An overlay that fires `host:jump` from poll. Verifies the
+        // overlay path keeps emit semantics (the same drain logic that
+        // works for stack components) even though the OverlayWindow
+        // surface is narrower.
+        let mut c = LuaComponent::from_source(
+            r#"return {
+                name = "jumper",
+                poll = function()
+                    host:jump(139.7595, 35.6828)
+                end,
+            }"#,
+            "jumper",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
+
+        use crate::compositor::Context;
+        const CTX: Context = Context {
+            center: LonLat { lon: 0.0, lat: 0.0 },
+            theme_id: crate::theme::ThemeId::Dark,
+            cursor: None,
+        };
+        let mut msgs: Vec<AppMsg> = Vec::new();
+        {
+            let mut win = OverlayWindow::new(&mut msgs, &CTX);
+            c.poll_overlay(&mut win);
+        }
+        let jumps: Vec<&LonLat> = msgs
+            .iter()
+            .filter_map(|m| match m {
+                AppMsg::Map(crate::map::Action::Jump(ll)) => Some(ll),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(jumps.len(), 1);
+        assert!((jumps[0].lon - 139.7595).abs() < 1e-9);
+        assert!((jumps[0].lat - 35.6828).abs() < 1e-9);
+    }
+
+    #[test]
+    fn poll_overlay_drains_host_close_without_emitting() {
+        // An overlay that incorrectly calls `host:close()` from poll.
+        // The overlay path must drain `close_rx` (else the unbounded
+        // channel would grow forever) but emit nothing on the
+        // OverlayWindow — overlays don't live on the focusable stack.
+        let mut c = LuaComponent::from_source(
+            r#"return {
+                name = "bad_overlay",
+                poll = function()
+                    host:close()
+                end,
+            }"#,
+            "bad_overlay",
+            super::super::host::LuaHostShared::empty(),
+        )
+        .expect("load");
+
+        use crate::compositor::Context;
+        const CTX: Context = Context {
+            center: LonLat { lon: 0.0, lat: 0.0 },
+            theme_id: crate::theme::ThemeId::Dark,
+            cursor: None,
+        };
+        let mut msgs: Vec<AppMsg> = Vec::new();
+        {
+            let mut win = OverlayWindow::new(&mut msgs, &CTX);
+            c.poll_overlay(&mut win);
+            // Second tick — the channel must have been drained on
+            // the first call. A missing drain would log a second
+            // warning here; correctness is unaffected because the
+            // OverlayWindow has no close path either way.
+            c.poll_overlay(&mut win);
+        }
+        // No close-path msgs exist on OverlayWindow; just assert
+        // no jumps / exports leaked into the queue.
+        assert!(
+            msgs.is_empty(),
+            "overlay poll must not emit anything for a host:close()"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #127.

- Introduce `OverlayWindow` (only `ctx()` + `emit()`) and `Component::poll_overlay` sibling hook so the framework refuses overlay `close()`/`open()`/`toggle()` at compile time instead of dropping them at runtime.
- Compositor's overlay-poll branch swaps `Window` → `OverlayWindow`; the silent-drop comment in `Compositor::poll` is replaced by the type system.
- `LuaComponent` (the only `Component` impl that serves both stack and overlay registrations) implements both `poll` and `poll_overlay`. Common drain logic factored into `drain_emits(impl FnMut(AppMsg))`. `host:close()` from a Lua overlay now drains `close_rx` and logs a warning — runtime equivalent of the new type-level refusal, since the bridge isn't type-checked.

## Test plan

- [x] `cargo build`
- [x] `cargo test` — 333 passed (was 331; +2 new)
  - `poll_overlay_drains_host_jump_into_emit` — overlay path keeps emit semantics
  - `poll_overlay_drains_host_close_without_emitting` — overlay `host:close()` drains the channel without emitting
- [x] `cargo clippy --all-targets` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)