### PR TITLE
refactor(lua): replace CloseFlag polling with Op::Close via shared OpsBuffer

### DIFF
--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -224,12 +224,31 @@ impl Frontend {
             // `tick` event fires against the live MapApi.
             self.render_into(terminal)?;
 
+            // Drain any [`Op`]s that Lua callbacks enqueued during this
+            // iteration (handler calls, on_tick callbacks, palette
+            // execute callbacks). Today only `Op::Close` is in use —
+            // the older `CloseFlag` polling has been replaced with this
+            // single buffered drain.
+            self.apply_lua_ops();
+
             // If plugin `on_tick` callbacks pushed polylines, throttle
             // the redraw request to the configured interval.
             self.tick_overlay_redraw();
         }
 
         Ok(())
+    }
+
+    /// Apply every [`Op`] queued by Lua callbacks since the last
+    /// drain. Called once per loop iteration, after `render_into` so
+    /// `on_tick` callbacks (which run inside `ui::draw`) have already
+    /// pushed.
+    fn apply_lua_ops(&mut self) {
+        for op in self.lua.drain_ops() {
+            match op {
+                crate::lua::op::Op::Close(id) => self.compositor.close_by_id(id),
+            }
+        }
     }
 
     /// Whether the event loop should keep running — flipped off by
