### PR TITLE
chore: bump MSRV to 1.88, refresh Cargo.lock, fix clippy 1.95 lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "earcut"
-version = "0.4.5"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
+checksum = "6fdec2c01e52bd27b6889d73cbf783977c5c80631b4a9a1fccc977da3c1f3a31"
 dependencies = [
  "num-traits",
 ]
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1340,9 +1340,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1381,9 +1381,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1729,9 +1729,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -1761,9 +1761,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2114,9 +2114,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core",
 ]
@@ -2158,7 +2158,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2209,7 +2209,7 @@ dependencies = [
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2391,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2404,18 +2404,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2902,9 +2902,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3043,14 +3043,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sgp4",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -3078,7 +3078,7 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3089,9 +3089,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -3189,11 +3189,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3202,14 +3202,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3220,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3230,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3240,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3253,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -3296,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3585,6 +3585,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ttymap"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 description = "A terminal map viewer that renders Mapbox Vector Tiles as Unicode Braille characters."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Kohei-Wada/ttymap"

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -380,15 +380,15 @@ fn register_plugins_in(
     plugins.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
 
     for (stem, path) in plugins {
-        if let Some(seen) = seen.as_deref_mut() {
-            if !seen.insert(stem.clone()) {
-                log::info!(
-                    "lua[{}]: shadowed by higher-priority runtime layer, skipping {}",
-                    stem,
-                    path.display()
-                );
-                continue;
-            }
+        if let Some(seen) = seen.as_deref_mut()
+            && !seen.insert(stem.clone())
+        {
+            log::info!(
+                "lua[{}]: shadowed by higher-priority runtime layer, skipping {}",
+                stem,
+                path.display()
+            );
+            continue;
         }
         if disable.iter().any(|d| d == &stem) {
             log::info!("lua[{}]: disabled via ttymap.opt.disable, skipping", stem);

--- a/src/lua/registry.rs
+++ b/src/lua/registry.rs
@@ -101,7 +101,7 @@ mod tests {
     fn lua_with_counter(global: &str) -> (Lua, RegistryKey) {
         let lua = Lua::new();
         // Counter starts at 0; each call bumps it by 1.
-        lua.load(&format!(
+        lua.load(format!(
             r#"
             {global} = 0
             function tick_{global}(_map)

--- a/src/lua/ttymap/map_api.rs
+++ b/src/lua/ttymap/map_api.rs
@@ -277,7 +277,6 @@ mod tests {
             lua.load(r#"map:polyline({{0,0},{1,1}}, "accent")"#).exec()
         })
         .expect("scope");
-        drop(api);
         assert_eq!(sink.len(), 1);
         assert_eq!(sink[0].coords.len(), 2);
         assert_eq!(sink[0].coords[0], LonLat { lon: 0.0, lat: 0.0 });
@@ -298,7 +297,6 @@ mod tests {
             lua.load(r#"map:polyline({{0,0}})"#).exec()
         })
         .expect("scope");
-        drop(api);
         assert!(sink.is_empty());
     }
 
@@ -318,7 +316,6 @@ mod tests {
             lua.load(r#"map:polyline({{0,0},{1,1}}, "road")"#).exec()
         })
         .expect("scope");
-        drop(api);
         assert_eq!(sink.len(), 1);
         assert_eq!(
             sink[0].color, road_idx,
@@ -342,7 +339,6 @@ mod tests {
             lua.load(r#"map:polyline({{0,0},{1,1}}, "zzzz")"#).exec()
         })
         .expect("scope");
-        drop(api);
         assert_eq!(sink.len(), 1);
         assert_eq!(sink[0].color, accent_idx);
     }
@@ -362,7 +358,6 @@ mod tests {
             lua.load(r#"map:polyline({{0,0},{1,1}}, 222)"#).exec()
         })
         .expect("scope");
-        drop(api);
         assert_eq!(sink.len(), 1);
         assert_eq!(
             sink[0].color, 222,
@@ -385,7 +380,6 @@ mod tests {
                 .exec()
         })
         .expect("scope");
-        drop(api);
         assert_eq!(sink.len(), 2);
         assert_eq!(sink[0].color, 0, "negative integer clamps to 0");
         assert_eq!(sink[1].color, 255, ">255 integer clamps to 255");
@@ -407,7 +401,6 @@ mod tests {
                 lua.load(r#"return map:road_color()"#).eval::<u8>()
             })
             .expect("scope");
-        drop(api);
         assert_eq!(result, DARK.road_motorway, "matches DARK.road_motorway");
     }
 
@@ -426,7 +419,6 @@ mod tests {
                 .exec()
         })
         .expect("scope");
-        drop(api);
         assert_eq!(sink.len(), 1);
         assert_eq!(sink[0].color, DARK.road_motorway);
     }
@@ -446,7 +438,6 @@ mod tests {
             lua.load(r#"map:point(0, 0, "x", 196)"#).exec()
         })
         .expect("scope");
-        drop(api);
         let mut found = false;
         for x in 0..area.width {
             for y in 0..area.height {
@@ -479,7 +470,6 @@ mod tests {
             lua.load(r#"map:label(0, 0, "hi", 214)"#).exec()
         })
         .expect("scope");
-        drop(api);
         let mut found = false;
         for x in 0..area.width {
             for y in 0..area.height {

--- a/src/map/render/canvas.rs
+++ b/src/map/render/canvas.rs
@@ -407,7 +407,7 @@ mod tests {
         // Clip first, then polygon — should be fast
         let clipped = canvas.clip_polygon(&[ring]);
         for r in &clipped {
-            canvas.polygon(&[r.clone()], 7);
+            canvas.polygon(std::slice::from_ref(r), 7);
         }
         // Should complete without hanging
     }
@@ -444,7 +444,7 @@ mod tests {
         }
         let clipped = canvas.clip_polygon(&rings);
         for r in &clipped {
-            canvas.polygon(&[r.clone()], 7);
+            canvas.polygon(std::slice::from_ref(r), 7);
         }
         // Should complete without hanging
     }

--- a/src/map/render/geom/clip.rs
+++ b/src/map/render/geom/clip.rs
@@ -273,8 +273,8 @@ mod tests {
         // Should produce a polygon covering (0,0)-(50,50) area
         assert!(clipped.len() >= 3);
         for &(x, y) in &clipped {
-            assert!(x >= 0 && x <= 100, "x={} out of bounds", x);
-            assert!(y >= 0 && y <= 100, "y={} out of bounds", y);
+            assert!((0..=100).contains(&x), "x={} out of bounds", x);
+            assert!((0..=100).contains(&y), "y={} out of bounds", y);
         }
     }
 

--- a/src/map/render/renderer.rs
+++ b/src/map/render/renderer.rs
@@ -1021,7 +1021,7 @@ mod tests {
         let styler = Arc::new(Styler::new(crate::theme::ThemeId::Dark));
         let mut renderer = Renderer::new(styler, "en".to_string(), 320, 320);
         let tile_only = renderer
-            .draw(&[tile.clone()], 6.0, center, &[])
+            .draw(std::slice::from_ref(&tile), 6.0, center, &[])
             .expect("frame");
         let combined = renderer
             .draw(&[tile], 6.0, center, &[overlay])


### PR DESCRIPTION
## Summary

- Bump \`rust-version\` from 1.85 to 1.88. Resolver was pinning 24+ deps to "1.85-compatible" versions, producing a wall of "Adding X (available: Y, requires Rust 1.86)" warnings on every \`cargo install --path .\`. The new floor lets it pick newest semver-compatible for icu_*, idna, unicode-width, rustls, wasm-bindgen, wit-bindgen (0.51 → 0.57.1), etc.
- Refresh Cargo.lock with those updates.
- Fix clippy 1.95 lints triggered by the newer toolchain (zero behaviour change):
  - \`collapsible_if\` (lua/mod.rs) — let-Some + bool guard via \`&&\`
  - \`needless_borrows_for_generic_args\` (lua/registry.rs) — drop \`&\`
  - \`cloned_ref_to_slice_refs\` (canvas, renderer) — \`std::slice::from_ref\`
  - \`manual_range_contains\` (geom/clip) — \`(0..=100).contains(&x)\`
  - \`drop_non_drop\` (ttymap/map_api, 10 sites) — drop the explicit \`drop(api)\`; NLL ends the \`&mut sink\` borrow at last use anyway

Major-version bumps still pending (separate PRs, each needs API audit): crossterm 0.29, lru 0.18, reqwest 0.13.

## Test plan

- [x] \`cargo test --lib\` — 380 pass
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo build --release\` — clean