### PR TITLE
feat(lua): ttymap.map:zoom() getter form (no-arg)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -333,6 +333,7 @@ impl App {
     fn context(&self) -> Context {
         Context {
             center: self.map.center(),
+            zoom: self.map.zoom(),
             theme_id: self.theme_id,
             cursor: self.cursor,
         }

--- a/src/compositor/base.rs
+++ b/src/compositor/base.rs
@@ -157,6 +157,7 @@ mod tests {
     const NONE: KeyModifiers = KeyModifiers::NONE;
     const CTX: Context = Context {
         center: LonLat { lon: 0.0, lat: 0.0 },
+        zoom: 0.0,
         theme_id: ThemeId::Dark,
         cursor: None,
     };

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -73,6 +73,7 @@ fn intercept_focus_key(event: KeyEvent) -> Option<AppMsg> {
 #[derive(Debug, Clone, Copy)]
 pub struct Context {
     pub center: LonLat,
+    pub zoom: f64,
     pub theme_id: ThemeId,
     /// Latest mouse cursor position in absolute terminal cells.
     /// `None` until the first mouse event arrives (or always, on
@@ -592,6 +593,7 @@ mod tests {
     fn push_always_stacks_new_instance() {
         let ctx = Context {
             center: LonLat { lon: 0.0, lat: 0.0 },
+            zoom: 0.0,
             theme_id: ThemeId::Dark,
             cursor: None,
         };
@@ -639,6 +641,7 @@ mod tests {
 
         let ctx = Context {
             center: LonLat { lon: 0.0, lat: 0.0 },
+            zoom: 0.0,
             theme_id: ThemeId::Dark,
             cursor: None,
         };

--- a/src/lua/bridge/palette_provider.rs
+++ b/src/lua/bridge/palette_provider.rs
@@ -213,6 +213,7 @@ mod tests {
     fn ctx() -> Context {
         Context {
             center: LonLat { lon: 0.0, lat: 0.0 },
+            zoom: 0.0,
             theme_id: ThemeId::Dark,
             cursor: None,
         }

--- a/src/lua/bridge/window_component.rs
+++ b/src/lua/bridge/window_component.rs
@@ -152,6 +152,11 @@ pub struct LuaWindowComponent {
     /// every dispatch path that carries a `Window`. The same Arc the
     /// setup state holds — `window.open` clones it in.
     center: Arc<Mutex<LonLat>>,
+    /// Zoom cell shared with the setup-state `ttymap.map` userdata
+    /// so `ttymap.map:zoom()` (getter form) returns the latest value
+    /// from inside this window's callbacks. Refreshed alongside
+    /// `center`.
+    zoom: Arc<Mutex<f64>>,
 }
 
 impl LuaWindowComponent {
@@ -164,17 +169,19 @@ impl LuaWindowComponent {
     /// (`lua[<log_tag>]: render() failed: …`) and as the fallback
     /// for [`Component::name`] when `spec.name` is missing.
     ///
-    /// `center` is the setup state's shared `Arc<Mutex<LonLat>>` —
-    /// refreshed each dispatch so `ttymap.map:center()` works from
-    /// inside the spec callbacks. The setup state owns the Sender /
-    /// Receiver pairs for jump / frame.export; this component does
-    /// not drain them (App drains them centrally).
+    /// `center` and `zoom` are the setup state's shared mutexes —
+    /// refreshed each dispatch so `ttymap.map:center()` and
+    /// `ttymap.map:zoom()` (no-arg getter) work from inside the spec
+    /// callbacks. The setup state owns the Sender / Receiver pairs
+    /// for jump / frame.export; this component does not drain them
+    /// (App drains them centrally).
     pub fn from_spec(
         lua: Lua,
         spec: Table,
         log_tag: &'static str,
         flag: CloseFlag,
         center: Arc<Mutex<LonLat>>,
+        zoom: Arc<Mutex<f64>>,
     ) -> mlua::Result<Self> {
         // Display name: spec's `name` if set, else the log tag.
         // Leak once; bounded by the number of windows opened.
@@ -199,6 +206,7 @@ impl LuaWindowComponent {
             has_render,
             footer_hints,
             center,
+            zoom,
         })
     }
 
@@ -209,6 +217,16 @@ impl LuaWindowComponent {
     fn refresh_center(&self, center: LonLat) {
         if let Ok(mut cell) = self.center.lock() {
             *cell = center;
+        }
+    }
+
+    /// Refresh the host-shared zoom level. Symmetric with
+    /// [`Self::refresh_center`]; called from the same dispatch
+    /// paths so `ttymap.map:zoom()` (getter form) tracks the live
+    /// value without callbacks taking it as an arg.
+    fn refresh_zoom(&self, zoom: f64) {
+        if let Ok(mut cell) = self.zoom.lock() {
+            *cell = zoom;
         }
     }
 
@@ -280,6 +298,7 @@ impl LuaWindowComponent {
 impl Component for LuaWindowComponent {
     fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
         self.refresh_center(win.ctx().center);
+        self.refresh_zoom(win.ctx().zoom);
         let action = self.dispatch_event(event);
         // Host-side jump / frame.export the callback queued hits the
         // setup state's senders, not per-window receivers. App drains
@@ -327,6 +346,7 @@ impl Component for LuaWindowComponent {
 
     fn poll(&mut self, win: &mut Window) {
         self.refresh_center(win.ctx().center);
+        self.refresh_zoom(win.ctx().zoom);
         // The only Lua-facing poll work this Component does is
         // honour the shared close flag. NO callback into the spec —
         // async work belongs on a `ttymap.api.frame.on_tick(fn)`
@@ -494,6 +514,11 @@ mod tests {
         Arc::new(Mutex::new(LonLat { lon: 0.0, lat: 0.0 }))
     }
 
+    /// Throwaway zoom cell, paired with [`dummy_center`].
+    fn dummy_zoom() -> Arc<Mutex<f64>> {
+        Arc::new(Mutex::new(0.0))
+    }
+
     /// Minimal helper: build a `LuaWindowComponent` from a Lua source
     /// snippet that returns the spec table directly. `window.open`
     /// gets its spec the same way — caller-side `eval`, resulting
@@ -502,8 +527,15 @@ mod tests {
     fn make(source: &str, log_tag: &'static str) -> LuaWindowComponent {
         let lua = mlua::Lua::new();
         let spec: Table = lua.load(source).eval().expect("eval spec");
-        LuaWindowComponent::from_spec(lua, spec, log_tag, CloseFlag::default(), dummy_center())
-            .expect("from_spec")
+        LuaWindowComponent::from_spec(
+            lua,
+            spec,
+            log_tag,
+            CloseFlag::default(),
+            dummy_center(),
+            dummy_zoom(),
+        )
+        .expect("from_spec")
     }
 
     #[test]
@@ -686,11 +718,19 @@ mod tests {
         let flag = CloseFlag::default();
         let lua = mlua::Lua::new();
         let spec: Table = lua.load(r#"return { name = "win" }"#).eval().unwrap();
-        let mut c =
-            LuaWindowComponent::from_spec(lua, spec, "win", flag.clone(), dummy_center()).unwrap();
+        let mut c = LuaWindowComponent::from_spec(
+            lua,
+            spec,
+            "win",
+            flag.clone(),
+            dummy_center(),
+            dummy_zoom(),
+        )
+        .unwrap();
 
         const CTX: Context = Context {
             center: LonLat { lon: 0.0, lat: 0.0 },
+            zoom: 0.0,
             theme_id: crate::theme::ThemeId::Dark,
             cursor: None,
         };
@@ -710,11 +750,19 @@ mod tests {
         let flag = CloseFlag::default();
         let lua = mlua::Lua::new();
         let spec: Table = lua.load(r#"return { name = "win" }"#).eval().unwrap();
-        let mut c =
-            LuaWindowComponent::from_spec(lua, spec, "win", flag.clone(), dummy_center()).unwrap();
+        let mut c = LuaWindowComponent::from_spec(
+            lua,
+            spec,
+            "win",
+            flag.clone(),
+            dummy_center(),
+            dummy_zoom(),
+        )
+        .unwrap();
 
         const CTX: Context = Context {
             center: LonLat { lon: 0.0, lat: 0.0 },
+            zoom: 0.0,
             theme_id: crate::theme::ThemeId::Dark,
             cursor: None,
         };

--- a/src/lua/bridge/window_handle.rs
+++ b/src/lua/bridge/window_handle.rs
@@ -145,6 +145,7 @@ mod tests {
 
         const CTX: Context = Context {
             center: LonLat { lon: 0.0, lat: 0.0 },
+            zoom: 0.0,
             theme_id: crate::theme::ThemeId::Dark,
             cursor: None,
         };

--- a/src/lua/ttymap/mod.rs
+++ b/src/lua/ttymap/mod.rs
@@ -24,6 +24,8 @@
 //! ttymap.map    :jump(lon, lat)             recentre the map (fire-and-forget)
 //! ttymap.map    :zoom(level)                set zoom directly (clamped to map's
 //!                                            allowed range; fire-and-forget)
+//! ttymap.map    :zoom() -> level             current zoom (no-arg getter form),
+//!                                            refreshed per dispatch
 //! ttymap.map    :fly_to(lon, lat, zoom)     composite recenter + zoom in one
 //!                                            dispatch (avoids the intermediate
 //!                                            new-centre / old-zoom frame)
@@ -242,6 +244,12 @@ pub struct LuaHostHandles {
     pub fly_to_rx: mpsc::Receiver<(LonLat, f64)>,
     pub export_rx: mpsc::Receiver<()>,
     pub center: Arc<Mutex<LonLat>>,
+    /// Latest zoom level mirrored from the host so
+    /// `ttymap.map:zoom()` (no-arg getter form) returns the current
+    /// zoom from any callback context. Same Arc held by the
+    /// [`HostMap`] userdata; refreshed on the dispatch paths that
+    /// also refresh `center`.
+    pub zoom: Arc<Mutex<f64>>,
     /// Components queued by `ttymap.api.window.open` (and, in A6,
     /// `ttymap.api.palette.open`). The App drains this per frame and
     /// pushes each component onto the compositor stack.
@@ -341,6 +349,7 @@ pub fn install(
     // requires `T: Send`, and the Sender never moves across threads.
     let (push_tx, push_rx) = mpsc::channel::<Box<dyn crate::compositor::Component>>();
     let center = Arc::new(Mutex::new(LonLat { lon: 0.0, lat: 0.0 }));
+    let zoom = Arc::new(Mutex::new(0.0_f64));
 
     let ttymap = lua.create_table()?;
     ttymap.set(
@@ -356,6 +365,7 @@ pub fn install(
             zoom_tx,
             fly_to_tx,
             center: center.clone(),
+            zoom: zoom.clone(),
         })?,
     )?;
     ttymap.set("json", lua.create_userdata(HostJson)?)?;
@@ -448,6 +458,7 @@ pub fn install(
     let window_api = lua.create_table()?;
     let push_tx_for_window = push_tx.clone();
     let center_for_window = center.clone();
+    let zoom_for_window = zoom.clone();
     window_api.set(
         "open",
         lua.create_function(
@@ -470,6 +481,7 @@ pub fn install(
                     tag,
                     flag.clone(),
                     center_for_window.clone(),
+                    zoom_for_window.clone(),
                 )?;
                 // Same-thread send: the channel never crosses threads.
                 // `send` returns Err only when the receiver has been
@@ -640,6 +652,7 @@ pub fn install(
         fly_to_rx,
         export_rx,
         center,
+        zoom,
         push_rx,
     })
 }
@@ -691,6 +704,7 @@ struct HostMap {
     zoom_tx: mpsc::Sender<f64>,
     fly_to_tx: mpsc::Sender<(LonLat, f64)>,
     center: Arc<Mutex<LonLat>>,
+    zoom: Arc<Mutex<f64>>,
 }
 
 impl UserData for HostMap {
@@ -706,13 +720,23 @@ impl UserData for HostMap {
             Ok(())
         });
 
-        // `ttymap.map:zoom(level)` — request the map zoom directly.
-        // Clamping to the map's `[min_zoom, max_zoom]` happens host-
-        // side in `MapState::process_action` so plugins don't need to
-        // know the bounds. Fire-and-forget; symmetric with `jump`.
-        methods.add_method("zoom", |_, this, level: f64| {
-            let _ = this.zoom_tx.send(level);
-            Ok(())
+        // `ttymap.map:zoom([level])` — overloaded:
+        //   `:zoom(level)` queues a zoom request (clamped host-side
+        //   in `MapState::process_action`). Fire-and-forget.
+        //   `:zoom()` (no arg) returns the current zoom level read
+        //   from the shared `Arc<Mutex<f64>>` the host refreshes on
+        //   the same dispatch paths it refreshes `:center()` on.
+        // mlua dispatches by the supplied argument signature: nil →
+        // `None` (getter), number → `Some(level)` (setter).
+        methods.add_method("zoom", |_, this, level: Option<f64>| match level {
+            Some(z) => {
+                let _ = this.zoom_tx.send(z);
+                Ok(mlua::Value::Nil)
+            }
+            None => {
+                let z = *this.zoom.lock().expect("zoom mutex poisoned");
+                Ok(mlua::Value::Number(z))
+            }
         });
 
         // `ttymap.map:fly_to(lon, lat, zoom)` — composite recenter +
@@ -1057,6 +1081,23 @@ mod tests {
         lua.load("ttymap.map:zoom(7.5)").exec().expect("exec");
         let z = handles.zoom_rx.try_recv().expect("zoom must be queued");
         assert!((z - 7.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn host_map_zoom_getter_reads_shared_cell() {
+        // `ttymap.map:zoom()` (no args) reads the host-mirrored zoom
+        // cell. The host writes via the same Arc the userdata holds,
+        // so simulate a dispatch refresh by writing to `handles.zoom`
+        // directly and assert Lua sees the new value. Symmetric with
+        // the `:center()` pattern. Confirms (a) no-arg call doesn't
+        // accidentally fall through to the setter and (b) the value
+        // round-trips as a Lua number.
+        let (lua, handles) = install_for_test();
+        *handles.zoom.lock().unwrap() = 9.25;
+        let z: f64 = lua.load("return ttymap.map:zoom()").eval().expect("eval");
+        assert!((z - 9.25).abs() < 1e-9);
+        // Calling the getter must not enqueue a setter request.
+        assert!(handles.zoom_rx.try_recv().is_err());
     }
 
     #[test]

--- a/src/map/state.rs
+++ b/src/map/state.rs
@@ -77,6 +77,9 @@ impl MapState {
     pub fn center(&self) -> LonLat {
         self.center
     }
+    pub fn zoom(&self) -> f64 {
+        self.zoom
+    }
     pub fn stop(&mut self) {
         self.running = false;
     }

--- a/src/palette/mod.rs
+++ b/src/palette/mod.rs
@@ -225,6 +225,7 @@ mod tests {
     const NONE: KeyModifiers = KeyModifiers::NONE;
     const CTX: Context = Context {
         center: LonLat { lon: 0.0, lat: 0.0 },
+        zoom: 0.0,
         theme_id: ThemeId::Dark,
         cursor: None,
     };


### PR DESCRIPTION
Closes #193.

## Summary

- Overload `ttymap.map:zoom`: `:zoom(level)` keeps fire-and-forget setter semantics; `:zoom()` (no arg) returns the current zoom level. mlua dispatches by argument signature via `Option<f64>`.
- Mirror the existing `:center()` plumbing: shared `Arc<Mutex<f64>>` between `HostMap` userdata and the host, refreshed on the same dispatch path the window component already uses for `center`.
- Adds `MapState::zoom()` getter, `Context.zoom: f64`, and `LuaWindowComponent::refresh_zoom` symmetrical to `refresh_center`.

## Why

After #190 added the setter, the only way for plugins to read zoom was from inside an `on_tick(map)` callback through `MapApi:zoom()`. A `register_keybind('m', ...)` callback (e.g. a bookmark plugin grabbing `(lon, lat, zoom)` in one place) ran in setup state with no access to zoom. This closes that gap.

## Test plan

- [x] `cargo test --lib` — 380 pass including new `host_map_zoom_getter_reads_shared_cell`
- [x] `cargo clippy -- -D warnings` (pre-commit) — clean
- [x] `cargo fmt --check` (pre-commit) — clean
- [x] New test verifies (a) no-arg call doesn't fall through to the setter (assert `zoom_rx.try_recv().is_err()`), (b) value round-trips as a Lua number through the shared cell.