@@ -344,8 +363,8 @@ impl Frontend {
         // self.compositor` for the push side.
         let lua = &self.lua;
         let compositor = &mut self.compositor;
-        lua.drain_pushes(|component| {
-            compositor.push(component);
+        lua.drain_pushes(|id, component| {
+            compositor.push_with_id(id, component);
         });
 
         let ctx = self.context();

--- a/src/lua/api/mod.rs
+++ b/src/lua/api/mod.rs
@@ -260,7 +260,10 @@ pub struct LuaHostHandles {
     /// `!Send` payloads at construction; only `Sender<T>: Send`
     /// requires `T: Send`, and we never move the sender across
     /// threads.
-    pub push_rx: mpsc::Receiver<Box<dyn crate::frontend::compositor::Component>>,
+    pub push_rx: mpsc::Receiver<(
+        crate::frontend::compositor::CardId,
+        Box<dyn crate::frontend::compositor::Component>,
+    )>,
 }
 
 // ── Self-registration capture ────────────────────────────────────────
@@ -345,6 +348,7 @@ pub fn install(
     shared: Arc<LuaHostShared>,
     slot: CaptureSlot,
     sender: LuaSender,
+    ops: crate::lua::op::OpsBuffer,
 ) -> mlua::Result<LuaHostHandles> {
     // `sender` is a [`LuaSender`] handed in from the composition
     // root; it wraps the App's `Sender<AppEvent>` so the lua module
@@ -359,7 +363,10 @@ pub fn install(
     // callback + App drain all run on the same thread). `mpsc`
     // accepts `!Send` payloads at construction; only `Sender<T>: Send`
     // requires `T: Send`, and the Sender never moves across threads.
-    let (push_tx, push_rx) = mpsc::channel::<Box<dyn crate::frontend::compositor::Component>>();
+    let (push_tx, push_rx) = mpsc::channel::<(
+        crate::frontend::compositor::CardId,
+        Box<dyn crate::frontend::compositor::Component>,
+    )>();
     let center = Arc::new(Mutex::new(LonLat { lon: 0.0, lat: 0.0 }));
     let zoom = Arc::new(Mutex::new(0.0_f64));
 
@@ -506,13 +513,20 @@ pub fn install(
 
     let card_api = lua.create_table()?;
     let push_tx_for_window = push_tx.clone();
+    let ops_for_window = ops.clone();
     card_api.set(
         "open",
         lua.create_function(
             move |lua, spec: Table| -> mlua::Result<crate::lua::bridge::card_handle::CardHandle> {
+                use crate::frontend::compositor::CardId;
                 use crate::lua::bridge::card_component::LuaCardComponent;
-                use crate::lua::bridge::card_handle::{CardHandle, CloseFlag};
-                let flag = CloseFlag::default();
+                use crate::lua::bridge::card_handle::CardHandle;
+                // Reserve the [`CardId`] at the call site so the
+                // handle returned to Lua can target this exact
+                // component for close, even though the actual push
+                // applies on a later iteration when the App drains
+                // `push_rx`.
+                let id = CardId::next();
                 // Build the component on the **same** Lua VM that ran
                 // `card.open` — i.e. the setup state. The spec's
                 // callbacks (`render`, `handle_event`, …) capture
@@ -520,7 +534,7 @@ pub fn install(
                 // must be a clone of it (cheap Arc bump, no copy of the
                 // VM). When `LuaCardComponent` later calls into those
                 // callbacks, the same upvalue scope is in scope.
-                let component = LuaCardComponent::from_spec(lua.clone(), spec, tag, flag.clone())?;
+                let component = LuaCardComponent::from_spec(lua.clone(), spec, tag)?;
                 // Same-thread send: the channel never crosses threads.
                 // `send` returns Err only when the receiver has been
                 // dropped, which happens at App teardown — log + carry
@@ -529,7 +543,10 @@ pub fn install(
                 // dropped the receiver mid-run; that should never happen
                 // in production, hence `error!` rather than `warn!`.
                 if push_tx_for_window
-                    .send(Box::new(component) as Box<dyn crate::frontend::compositor::Component>)
+                    .send((
+                        id,
+                        Box::new(component) as Box<dyn crate::frontend::compositor::Component>,
+                    ))
                     .is_err()
                 {
                     log::error!(
@@ -537,7 +554,7 @@ pub fn install(
                         tag
                     );
                 }
-                Ok(CardHandle::new(flag))
+                Ok(CardHandle::new(id, ops_for_window.clone()))
             },
         )?,
     )?;
@@ -547,23 +564,26 @@ pub fn install(
     //
     // Mirror of `ttymap.api.card.open`: build a palette provider on
     // the same Lua VM (the setup state), wrap it in a
-    // [`PaletteComponent`] plus a [`CloseFlagWrapper`] so the host can
-    // pop the palette via the shared `CloseFlag` the
-    // [`PaletteHandle`] also holds, and queue it onto `push_tx`. The
-    // App drains `push_tx` per frame and pushes each component onto
-    // the compositor stack.
+    // [`PaletteComponent`], and queue (id, component) onto `push_tx`.
+    // The App drains per frame and pushes via `compositor.push_with_id`,
+    // associating the component with the [`CardId`] reserved here. The
+    // returned [`PaletteHandle`] holds the same id and can request
+    // close via [`Op::Close`].
     let palette_api = lua.create_table()?;
     let push_tx_for_palette = push_tx.clone();
+    let ops_for_palette = ops.clone();
     palette_api.set(
         "open",
         lua.create_function(
             move |lua,
                   spec: Table|
                   -> mlua::Result<crate::lua::bridge::palette_handle::PaletteHandle> {
-                use crate::lua::bridge::card_handle::{CloseFlag, CloseFlagWrapper};
+                use crate::frontend::compositor::CardId;
                 use crate::lua::bridge::palette_handle::PaletteHandle;
                 use crate::lua::bridge::palette_provider::LuaPaletteProvider;
-                let flag = CloseFlag::default();
+                // Reserve the id up-front so the returned [`PaletteHandle`]
+                // can target this exact PaletteComponent for close.
+                let id = CardId::next();
                 // Build the provider on the **same** Lua VM that ran
                 // `palette.open` — the setup state. The spec's
                 // callbacks (`filter`, `items`, `execute`, …) capture
@@ -572,9 +592,11 @@ pub fn install(
                 let provider = LuaPaletteProvider::from_spec(lua.clone(), spec, tag)?;
                 let palette =
                     crate::frontend::palette::PaletteComponent::with_provider(Box::new(provider));
-                let wrapped = CloseFlagWrapper::new(palette, flag.clone());
                 if push_tx_for_palette
-                    .send(Box::new(wrapped) as Box<dyn crate::frontend::compositor::Component>)
+                    .send((
+                        id,
+                        Box::new(palette) as Box<dyn crate::frontend::compositor::Component>,
+                    ))
                     .is_err()
                 {
                     log::error!(
@@ -582,7 +604,7 @@ pub fn install(
                         tag
                     );
                 }
-                Ok(PaletteHandle::new(flag))
+                Ok(PaletteHandle::new(id, ops_for_palette.clone()))
             },
         )?,
     )?;
@@ -899,8 +921,15 @@ mod tests {
         let slot = new_capture_slot();
         let (event_tx, event_rx) = mpsc::channel();
         let sender = LuaSender::new(event_tx);
-        let handles = install(&lua, "lua-test", LuaHostShared::empty(), slot, sender)
-            .expect("install ttymap table");
+        let handles = install(
+            &lua,
+            "lua-test",
+            LuaHostShared::empty(),
+            slot,
+            sender,
+            crate::lua::op::new_ops_buffer(),
+        )
+        .expect("install ttymap table");
         (lua, handles, event_rx)
     }
 
@@ -1029,6 +1058,7 @@ mod tests {
             LuaHostShared::empty(),
             slot.clone(),
             dummy_lua_sender(),
+            crate::lua::op::new_ops_buffer(),
         )
         .expect("install ttymap table");
         lua.load(
@@ -1067,6 +1097,7 @@ mod tests {
             LuaHostShared::empty(),
             slot.clone(),
             dummy_lua_sender(),
+            crate::lua::op::new_ops_buffer(),
         )
         .expect("install ttymap table");
         lua.load(
@@ -1101,6 +1132,7 @@ mod tests {
             LuaHostShared::empty(),
             slot,
             dummy_lua_sender(),
+            crate::lua::op::new_ops_buffer(),
         )
         .expect("install ttymap table");
         let result: mlua::Result<()> = lua.load(r#"ttymap.on_event("", function() end)"#).exec();
@@ -1209,8 +1241,15 @@ mod tests {
         let lua = mlua::Lua::new();
         let shared = LuaHostShared::empty();
         let slot = new_capture_slot();
-        let _handles = install(&lua, "lua-test", shared.clone(), slot, dummy_lua_sender())
-            .expect("install ttymap table");
+        let _handles = install(
+            &lua,
+            "lua-test",
+            shared.clone(),
+            slot,
+            dummy_lua_sender(),
+            crate::lua::op::new_ops_buffer(),
+        )
+        .expect("install ttymap table");
 
         lua.load(
             r#"
@@ -1258,8 +1297,15 @@ mod tests {
         let lua = mlua::Lua::new();
         let shared = LuaHostShared::empty();
         let slot = new_capture_slot();
-        let _handles = install(&lua, "lua-test", shared.clone(), slot, dummy_lua_sender())
-            .expect("install ttymap table");
+        let _handles = install(
+            &lua,
+            "lua-test",
+            shared.clone(),
+            slot,
+            dummy_lua_sender(),
+            crate::lua::op::new_ops_buffer(),
+        )
+        .expect("install ttymap table");
         for i in 0..(NOTIFY_RING_CAP + 4) {
             lua.load(format!(r#"ttymap.notify("msg-{}")"#, i))
                 .exec()
@@ -1362,12 +1408,11 @@ mod tests {
             handles.push_rx.try_recv().is_err(),
             "push_rx should be drained after a single recv"
         );
-        // Close the handle from Lua. Without an App-side close drain
-        // the component on `push_rx` would never see the flip; the
-        // flag is shared with that component's `CloseFlag`, but
-        // since we already drained the receiver and dropped the
-        // component, this just confirms the userdata method survives
-        // the call (idempotent close is the CardHandle contract).
+        // Close the handle from Lua. The push_rx receiver was already
+        // drained above, so the component is gone; this just confirms
+        // the userdata method survives the call (idempotent close is
+        // the CardHandle contract — internally it pushes Op::Close to
+        // the shared OpsBuffer; the App applies it via close_by_id).
         lua.load("ttymap_test_handle:close()")
             .exec()
             .expect("close");

--- a/src/lua/bridge/card_component.rs
+++ b/src/lua/bridge/card_component.rs
@@ -17,12 +17,16 @@
 //! A window opened via `card.open` does focused-UI work only; map
 //! paint and async drain run in the per-frame tick on the main thread.
 //!
-//! Lifetime: the matching [`CardHandle`] (returned to Lua by
-//! `card.open`) carries a clone of the same [`CloseFlag`]. Either
-//! side flipping the flag is honoured on the next [`Component::poll`]
-//! tick, where this component pops itself off the stack via
-//! [`Window::close`]. Idempotent — a flipped-then-flipped flag does
-//! nothing extra.
+//! Lifetime: the matching [`CardHandle`](super::card_handle::CardHandle)
+//! (returned to Lua by `card.open`) holds the same
+//! [`CardId`](crate::frontend::compositor::CardId) reserved at the
+//! call site. Lua-side `handle:close()` enqueues an
+//! [`Op::Close`](crate::lua::op::Op::Close) onto the shared
+//! [`OpsBuffer`](crate::lua::op::OpsBuffer); the App applies it per
+//! iteration via
+//! [`crate::frontend::compositor::Compositor::close_by_id`].
+//! Idempotent — repeated `close()` calls just enqueue duplicate
+//! `Op::Close` entries that are no-ops once the component is gone.
 //!
 //! Drain plumbing (`ttymap.map:jump`, `ttymap.api.frame.export`)
 //! lives in the **setup state** that ran the script's top-level
@@ -42,7 +46,6 @@ use mlua::{Lua, Table};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem, ListState, Paragraph};
 
-use super::card_handle::CloseFlag;
 use super::card_parse::{
     KeyAction, key_code_to_lua, parse_footer_hints, parse_item_value, parse_line_value,
 };
@@ -55,15 +58,14 @@ use crate::theme::StyleKind;
 
 /// A [`Component`] backed by a Lua spec table. Pushed onto the
 /// compositor stack by `ttymap.api.card.open(spec)`; popped when
-/// either side flips the shared [`CloseFlag`].
+/// the matching [`CardHandle`](super::card_handle::CardHandle)
+/// enqueues an [`Op::Close`](crate::lua::op::Op::Close) keyed by the
+/// reserved [`CardId`](crate::frontend::compositor::CardId), or when
+/// the spec's `handle_event` returns `{ close = true }`.
 pub struct LuaCardComponent {
     /// Bridge plumbing — fresh `Lua` VM, registered spec table,
     /// log tag (= identification used in warnings).
     handle: LuaBridgeHandle,
-    /// Shared with the [`CardHandle`](super::card_handle::CardHandle)
-    /// returned to Lua. Either side flipping it triggers a `win.close()`
-    /// on the next poll tick.
-    flag: CloseFlag,
     /// User-facing display label, read from `spec.name` if present
     /// at construction. Falls back to the handle's log tag (the
     /// `chunk_name` passed in by `card.open`). Leaked once so
@@ -122,12 +124,7 @@ impl LuaCardComponent {
     /// frame.export and the host-shared `center` / `zoom` mutexes;
     /// this component does not drain them (App drains them
     /// centrally per loop iteration).
-    pub fn from_spec(
-        lua: Lua,
-        spec: Table,
-        log_tag: &'static str,
-        flag: CloseFlag,
-    ) -> mlua::Result<Self> {
+    pub fn from_spec(lua: Lua, spec: Table, log_tag: &'static str) -> mlua::Result<Self> {
         // Display name: spec's `name` if set, else the log tag.
         // Leak once; bounded by the number of windows opened.
         let display: &'static str = spec
@@ -148,7 +145,6 @@ impl LuaCardComponent {
         let handle = LuaBridgeHandle::new(lua, spec, log_tag)?;
         Ok(Self {
             handle,
-            flag,
             display,
             has_render,
             has_items,
@@ -434,16 +430,6 @@ impl Component for LuaCardComponent {
         }
     }
 
-    fn poll(&mut self, win: &mut Window) {
-        // The only Lua-facing poll work this Component does is
-        // honour the shared close flag. NO callback into the spec —
-        // async work belongs on a `ttymap.api.frame.on_tick(fn)`
-        // subscription, not on the focused window.
-        if self.flag.take() {
-            win.close();
-        }
-    }
-
     fn name(&self) -> &'static str {
         self.display
     }
@@ -474,7 +460,7 @@ mod tests {
     fn make(source: &str, log_tag: &'static str) -> LuaCardComponent {
         let lua = mlua::Lua::new();
         let spec: Table = lua.load(source).eval().expect("eval spec");
-        LuaCardComponent::from_spec(lua, spec, log_tag, CloseFlag::default()).expect("from_spec")
+        LuaCardComponent::from_spec(lua, spec, log_tag).expect("from_spec")
     }
 
     #[test]
@@ -612,62 +598,7 @@ mod tests {
         );
     }
 
-    // ── close flag (the only poll-time work this Component does) ──
-
-    #[test]
-    fn poll_does_nothing_until_flag_is_flipped() {
-        use crate::frontend::AppEvent;
-        use crate::frontend::compositor::Context;
-        use crate::frontend::compositor::window::WindowOps;
-
-        let flag = CloseFlag::default();
-        let lua = mlua::Lua::new();
-        let spec: Table = lua.load(r#"return { name = "win" }"#).eval().unwrap();
-        let mut c = LuaCardComponent::from_spec(lua, spec, "win", flag.clone()).unwrap();
-
-        const CTX: Context = Context {
-            theme_id: crate::theme::ThemeId::Dark,
-            cursor: None,
-        };
-        let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
-        let mut ops = WindowOps::default();
-        {
-            let mut win = Window::new(&mut ops, &CTX, &tx);
-            c.poll(&mut win);
-        }
-        assert!(!ops.close, "no flag flip → no close queued");
-    }
-
-    #[test]
-    fn poll_honours_flag_and_closes_window() {
-        use crate::frontend::AppEvent;
-        use crate::frontend::compositor::Context;
-        use crate::frontend::compositor::window::WindowOps;
-
-        let flag = CloseFlag::default();
-        let lua = mlua::Lua::new();
-        let spec: Table = lua.load(r#"return { name = "win" }"#).eval().unwrap();
-        let mut c = LuaCardComponent::from_spec(lua, spec, "win", flag.clone()).unwrap();
-
-        const CTX: Context = Context {
-            theme_id: crate::theme::ThemeId::Dark,
-            cursor: None,
-        };
-        let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
-        flag.request();
-        let mut ops = WindowOps::default();
-        {
-            let mut win = Window::new(&mut ops, &CTX, &tx);
-            c.poll(&mut win);
-        }
-        assert!(ops.close, "flipped flag → win.close() queued");
-
-        // Idempotent — second poll without re-flipping is a no-op.
-        let mut ops = WindowOps::default();
-        {
-            let mut win = Window::new(&mut ops, &CTX, &tx);
-            c.poll(&mut win);
-        }
-        assert!(!ops.close);
-    }
+    // Close coverage moved to `card_handle::tests::close_enqueues_op_close_idempotent`:
+    // the close path no longer goes through Component::poll, so the
+    // CloseFlag polling tests retire with the flag itself.
 }

--- a/src/lua/bridge/card_handle.rs
+++ b/src/lua/bridge/card_handle.rs
@@ -2,174 +2,70 @@
 //! component onto the compositor stack, return a Lua-facing handle
 //! whose only method is `close()` (idempotent).
 //!
-//! The handle holds a shared atomic flag; `close()` flips it. The
-//! `LuaCardComponent` it pushed checks the flag on its next poll
-//! tick and pops itself off the stack via `win.close()`.
-
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+//! The handle holds a reserved [`CardId`] and a clone of the
+//! Lua subsystem's shared [`OpsBuffer`]. `close()` enqueues an
+//! [`Op::Close`] keyed by the id; the App drains the buffer per
+//! iteration and pops the matching component via
+//! [`crate::frontend::compositor::Compositor::close_by_id`].
+//!
+//! Replaces the older `Arc<AtomicBool>` flag + per-component
+//! `Component::poll` polling pattern: there's no per-frame
+//! "is this card asking to close?" scan; the close is a single
+//! push to the buffer, applied directly by id.
 
 use mlua::UserData;
 
-/// Shared close flag between the Lua-side handle and the Rust-side
-/// component. Cloned at construction; either side flipping it
-/// triggers the next poll-tick `win.close()`.
-#[derive(Clone, Default)]
-pub struct CloseFlag(Arc<AtomicBool>);
-
-impl CloseFlag {
-    // Relaxed is sufficient: the flag is the only shared state and
-    // there is no companion data whose write must be ordered with
-    // respect to the flip.
-    pub fn request(&self) {
-        self.0.store(true, Ordering::Relaxed);
-    }
-    pub fn take(&self) -> bool {
-        self.0.swap(false, Ordering::Relaxed)
-    }
-}
+use crate::frontend::compositor::CardId;
+use crate::lua::op::{Op, OpsBuffer};
 
 /// Lua-facing handle returned by `ttymap.api.card.open(...)`.
-/// Idempotent `:close()` — flipping a flipped flag is a no-op.
+/// Idempotent `:close()` — pushing two `Op::Close(id)` for the same
+/// id is harmless (the second `close_by_id` call is a no-op once the
+/// component is already off the stack).
 pub struct CardHandle {
-    flag: CloseFlag,
+    id: CardId,
+    ops: OpsBuffer,
 }
 
 impl CardHandle {
-    /// Build a handle that signals close via the shared `flag`.
-    pub fn new(flag: CloseFlag) -> Self {
-        Self { flag }
+    /// Build a handle that requests close via [`Op::Close`] keyed by
+    /// the supplied `id`.
+    pub fn new(id: CardId, ops: OpsBuffer) -> Self {
+        Self { id, ops }
     }
 }
 
 impl UserData for CardHandle {
     fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
         methods.add_method("close", |_, this, _: ()| {
-            this.flag.request();
+            this.ops.borrow_mut().push(Op::Close(this.id));
             Ok(())
         });
-    }
-}
-
-/// Generic wrapper that drains a [`CloseFlag`] on each `poll` tick
-/// and forwards every other [`Component`] method to the inner impl.
-///
-/// Used by `ttymap.api.palette.open` (and any future A-series
-/// primitive that wraps a pre-existing `Component`) to add the
-/// shared-flag close protocol without duplicating it inside each
-/// adapter type. [`LuaCardComponent`] does the same thing inline
-/// in its own `poll` because it owns the flag directly; for adapters
-/// that already exist (`PaletteComponent` wrapping a
-/// [`LuaPaletteProvider`]) wrapping is the cheaper bridge.
-///
-/// [`Component`]: crate::frontend::compositor::Component
-/// [`LuaCardComponent`]: super::card_component::LuaCardComponent
-/// [`LuaPaletteProvider`]: super::palette_provider::LuaPaletteProvider
-pub struct CloseFlagWrapper<C> {
-    inner: C,
-    flag: CloseFlag,
-}
-
-impl<C> CloseFlagWrapper<C> {
-    pub fn new(inner: C, flag: CloseFlag) -> Self {
-        Self { inner, flag }
-    }
-}
-
-impl<C: crate::frontend::compositor::Component> crate::frontend::compositor::Component
-    for CloseFlagWrapper<C>
-{
-    fn handle_event(
-        &mut self,
-        event: crossterm::event::KeyEvent,
-        win: &mut crate::frontend::compositor::window::Window,
-    ) {
-        self.inner.handle_event(event, win);
-    }
-
-    fn render(&self, win: &mut crate::frontend::compositor::window::RenderWindow) {
-        self.inner.render(win);
-    }
-
-    fn poll(&mut self, win: &mut crate::frontend::compositor::window::Window) {
-        self.inner.poll(win);
-        if self.flag.take() {
-            win.close();
-        }
-    }
-
-    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
-        self.inner.footer_hints()
-    }
-
-    fn name(&self) -> &'static str {
-        self.inner.name()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lua::op::new_ops_buffer;
 
     #[test]
-    fn close_flips_flag_idempotent() {
-        let flag = CloseFlag::default();
+    fn close_enqueues_op_close_idempotent() {
+        let ops = new_ops_buffer();
+        let id = CardId::next();
         let lua = mlua::Lua::new();
-        let ud = lua.create_userdata(CardHandle::new(flag.clone())).unwrap();
+        let ud = lua
+            .create_userdata(CardHandle::new(id, ops.clone()))
+            .unwrap();
         lua.load("local h = ...; h:close(); h:close()")
             .call::<()>(ud)
             .unwrap();
-        assert!(flag.take());
-        assert!(!flag.take());
-    }
-
-    /// [`CloseFlagWrapper::poll`] must call `win.close()` exactly when
-    /// the shared flag has been flipped — and nothing extra at any
-    /// other time. Mirrors the equivalent test on
-    /// [`super::card_component::LuaCardComponent`].
-    #[test]
-    fn close_flag_wrapper_polls_close_when_flag_set() {
-        use crate::frontend::AppEvent;
-        use crate::frontend::compositor::Component;
-        use crate::frontend::compositor::Context;
-        use crate::frontend::compositor::window::{Window, WindowOps};
-
-        /// Inert inner component — no-op for every method so the
-        /// wrapper's behaviour is the only thing under test.
-        struct Inert;
-        impl Component for Inert {}
-
-        const CTX: Context = Context {
-            theme_id: crate::theme::ThemeId::Dark,
-            cursor: None,
-        };
-        let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
-
-        let flag = CloseFlag::default();
-        let mut wrapped = CloseFlagWrapper::new(Inert, flag.clone());
-
-        // No flip → no close.
-        let mut ops = WindowOps::default();
-        {
-            let mut win = Window::new(&mut ops, &CTX, &tx);
-            wrapped.poll(&mut win);
+        let drained: Vec<Op> = std::mem::take(&mut *ops.borrow_mut());
+        assert_eq!(drained.len(), 2, "two close() calls -> two ops queued");
+        for op in drained {
+            match op {
+                Op::Close(got) => assert_eq!(got, id),
+            }
         }
-        assert!(!ops.close);
-
-        // Flipped flag → close queued, then idempotent.
-        flag.request();
-        let mut ops = WindowOps::default();
-        {
-            let mut win = Window::new(&mut ops, &CTX, &tx);
-            wrapped.poll(&mut win);
-        }
-        assert!(ops.close);
-
-        let mut ops = WindowOps::default();
-        {
-            let mut win = Window::new(&mut ops, &CTX, &tx);
-            wrapped.poll(&mut win);
-        }
-        assert!(!ops.close);
     }
 }

--- a/src/lua/bridge/handle.rs
+++ b/src/lua/bridge/handle.rs
@@ -145,10 +145,11 @@ pub fn fresh_load(
     host_tag: &'static str,
     shared: Arc<host::LuaHostShared>,
     sender: LuaSender,
+    ops: crate::lua::op::OpsBuffer,
 ) -> mlua::Result<(Lua, host::CapturedRegistration, host::LuaHostHandles)> {
     let lua = new_lua();
     let slot = host::new_capture_slot();
-    let handles = host::install(&lua, host_tag, shared, slot.clone(), sender)?;
+    let handles = host::install(&lua, host_tag, shared, slot.clone(), sender, ops)?;
     lua.load(source).set_name(chunk_name).exec()?;
     let captured = std::mem::take(&mut *slot.borrow_mut());
     let has_surface = !captured.palette_commands.is_empty()

--- a/src/lua/bridge/palette_handle.rs
+++ b/src/lua/bridge/palette_handle.rs
@@ -3,34 +3,39 @@
 //! Lua-facing handle whose only method is `close()` (idempotent).
 //!
 //! Structurally identical to [`super::card_handle::CardHandle`]:
-//! the handle holds a shared atomic flag, `close()` flips it, and the
-//! wrapped [`crate::frontend::palette::PaletteComponent`] checks the flag on its
-//! next poll tick (via [`super::card_handle::CloseFlagWrapper`]) and
-//! pops itself off the stack via `win.close()`. Kept as its own type
-//! so callers know which kind of primitive they have — the Rust-side
-//! wiring is shared, but the Lua-side identity is not.
+//! the handle holds a reserved [`CardId`] and a clone of the Lua
+//! subsystem's shared [`OpsBuffer`]; `close()` enqueues an
+//! [`Op::Close`] that the App applies via
+//! [`crate::frontend::compositor::Compositor::close_by_id`]. Kept as
+//! its own type so callers know which kind of primitive they have —
+//! the Rust-side wiring is shared, but the Lua-side identity is not.
 
 use mlua::UserData;
 
-use super::card_handle::CloseFlag;
+use crate::frontend::compositor::CardId;
+use crate::lua::op::{Op, OpsBuffer};
 
 /// Lua-facing handle returned by `ttymap.api.palette.open(...)`.
-/// Idempotent `:close()` — flipping a flipped flag is a no-op.
+/// Idempotent `:close()` — pushing two `Op::Close(id)` for the same
+/// id is harmless (the second `close_by_id` call is a no-op once the
+/// component is already off the stack).
 pub struct PaletteHandle {
-    flag: CloseFlag,
+    id: CardId,
+    ops: OpsBuffer,
 }
 
 impl PaletteHandle {
-    /// Build a handle that signals close via the shared `flag`.
-    pub fn new(flag: CloseFlag) -> Self {
-        Self { flag }
+    /// Build a handle that requests close via [`Op::Close`] keyed by
+    /// the supplied `id`.
+    pub fn new(id: CardId, ops: OpsBuffer) -> Self {
+        Self { id, ops }
     }
 }
 
 impl UserData for PaletteHandle {
     fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
         methods.add_method("close", |_, this, _: ()| {
-            this.flag.request();
+            this.ops.borrow_mut().push(Op::Close(this.id));
             Ok(())
         });
     }
@@ -39,18 +44,25 @@ impl UserData for PaletteHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lua::op::new_ops_buffer;
 
     #[test]
-    fn close_flips_flag_idempotent() {
-        let flag = CloseFlag::default();
+    fn close_enqueues_op_close_idempotent() {
+        let ops = new_ops_buffer();
+        let id = CardId::next();
         let lua = mlua::Lua::new();
         let ud = lua
-            .create_userdata(PaletteHandle::new(flag.clone()))
+            .create_userdata(PaletteHandle::new(id, ops.clone()))
             .unwrap();
         lua.load("local h = ...; h:close(); h:close()")
             .call::<()>(ud)
             .unwrap();
-        assert!(flag.take());
-        assert!(!flag.take());
+        let drained: Vec<Op> = std::mem::take(&mut *ops.borrow_mut());
+        assert_eq!(drained.len(), 2);
+        for op in drained {
+            match op {
+                Op::Close(got) => assert_eq!(got, id),
+            }
+        }
     }
 }

--- a/src/lua/bridge/palette_provider.rs
+++ b/src/lua/bridge/palette_provider.rs
@@ -246,8 +246,15 @@ mod tests {
         // surface, not the bus.
         let (tx, _rx) = std::sync::mpsc::channel();
         let sender = LuaSender::new(tx);
-        let _handles = install(&lua, "lua-test", LuaHostShared::empty(), slot, sender)
-            .expect("install ttymap");
+        let _handles = install(
+            &lua,
+            "lua-test",
+            LuaHostShared::empty(),
+            slot,
+            sender,
+            crate::lua::op::new_ops_buffer(),
+        )
+        .expect("install ttymap");
         let spec: Table = lua.load(script).eval().expect("eval spec");
         LuaPaletteProvider::from_spec(lua, spec, "lua-test").expect("from_spec")
     }

--- a/src/lua/handle.rs
+++ b/src/lua/handle.rs
@@ -7,10 +7,11 @@
 //! "Frontend doesn't know how Lua is wired internally" boundary —
 //! all bus dispatch and host-state plumbing lives behind this type.
 
-use crate::frontend::compositor::Component;
 use crate::frontend::compositor::MapApi;
+use crate::frontend::compositor::{CardId, Component};
 use crate::geo::LonLat;
 use crate::lua::api::LuaHostHandles;
+use crate::lua::op::{Op, OpsBuffer};
 use crate::lua::registry::{LuaEventBus, names};
 
 /// Runtime-held part of the Lua subsystem (built by
@@ -22,11 +23,25 @@ use crate::lua::registry::{LuaEventBus, names};
 pub struct LuaHandle {
     bus: LuaEventBus,
     host_handles: Vec<LuaHostHandles>,
+    /// Shared buffer that Lua callbacks push [`Op`]s into; Frontend
+    /// drains via [`Self::drain_ops`] once per loop iteration.
+    ops: OpsBuffer,
 }
 
 impl LuaHandle {
-    pub fn new(bus: LuaEventBus, host_handles: Vec<LuaHostHandles>) -> Self {
-        Self { bus, host_handles }
+    pub fn new(bus: LuaEventBus, host_handles: Vec<LuaHostHandles>, ops: OpsBuffer) -> Self {
+        Self {
+            bus,
+            host_handles,
+            ops,
+        }
+    }
+
+    /// Take every [`Op`] enqueued by Lua callbacks since the last
+    /// drain. Frontend calls this once per loop iteration and applies
+    /// each op to the compositor / dispatch path.
+    pub fn drain_ops(&self) -> Vec<Op> {
+        std::mem::take(&mut *self.ops.borrow_mut())
     }
 
     /// Fire the per-frame `"tick"` event. Called by `ui::draw` once
@@ -89,13 +104,15 @@ impl LuaHandle {
     }
 
     /// Drain every plugin's `push_rx` queue — components that Lua
-    /// queued via `ttymap.api.card.open` / `palette.open`. The
-    /// caller decides what to do with each pulled component (in
-    /// practice: push it onto the compositor stack).
-    pub fn drain_pushes<F: FnMut(Box<dyn Component>)>(&self, mut on_push: F) {
+    /// queued via `ttymap.api.card.open` / `palette.open`. Each
+    /// pull carries the [`CardId`] reserved at the call site (so the
+    /// matching [`crate::lua::bridge::card_handle::CardHandle`] can
+    /// later request a close via [`Op::Close`]); the caller pushes
+    /// onto the compositor stack via `push_with_id`.
+    pub fn drain_pushes<F: FnMut(CardId, Box<dyn Component>)>(&self, mut on_push: F) {
         for handles in &self.host_handles {
-            while let Ok(component) = handles.push_rx.try_recv() {
-                on_push(component);
+            while let Ok((id, component)) = handles.push_rx.try_recv() {
+                on_push(id, component);
             }
         }
     }

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -17,6 +17,7 @@ pub mod api;
 pub mod bridge;
 pub mod handle;
 pub mod init_lua;
+pub mod op;
 pub mod registry;
 pub mod runtimepath;
 pub mod sender;
@@ -95,11 +96,13 @@ pub fn build_subsystem(
     // script itself (`enabled = false` in the spec). Higher-priority
     // layers shadow lower ones by stem.
     let runtime_path = runtime_path();
+    let ops = op::new_ops_buffer();
     register_builtin_plugins(
         runtime_path,
         &config.plugins.disable,
         shared.clone(),
         lua_sender,
+        ops.clone(),
         &mut r,
     );
 
@@ -129,6 +132,7 @@ pub fn build_subsystem(
     let handle = LuaHandle::new(
         std::mem::take(&mut r.event_bus),
         std::mem::take(&mut r.lua_host_handles),
+        ops,
     );
 
     LuaSubsystem {
@@ -278,6 +282,7 @@ pub fn register_builtin_plugins(
     disable: &[String],
     shared: Arc<api::LuaHostShared>,
     sender: LuaSender,
+    ops: op::OpsBuffer,
     r: &mut Registrar,
 ) {
     if runtime_path.is_empty() {
@@ -296,6 +301,7 @@ pub fn register_builtin_plugins(
             disable,
             shared.clone(),
             sender.clone(),
+            ops.clone(),
             r,
         );
     }
@@ -310,6 +316,7 @@ fn register_one(
     source: &'static str,
     shared: Arc<api::LuaHostShared>,
     sender: LuaSender,
+    ops: op::OpsBuffer,
     r: &mut Registrar,
 ) {
     // Run the script once to capture its activation surfaces and
@@ -325,7 +332,7 @@ fn register_one(
     // display name). Same value — the file stem is the plugin's
     // canonical identifier on every surface.
     let (lua, captured, handles) =
-        match bridge::handle::fresh_load(source, name, name, shared_for_plugin, sender) {
+        match bridge::handle::fresh_load(source, name, name, shared_for_plugin, sender, ops) {
             Ok(t) => t,
             Err(e) => {
                 log::warn!("lua[{}]: failed to load, plugin skipped: {}", name, e);
@@ -480,6 +487,7 @@ fn register_plugins_in(
     disable: &[String],
     shared: Arc<api::LuaHostShared>,
     sender: LuaSender,
+    ops: op::OpsBuffer,
     r: &mut Registrar,
 ) {
     let entries = match std::fs::read_dir(dir) {
@@ -539,7 +547,7 @@ fn register_plugins_in(
         // Cost: a few KB per plugin per program lifetime.
         let name: &'static str = Box::leak(stem.to_string().into_boxed_str());
         let source: &'static str = Box::leak(source.into_boxed_str());
-        register_one(name, source, shared.clone(), sender.clone(), r);
+        register_one(name, source, shared.clone(), sender.clone(), ops.clone(), r);
     }
 }
 
@@ -601,7 +609,14 @@ mod tests {
         let shared = api::LuaHostShared::empty();
         let mut r = Registrar::default();
         let rtp = vec![std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("runtime")];
-        register_builtin_plugins(&rtp, &[], shared, dummy_lua_sender(), &mut r);
+        register_builtin_plugins(
+            &rtp,
+            &[],
+            shared,
+            dummy_lua_sender(),
+            op::new_ops_buffer(),
+            &mut r,
+        );
 
         let palette: std::collections::HashSet<String> = r
             .palette_entries
@@ -647,9 +662,15 @@ mod tests {
     /// registration time.
     fn parse_spec(source: &str, name: &str) -> (mlua::Lua, api::CapturedRegistration) {
         let shared = api::LuaHostShared::empty();
-        let (lua, captured, _handles) =
-            bridge::handle::fresh_load(source, name, "lua-test", shared, dummy_lua_sender())
-                .expect("load");
+        let (lua, captured, _handles) = bridge::handle::fresh_load(
+            source,
+            name,
+            "lua-test",
+            shared,
+            dummy_lua_sender(),
+            op::new_ops_buffer(),
+        )
+        .expect("load");
         (lua, captured)
     }
 
@@ -718,7 +739,15 @@ mod tests {
 
         let shared = api::LuaHostShared::empty();
         let mut r = Registrar::default();
-        register_plugins_in(&dir, None, &[], shared.clone(), dummy_lua_sender(), &mut r);
+        register_plugins_in(
+            &dir,
+            None,
+            &[],
+            shared.clone(),
+            dummy_lua_sender(),
+            op::new_ops_buffer(),
+            &mut r,
+        );
 
         let entries = shared.palette_entries.lock().expect("lock palette_entries");
         let demo = entries
@@ -772,6 +801,7 @@ mod tests {
             &[],
             api::LuaHostShared::empty(),
             dummy_lua_sender(),
+            op::new_ops_buffer(),
             &mut r,
         );
         let ls = labels(&r);
@@ -798,6 +828,7 @@ mod tests {
             &[],
             api::LuaHostShared::empty(),
             dummy_lua_sender(),
+            op::new_ops_buffer(),
             &mut r,
         );
         let ls = labels(&r);
@@ -829,6 +860,7 @@ mod tests {
             &disable,
             api::LuaHostShared::empty(),
             dummy_lua_sender(),
+            op::new_ops_buffer(),
             &mut r,
         );
         let ls = labels(&r);
@@ -858,6 +890,7 @@ mod tests {
             &[],
             api::LuaHostShared::empty(),
             dummy_lua_sender(),
+            op::new_ops_buffer(),
             &mut r,
         );
         let ls = labels(&r);
@@ -889,6 +922,7 @@ mod tests {
             &[],
             api::LuaHostShared::empty(),
             dummy_lua_sender(),
+            op::new_ops_buffer(),
             &mut r,
         );
         assert!(
@@ -914,6 +948,7 @@ mod tests {
             &[],
             api::LuaHostShared::empty(),
             dummy_lua_sender(),
+            op::new_ops_buffer(),
             &mut r,
         );
         let ls = labels(&r);
@@ -1002,6 +1037,7 @@ mod tests {
             &[],
             api::LuaHostShared::empty(),
             dummy_lua_sender(),
+            op::new_ops_buffer(),
             &mut r,
         );
         assert!(r.palette_entries.is_empty());

--- a/src/lua/op.rs
+++ b/src/lua/op.rs
@@ -1,0 +1,51 @@
+//! Lua → Frontend operation vocabulary.
+//!
+//! [`Op`] is the typed output of a Lua subsystem tick / callback: each
+//! variant describes a single same-thread "do this on the App" request
+//! that the Lua bridge enqueues into a shared [`OpsBuffer`] and that
+//! Frontend drains once per iteration.
+//!
+//! Replaces the older mix of three same-thread mechanisms — the
+//! per-component `CloseFlag` (Arc<AtomicBool> polled every frame), the
+//! per-plugin `push_rx` queue (Box<dyn Component>), and the chatty
+//! [`crate::lua::sender::LuaSender`] — with a single typed buffer.
+//! This PR migrates only the close path; the others follow.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::frontend::compositor::CardId;
+
+/// A same-thread request from the Lua subsystem to the App.
+///
+/// Lua callbacks (handle `:close()`, `api.card.open`, etc.) push these
+/// into a shared [`OpsBuffer`]; Frontend drains the buffer once per
+/// loop iteration and applies each op.
+///
+/// Currently only [`Op::Close`] is in use. The other variants are
+/// reserved for the upcoming `push_tx` and `LuaSender` migrations so
+/// the buffer becomes the single Lua → Frontend transport.
+#[derive(Debug)]
+pub enum Op {
+    /// Pop the component matching `id` off the compositor stack.
+    /// Emitted by `CardHandle::close` / `PaletteHandle::close`. Silent
+    /// no-op when `id` is not on the stack (handle closed twice, or
+    /// the component already self-closed via `win.close()`).
+    Close(CardId),
+}
+
+/// Shared, single-threaded buffer that accumulates [`Op`]s from Lua
+/// callbacks and is drained by Frontend per iteration.
+///
+/// `Rc<RefCell<...>>`: same-thread sharing across the API closures
+/// (held inside the Lua VM via captured clones), the returned handles
+/// (`CardHandle` / `PaletteHandle`), and the runtime [`LuaHandle`]
+/// (read by Frontend). The Lua VM is single-threaded by mlua design,
+/// and the buffer never crosses threads.
+pub type OpsBuffer = Rc<RefCell<Vec<Op>>>;
+
+/// Construct an empty [`OpsBuffer`]. Called once at composition root
+/// and cloned into every site that needs to enqueue ops.
+pub fn new_ops_buffer() -> OpsBuffer {
+    Rc::new(RefCell::new(Vec::new()))
+}


### PR DESCRIPTION
## Summary

Lua's \`handle:close()\` previously flipped a per-component \`Arc<AtomicBool>\` (\`CloseFlag\`) that the compositor scanned every frame via \`Component::poll\`. Polling stack-wide just to read 1-bit flags was the smell — and it was the only thing keeping \`Component::poll\` alive (palette debounce aside, which a later PR will lift onto the same accumulator).

Replaces with a typed \`Op\` enum + a single \`Rc<RefCell<Vec<Op>>>\` buffer (\`OpsBuffer\`) shared across the Lua subsystem.

## Changes

- **New \`src/lua/op.rs\`**: \`Op::Close(CardId)\` + \`OpsBuffer\` type alias
- **\`CardHandle\` / \`PaletteHandle\`**: hold the reserved \`CardId\` + a clone of \`OpsBuffer\`; \`close()\` enqueues \`Op::Close(id)\` instead of flipping a flag
- **\`LuaCardComponent\`**: drops the \`CloseFlag\` field and the \`Component::poll\` override (nothing in the Lua bridge uses \`Component::poll\` anymore)
- **\`api.card.open\` / \`api.palette.open\`**: reserve a fresh \`CardId\` at the call site and send \`(id, Box<dyn Component>)\` through the per-plugin \`push_tx\`; the App applies via \`Compositor::push_with_id\` so the close path can target by id
- **\`LuaHandle\`**: exposes \`drain_ops() -> Vec<Op>\`
- **\`Frontend::run\`**: drains ops once per iteration after \`render_into\` and routes \`Op::Close\` to \`Compositor::close_by_id\`
- **Retired**: \`CloseFlag\` struct, \`CloseFlagWrapper\` adapter (palette components pushed directly without wrapping)

Tests covering the polling-flag behaviour move to \`card_handle::tests::close_enqueues_op_close_idempotent\` (and the PaletteHandle mirror).

## Test plan

- [x] \`cargo test\` — 388 / 388 pass
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

## Follow-up

Two more PRs to fully unify the Lua → Frontend transport (currently still 3 patterns: \`push_tx\` for components, \`LuaSender\` for intents, and now \`OpsBuffer\` for closes):

1. \`push_tx\` (drain_pushes) → \`Op::Push { id, component }\` on the same buffer
2. \`LuaSender\` (intent emission) → \`Op::Intent\` on the same buffer

After both, \`Component::poll\` can retire entirely (palette debounce moves to a tick-driven path).