### PR TITLE
refactor(lua): move center/zoom refresh from window component to App

### DIFF
--- a/docs/lua-architecture.md
+++ b/docs/lua-architecture.md
@@ -178,9 +178,12 @@ via OR-merge into existing braille cells).
 ## Live host-state read-back
 
 `ttymap.map:center()` and `ttymap.map:zoom()` (no-arg getter) read
-shared `Arc<Mutex<...>>` cells. The host refreshes them on dispatch
-paths that carry a `Window` (handled in `LuaWindowComponent`); cells
-are kept in sync via the same Arc held by `HostMap` userdata.
+shared `Arc<Mutex<...>>` cells. The host refreshes them once per
+loop iteration in `App::drain_lua_host_handles`, before draining each
+plugin's setup-state channels. That means the values are correct in
+**every** callback path — palette `invoke`, `register_keybind`
+callbacks, `on_tick` — not just inside an active window's dispatch.
+Cells are shared with `HostMap` userdata via the same Arc.
 
 ## Runtime path resolution
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -294,13 +294,30 @@ impl App {
     }
 
     /// Drain every Lua plugin's setup-state receivers once.
+    ///
+    /// Before draining, refreshes the host-shared `center` / `zoom`
+    /// cells each plugin's `ttymap.map:center()` / `:zoom()` reads
+    /// from. Doing this once at the App level — instead of from
+    /// inside each `LuaWindowComponent` dispatch — means the values
+    /// are correct for *every* callback path (palette invoke,
+    /// register_keybind, on_tick), not just paths that go through
+    /// an active window.
+    ///
     /// Components queued via `ttymap.api.window.open` /
     /// `palette.open` get pushed onto the compositor stack inline;
     /// `ttymap.map:jump` and `ttymap.api.frame.export` requests are
     /// returned as [`AppMsg`]s for the caller to dispatch.
     fn drain_lua_host_handles(&mut self) -> Vec<AppMsg> {
+        let center = self.map.center();
+        let zoom = self.map.zoom();
         let mut msgs = Vec::new();
         for handles in &self.lua_host_handles {
+            if let Ok(mut cell) = handles.center.lock() {
+                *cell = center;
+            }
+            if let Ok(mut cell) = handles.zoom.lock() {
+                *cell = zoom;
+            }
             // Push queued components first so the same tick's
             // compositor.poll already sees them.
             while let Ok(component) = handles.push_rx.try_recv() {
@@ -332,8 +349,6 @@ impl App {
 
     fn context(&self) -> Context {
         Context {
-            center: self.map.center(),
-            zoom: self.map.zoom(),
             theme_id: self.theme_id,
             cursor: self.cursor,
         }

--- a/src/compositor/base.rs
+++ b/src/compositor/base.rs
@@ -151,13 +151,10 @@ mod tests {
     use super::super::Context;
     use super::super::window::WindowOps;
     use super::*;
-    use crate::geo::LonLat;
     use crate::theme::ThemeId;
 
     const NONE: KeyModifiers = KeyModifiers::NONE;
     const CTX: Context = Context {
-        center: LonLat { lon: 0.0, lat: 0.0 },
-        zoom: 0.0,
         theme_id: ThemeId::Dark,
         cursor: None,
     };

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -40,7 +40,6 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 
 use crate::app::AppMsg;
-use crate::geo::LonLat;
 use crate::theme::ThemeId;
 use crate::theme::UiTheme;
 
@@ -72,8 +71,6 @@ fn intercept_focus_key(event: KeyEvent) -> Option<AppMsg> {
 /// [`Window::ctx`](window::Window::ctx).
 #[derive(Debug, Clone, Copy)]
 pub struct Context {
-    pub center: LonLat,
-    pub zoom: f64,
     pub theme_id: ThemeId,
     /// Latest mouse cursor position in absolute terminal cells.
     /// `None` until the first mouse event arrives (or always, on
@@ -592,8 +589,6 @@ mod tests {
     #[test]
     fn push_always_stacks_new_instance() {
         let ctx = Context {
-            center: LonLat { lon: 0.0, lat: 0.0 },
-            zoom: 0.0,
             theme_id: ThemeId::Dark,
             cursor: None,
         };
@@ -640,8 +635,6 @@ mod tests {
         }
 
         let ctx = Context {
-            center: LonLat { lon: 0.0, lat: 0.0 },
-            zoom: 0.0,
             theme_id: ThemeId::Dark,
             cursor: None,
         };

--- a/src/lua/bridge/palette_provider.rs
+++ b/src/lua/bridge/palette_provider.rs
@@ -212,8 +212,6 @@ mod tests {
 
     fn ctx() -> Context {
         Context {
-            center: LonLat { lon: 0.0, lat: 0.0 },
-            zoom: 0.0,
             theme_id: ThemeId::Dark,
             cursor: None,
         }

--- a/src/lua/bridge/window_component.rs
+++ b/src/lua/bridge/window_component.rs
@@ -33,8 +33,6 @@
 //! Per audit §13: errors are logged and recovered, never propagated.
 //! A buggy plugin must not take the host down.
 
-use std::sync::{Arc, Mutex};
-
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mlua::{Lua, Table};
 use ratatui::text::{Line, Span};
@@ -45,7 +43,6 @@ use super::window_handle::CloseFlag;
 use crate::compositor::Component;
 use crate::compositor::layout::PanelAnchor;
 use crate::compositor::window::{RenderWindow, Window};
-use crate::geo::LonLat;
 use crate::theme::StyleKind;
 
 // ── Layout ─────────────────────────────────────────────────────────
@@ -146,17 +143,6 @@ pub struct LuaWindowComponent {
     /// `&'static str` without leaking per call. Empty when the spec
     /// omits the field.
     footer_hints: Vec<(&'static str, &'static str)>,
-    /// Map centre cell shared with the setup-state `ttymap.map`
-    /// userdata so `ttymap.map:center()` returns the latest value
-    /// from inside this window's callbacks. Refreshed at the start of
-    /// every dispatch path that carries a `Window`. The same Arc the
-    /// setup state holds — `window.open` clones it in.
-    center: Arc<Mutex<LonLat>>,
-    /// Zoom cell shared with the setup-state `ttymap.map` userdata
-    /// so `ttymap.map:zoom()` (getter form) returns the latest value
-    /// from inside this window's callbacks. Refreshed alongside
-    /// `center`.
-    zoom: Arc<Mutex<f64>>,
 }
 
 impl LuaWindowComponent {
@@ -169,19 +155,15 @@ impl LuaWindowComponent {
     /// (`lua[<log_tag>]: render() failed: …`) and as the fallback
     /// for [`Component::name`] when `spec.name` is missing.
     ///
-    /// `center` and `zoom` are the setup state's shared mutexes —
-    /// refreshed each dispatch so `ttymap.map:center()` and
-    /// `ttymap.map:zoom()` (no-arg getter) work from inside the spec
-    /// callbacks. The setup state owns the Sender / Receiver pairs
-    /// for jump / frame.export; this component does not drain them
-    /// (App drains them centrally).
+    /// The setup state owns the Sender / Receiver pairs for jump /
+    /// frame.export and the host-shared `center` / `zoom` mutexes;
+    /// this component does not drain them (App drains them
+    /// centrally per loop iteration).
     pub fn from_spec(
         lua: Lua,
         spec: Table,
         log_tag: &'static str,
         flag: CloseFlag,
-        center: Arc<Mutex<LonLat>>,
-        zoom: Arc<Mutex<f64>>,
     ) -> mlua::Result<Self> {
         // Display name: spec's `name` if set, else the log tag.
         // Leak once; bounded by the number of windows opened.
@@ -205,29 +187,7 @@ impl LuaWindowComponent {
             layout,
             has_render,
             footer_hints,
-            center,
-            zoom,
         })
-    }
-
-    /// Refresh the host-shared map centre. Called at the start of
-    /// every dispatch path that carries a `Window` so
-    /// `ttymap.map:center()` returns up-to-date values without each
-    /// callback having to take it as an arg.
-    fn refresh_center(&self, center: LonLat) {
-        if let Ok(mut cell) = self.center.lock() {
-            *cell = center;
-        }
-    }
-
-    /// Refresh the host-shared zoom level. Symmetric with
-    /// [`Self::refresh_center`]; called from the same dispatch
-    /// paths so `ttymap.map:zoom()` (getter form) tracks the live
-    /// value without callbacks taking it as an arg.
-    fn refresh_zoom(&self, zoom: f64) {
-        if let Ok(mut cell) = self.zoom.lock() {
-            *cell = zoom;
-        }
     }
 
     /// Pull the `render()` lines from the Lua spec as raw line
@@ -297,8 +257,6 @@ impl LuaWindowComponent {
 
 impl Component for LuaWindowComponent {
     fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
-        self.refresh_center(win.ctx().center);
-        self.refresh_zoom(win.ctx().zoom);
         let action = self.dispatch_event(event);
         // Host-side jump / frame.export the callback queued hits the
         // setup state's senders, not per-window receivers. App drains
@@ -345,8 +303,6 @@ impl Component for LuaWindowComponent {
     }
 
     fn poll(&mut self, win: &mut Window) {
-        self.refresh_center(win.ctx().center);
-        self.refresh_zoom(win.ctx().zoom);
         // The only Lua-facing poll work this Component does is
         // honour the shared close flag. NO callback into the spec —
         // async work belongs on a `ttymap.api.frame.on_tick(fn)`
@@ -506,19 +462,6 @@ fn key_code_to_lua(code: KeyCode) -> (&'static str, Option<char>) {
 mod tests {
     use super::*;
 
-    /// Throwaway centre cell for tests that don't care about the
-    /// host-API drain. The setup state owns the channels in
-    /// production; per-window tests build a fresh Arc<Mutex<LonLat>>
-    /// each call so dispatch refresh has somewhere to write.
-    fn dummy_center() -> Arc<Mutex<LonLat>> {
-        Arc::new(Mutex::new(LonLat { lon: 0.0, lat: 0.0 }))
-    }
-
-    /// Throwaway zoom cell, paired with [`dummy_center`].
-    fn dummy_zoom() -> Arc<Mutex<f64>> {
-        Arc::new(Mutex::new(0.0))
-    }
-
     /// Minimal helper: build a `LuaWindowComponent` from a Lua source
     /// snippet that returns the spec table directly. `window.open`
     /// gets its spec the same way — caller-side `eval`, resulting
@@ -527,15 +470,7 @@ mod tests {
     fn make(source: &str, log_tag: &'static str) -> LuaWindowComponent {
         let lua = mlua::Lua::new();
         let spec: Table = lua.load(source).eval().expect("eval spec");
-        LuaWindowComponent::from_spec(
-            lua,
-            spec,
-            log_tag,
-            CloseFlag::default(),
-            dummy_center(),
-            dummy_zoom(),
-        )
-        .expect("from_spec")
+        LuaWindowComponent::from_spec(lua, spec, log_tag, CloseFlag::default()).expect("from_spec")
     }
 
     #[test]
@@ -718,19 +653,9 @@ mod tests {
         let flag = CloseFlag::default();
         let lua = mlua::Lua::new();
         let spec: Table = lua.load(r#"return { name = "win" }"#).eval().unwrap();
-        let mut c = LuaWindowComponent::from_spec(
-            lua,
-            spec,
-            "win",
-            flag.clone(),
-            dummy_center(),
-            dummy_zoom(),
-        )
-        .unwrap();
+        let mut c = LuaWindowComponent::from_spec(lua, spec, "win", flag.clone()).unwrap();
 
         const CTX: Context = Context {
-            center: LonLat { lon: 0.0, lat: 0.0 },
-            zoom: 0.0,
             theme_id: crate::theme::ThemeId::Dark,
             cursor: None,
         };
@@ -750,19 +675,9 @@ mod tests {
         let flag = CloseFlag::default();
         let lua = mlua::Lua::new();
         let spec: Table = lua.load(r#"return { name = "win" }"#).eval().unwrap();
-        let mut c = LuaWindowComponent::from_spec(
-            lua,
-            spec,
-            "win",
-            flag.clone(),
-            dummy_center(),
-            dummy_zoom(),
-        )
-        .unwrap();
+        let mut c = LuaWindowComponent::from_spec(lua, spec, "win", flag.clone()).unwrap();
 
         const CTX: Context = Context {
-            center: LonLat { lon: 0.0, lat: 0.0 },
-            zoom: 0.0,
             theme_id: crate::theme::ThemeId::Dark,
             cursor: None,
         };

--- a/src/lua/bridge/window_handle.rs
+++ b/src/lua/bridge/window_handle.rs
@@ -136,7 +136,6 @@ mod tests {
         use crate::compositor::Component;
         use crate::compositor::Context;
         use crate::compositor::window::{Window, WindowOps};
-        use crate::geo::LonLat;
 
         /// Inert inner component — no-op for every method so the
         /// wrapper's behaviour is the only thing under test.
@@ -144,8 +143,6 @@ mod tests {
         impl Component for Inert {}
 
         const CTX: Context = Context {
-            center: LonLat { lon: 0.0, lat: 0.0 },
-            zoom: 0.0,
             theme_id: crate::theme::ThemeId::Dark,
             cursor: None,
         };

--- a/src/lua/ttymap/mod.rs
+++ b/src/lua/ttymap/mod.rs
@@ -457,8 +457,6 @@ pub fn install(
 
     let window_api = lua.create_table()?;
     let push_tx_for_window = push_tx.clone();
-    let center_for_window = center.clone();
-    let zoom_for_window = zoom.clone();
     window_api.set(
         "open",
         lua.create_function(
@@ -475,14 +473,8 @@ pub fn install(
                 // must be a clone of it (cheap Arc bump, no copy of the
                 // VM). When `LuaWindowComponent` later calls into those
                 // callbacks, the same upvalue scope is in scope.
-                let component = LuaWindowComponent::from_spec(
-                    lua.clone(),
-                    spec,
-                    tag,
-                    flag.clone(),
-                    center_for_window.clone(),
-                    zoom_for_window.clone(),
-                )?;
+                let component =
+                    LuaWindowComponent::from_spec(lua.clone(), spec, tag, flag.clone())?;
                 // Same-thread send: the channel never crosses threads.
                 // `send` returns Err only when the receiver has been
                 // dropped, which happens at App teardown — log + carry

--- a/src/palette/mod.rs
+++ b/src/palette/mod.rs
@@ -218,14 +218,11 @@ mod tests {
     use super::provider::{PaletteItem, PaletteProvider};
     use super::*;
     use crate::app::AppMsg;
-    use crate::geo::LonLat;
     use crate::map::Action;
     use crate::theme::ThemeId;
 
     const NONE: KeyModifiers = KeyModifiers::NONE;
     const CTX: Context = Context {
-        center: LonLat { lon: 0.0, lat: 0.0 },
-        zoom: 0.0,
         theme_id: ThemeId::Dark,
         cursor: None,
     };


### PR DESCRIPTION
## Summary

\`LuaWindowComponent::refresh_center\` / \`refresh_zoom\` wrote into the shared \`Arc<Mutex<...>>\` cells from inside its \`handle_event\` / \`poll\`. That meant \`ttymap.map:center()\` and \`ttymap.map:zoom()\` (getter form) only saw fresh values when dispatch went through an active window. Plugins reading from a \`register_keybind\` callback or palette \`invoke\` without a window open got initial \`(0, 0)\` / \`0.0\`.

\`App::drain_lua_host_handles\` now refreshes both cells from \`self.map.center()\` / \`self.map.zoom()\` once per loop iteration, before draining channels. Live values reach every callback path uniformly.

Knock-on cleanup the new architecture made trivial:

- \`Context.center\` / \`Context.zoom\` removed (the only consumer was the old refresh path)
- \`LuaWindowComponent\` loses two Arc fields, both \`refresh_*\` methods, and the constructor args that fed them
- \`ttymap::install\` no longer clones \`center_for_window\` / \`zoom_for_window\` into the window factory closure
- Tests drop \`dummy_center\` / \`dummy_zoom\` helpers and the redundant Context init fields
- \`docs/lua-architecture.md\` "Live host-state read-back" section rewritten to document the new refresh point

Net: **+32 / -125**.

## Test plan

- [x] \`cargo test --lib\` — 380 pass
- [x] \`cargo clippy -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] No behavioural regression for window-component path: previous timing was "refresh on dispatch into the window"; new timing is "refresh at start of loop iteration before drain". The window dispatch happens later in the same iteration, so it sees the same values it would have seen.
- [x] Behavioural improvement for non-window paths: register_keybind callback firing in setup state now reads correct center/zoom on the very first key press; previously read 0.0 until a window had ever dispatched.