### PR TITLE
refactor(compositor): tag stack entries with stable CardId

### DIFF
--- a/src/frontend/compositor/mod.rs
+++ b/src/frontend/compositor/mod.rs
@@ -80,6 +80,30 @@ fn intercept_focus_key(event: KeyEvent) -> Option<UserIntent> {
     None
 }
 
+// ── Stable component identity ──────────────────────────────────────
+
+/// Stable identity for a component on the [`Compositor`] stack.
+///
+/// Allocated by [`CardId::next`] from a process-global atomic counter
+/// so external actors (Lua handles, future async sources) can reserve
+/// an id at the call site that opens a card and use it later to
+/// request a close — even though the actual push may have applied on
+/// a later iteration. Uniqueness across the program lifetime; we
+/// never recycle ids.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CardId(u64);
+
+impl CardId {
+    /// Allocate a fresh `CardId`. Single atomic increment; the
+    /// counter is process-global so any caller (compositor's own
+    /// `push`, Lua bridge's `api.card.open`) gets a unique id without
+    /// coordination.
+    pub fn next() -> Self {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        Self(COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
+    }
+}
+
 // ── Component + event routing ──────────────────────────────────────
 
 /// Read-only snapshot of app-level context a component may need
@@ -198,7 +222,7 @@ use window::{Window, WindowOps};
 /// [`BaseLayer`] even while modals are rendered above it, which is
 /// how the old `Focus::Background` state maps into this design.
 pub struct Compositor {
-    stack: Vec<Box<dyn Component>>,
+    stack: Vec<(CardId, Box<dyn Component>)>,
     /// Index of the component that receives key events first.
     /// Invariant: `focused_idx < stack.len()` whenever the stack is
     /// non-empty. After every push, this becomes the new top; after
@@ -214,9 +238,34 @@ impl Compositor {
         }
     }
 
-    pub fn push(&mut self, c: Box<dyn Component>) {
-        self.stack.push(c);
+    /// Push a component, allocating a fresh [`CardId`] internally.
+    /// Used for in-process pushes whose caller doesn't need to
+    /// reference the id later (e.g. [`BaseLayer`] at startup,
+    /// palette at startup, or `Window::open` from inside a key
+    /// handler).
+    pub fn push(&mut self, c: Box<dyn Component>) -> CardId {
+        let id = CardId::next();
+        self.push_with_id(id, c);
+        id
+    }
+
+    /// Push a component with a caller-supplied id. Used by external
+    /// sources (Lua `api.card.open`) that need to reserve the id at
+    /// the call site so they can return a handle whose close path
+    /// targets this specific component.
+    pub fn push_with_id(&mut self, id: CardId, c: Box<dyn Component>) {
+        self.stack.push((id, c));
         self.focused_idx = self.stack.len() - 1;
+    }
+
+    /// Pop the component matching `id` off the stack. Silent no-op
+    /// when `id` isn't present (handle closed twice, or component
+    /// already self-closed via `win.close()`).
+    pub fn close_by_id(&mut self, id: CardId) {
+        if let Some(idx) = self.stack.iter().position(|(i, _)| *i == id) {
+            self.stack.remove(idx);
+            self.clamp_focus_after_shrink();
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -259,7 +308,7 @@ impl Compositor {
         let mut ops = WindowOps::default();
         {
             let mut win = Window::new(&mut ops, ctx, event_tx);
-            self.stack[focused].handle_event(event, &mut win);
+            self.stack[focused].1.handle_event(event, &mut win);
         }
         // Fall-through: only when the hook queued nothing *and*
         // explicitly called `ignore()`, and the focus isn't already
@@ -268,7 +317,7 @@ impl Compositor {
             let mut ops = WindowOps::default();
             {
                 let mut win = Window::new(&mut ops, ctx, event_tx);
-                self.stack[0].handle_event(event, &mut win);
+                self.stack[0].1.handle_event(event, &mut win);
             }
             self.apply_ops(0, ops);
             return;
@@ -289,8 +338,7 @@ impl Compositor {
             self.clamp_focus_after_shrink();
         }
         for c in ops.opens {
-            self.stack.push(c);
-            self.focused_idx = self.stack.len() - 1;
+            self.push(c);
         }
     }
 
@@ -306,7 +354,7 @@ impl Compositor {
             let mut ops = WindowOps::default();
             {
                 let mut win = Window::new(&mut ops, ctx, event_tx);
-                self.stack[i].poll(&mut win);
+                self.stack[i].1.poll(&mut win);
             }
             self.apply_ops(i, ops);
         }
@@ -340,12 +388,12 @@ impl Compositor {
         // lookup — find the topmost floating component and paint
         // it. Always focused when present (the palette consumes
         // input the moment it opens).
-        if let Some((idx, c)) = self
+        if let Some((idx, (_, c))) = self
             .stack
             .iter()
             .enumerate()
             .rev()
-            .find(|(_, c)| c.placement() == Placement::Floating)
+            .find(|(_, (_, c))| c.placement() == Placement::Floating)
         {
             let focused = idx == self.focused_idx;
             let mut win = window::RenderWindow::new(f, map_area, theme, ctx).focused(focused);
@@ -378,7 +426,7 @@ impl Compositor {
     pub fn sidebar_component_count(&self) -> usize {
         self.stack
             .iter()
-            .filter(|c| c.placement() == Placement::Sidebar)
+            .filter(|(_, c)| c.placement() == Placement::Sidebar)
             .count()
     }
 
@@ -386,7 +434,7 @@ impl Compositor {
     pub fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
         self.stack
             .get(self.focused_idx)
-            .map(|c| c.footer_hints())
+            .map(|(_, c)| c.footer_hints())
             .unwrap_or_default()
     }
 
@@ -397,7 +445,7 @@ impl Compositor {
     pub fn focused_name(&self) -> &'static str {
         self.stack
             .get(self.focused_idx)
-            .map(|c| c.name())
+            .map(|(_, c)| c.name())
             .unwrap_or("")
     }
 

--- a/src/frontend/compositor/sidebar.rs
+++ b/src/frontend/compositor/sidebar.rs
@@ -11,7 +11,7 @@ use ratatui::layout::{Constraint, Layout, Margin, Rect};
 use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
 
 use super::window;
-use super::{Component, Context, Placement};
+use super::{CardId, Component, Context, Placement};
 use crate::theme::UiTheme;
 
 /// Maximum number of sidebar cards rendered simultaneously.
@@ -29,7 +29,7 @@ pub(super) fn render(
     side_area: Rect,
     theme: &UiTheme,
     ctx: &Context,
-    stack: &[Box<dyn Component>],
+    stack: &[(CardId, Box<dyn Component>)],
     focused_idx: usize,
 ) {
     // Walk the stack once to collect sidebar refs alongside the
@@ -37,7 +37,7 @@ pub(super) fn render(
     // not the global stack).
     let mut sidebar_components: Vec<&dyn Component> = Vec::new();
     let mut focused_in_sidebar: Option<usize> = None;
-    for (i, c) in stack.iter().enumerate() {
+    for (i, (_, c)) in stack.iter().enumerate() {
         if c.placement() == Placement::Sidebar {
             if i == focused_idx {
                 focused_in_sidebar = Some(sidebar_components.len());

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -344,7 +344,9 @@ impl Frontend {
         // self.compositor` for the push side.
         let lua = &self.lua;
         let compositor = &mut self.compositor;
-        lua.drain_pushes(|component| compositor.push(component));
+        lua.drain_pushes(|component| {
+            compositor.push(component);
+        });
 
         let ctx = self.context();
         self.compositor.poll(&ctx, event_tx);


### PR DESCRIPTION
## Summary

Lays the foundation for the upcoming \"Lua tick returns Vec<Op>\" refactor (which will eliminate \`CloseFlag\` polling, \`drain_pushes\`, and unify the 3 same-thread Lua → Frontend communication patterns).

This PR is **just the foundation, no behavioural change**. It tags every component on the [\`Compositor\`] stack with a stable [\`CardId\`] so external actors (Lua handles, future async sources) can reserve an id at the call site that opens a card and use it later to request a close — even when the actual push applies on a later iteration.

## Changes

- New [\`CardId\`] newtype (\`u64\`) with [\`CardId::next\`] backed by a process-global atomic counter
- \`Compositor.stack\` changes from \`Vec<Box<dyn Component>>\` to \`Vec<(CardId, Box<dyn Component>)>\`
- [\`Compositor::push(c)\`] now returns the freshly allocated \`CardId\`
- [\`Compositor::push_with_id(id, c)\`] for caller-supplied ids (used next PR by \`api.card.open\`)
- [\`Compositor::close_by_id(id)\`] for id-based close (silent no-op when absent — replaces \`CloseFlag\` polling next PR)
- All internal stack accessors updated to go through the tuple's \`.1\`
- Sidebar layout signature picks up the tuple

## Test plan

- [x] \`cargo test\` — 391/391 pass
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

## Follow-up (next PR)

\`Op\` enum + \`LuaSubsystem::tick → Vec<Op>\` returning intents/pushes/closes; uses the \`close_by_id\` method added here to remove \`CloseFlag\` / \`CloseFlagWrapper\` plumbing.