### PR TITLE
refactor(lua): simplify init_lua read_back + document parse's new_lua dep

### DIFF
--- a/src/lua/init_lua.rs
+++ b/src/lua/init_lua.rs
@@ -198,28 +198,7 @@ fn read_back(lua: &Lua, defaults: &Config) -> mlua::Result<Config> {
     let ttymap: Table = lua.globals().get("ttymap")?;
     let opt: Table = ttymap.get("opt")?;
 
-    let mut cfg = Config {
-        map: crate::config::MapConfig {
-            lat: defaults.map.lat,
-            lon: defaults.map.lon,
-            zoom: defaults.map.zoom,
-            max_zoom: defaults.map.max_zoom,
-            zoom_step: defaults.map.zoom_step,
-        },
-        render: crate::config::RenderConfig {
-            style: defaults.render.style.clone(),
-            language: defaults.render.language.clone(),
-        },
-        cache: crate::config::CacheConfig {
-            tiles: defaults.cache.tiles,
-            memory_tiles: defaults.cache.memory_tiles,
-        },
-        geoip: crate::config::GeoipConfig {
-            on_startup: defaults.geoip.on_startup,
-            endpoint: defaults.geoip.endpoint.clone(),
-            timeout_ms: defaults.geoip.timeout_ms,
-        },
-    };
+    let mut cfg = defaults.clone();
 
     if let Ok(t) = opt.get::<Table>("map") {
         if let Ok(v) = t.get::<f64>("lat") {

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -216,6 +216,14 @@ impl ModuleMeta {
     /// Read the plugin's metadata fields by parsing the source once.
     /// Defaults are picked so a minimal `return { name = "x" }` script
     /// works as a toggle Component named "x".
+    ///
+    /// Uses [`new_lua`] (full searcher + package.path setup) rather
+    /// than a bare `Lua::new()` because module load can trigger
+    /// top-level `require` — `scalebar.lua` does `local fmt = require
+    /// "ttymap.fmt"` at the file head, which needs the runtime-path
+    /// searcher installed. Without it, the metadata read fails and
+    /// the dispatcher falls back to default Toggle/Component, silently
+    /// dropping `activation = "overlay"` declarations.
     fn parse(source: &str, name: &str) -> Self {
         let lua = new_lua();
         let module: Table = match lua.load(source).set_name(name).eval() {


### PR DESCRIPTION
Two small wins from the post-#180 audit. Both low-risk, tests untouched.

## Changes

### \`init_lua::read_back\` — rebuild → clone+override
\`\`\`diff
- let mut cfg = Config {
-     map: crate::config::MapConfig {
-         lat: defaults.map.lat,
-         lon: defaults.map.lon,
-         ... 22 lines of manual field copies ...
-     },
- };
+ let mut cfg = defaults.clone();
\`\`\`
\`Config\` derives \`Clone\` since #180; the manual reconstruction was a
holdover. Seeding with \`defaults.clone()\` and letting the override
branches patch only what \`init.lua\` set reads as \"override\" rather
than \"rebuild from scratch\".

### \`ModuleMeta::parse\` — document the \`new_lua()\` requirement
The audit suggested swapping \`new_lua()\` for bare \`Lua::new()\` since
metadata reads are static field lookups. Tried it: \`every_bundled_script_registers\`
fails because \`scalebar.lua\` does \`local fmt = require \"ttymap.fmt\"\`
at module top level — the metadata read needs the runtime-path
searcher installed.

The fix is a doc comment on \`parse\` explaining why the searcher is
load-bearing here, so future optimisation attempts see the trap
upfront instead of running into the failing test.

## Test plan

- [x] \`cargo test\` — 345 passed (unchanged from main)
- [x] \`cargo clippy\` — no new warnings
- [x] \`every_bundled_script_registers\` confirmed to be the regression
  guard for the parse / new_lua coupling

🤖 Generated with [Claude Code](https://claude.com/claude-code)