### PR TITLE
refactor(compositor): unify WindowOps onto the Op enum

### DIFF
--- a/src/frontend/compositor/base.rs
+++ b/src/frontend/compositor/base.rs
@@ -148,10 +148,9 @@ impl Component for BaseLayer {
 
 #[cfg(test)]
 mod tests {
-    use super::super::Context;
     use super::super::window::WindowOps;
+    use super::super::{CardId, Context};
     use super::*;
-    use crate::frontend::AppEvent;
     use crate::theme::ThemeId;
 
     const NONE: KeyModifiers = KeyModifiers::NONE;
@@ -164,37 +163,29 @@ mod tests {
         BaseLayer::new(KeyMap::default(), Vec::new(), Vec::new())
     }
 
-    /// Dispatch a key into `bg` against a disposable bus. Returns
-    /// the queued stack ops (close / opens / ignored) plus every
-    /// `UserIntent` the hook emitted onto the bus, drained in order.
-    fn dispatch(bg: &mut BaseLayer, code: KeyCode) -> (WindowOps, Vec<UserIntent>) {
-        let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
+    /// Dispatch a key into `bg`. Intent emissions and stack ops both
+    /// land on the returned [`WindowOps`]; tests inspect via the
+    /// `closed()` / `pushed()` / `intents()` helpers.
+    fn dispatch(bg: &mut BaseLayer, code: KeyCode) -> WindowOps {
         let mut ops = WindowOps::default();
         {
-            let mut win = Window::new(&mut ops, &CTX, &tx);
+            let mut win = Window::new(&mut ops, &CTX, CardId::next());
             bg.handle_event(KeyEvent::new(code, NONE), &mut win);
         }
-        let mut msgs = Vec::new();
-        while let Ok(ev) = rx.try_recv() {
-            match ev {
-                AppEvent::Intent(m) => msgs.push(m),
-                other => panic!("unexpected event: {other:?}"),
-            }
-        }
-        (ops, msgs)
+        ops
     }
 
     #[test]
     fn gg_produces_zoom_to_world_on_second_g() {
         let mut bg = bg();
         // 1st g: nothing fires, pending_g latched.
-        let (ops, msgs) = dispatch(&mut bg, KeyCode::Char('g'));
-        assert!(msgs.is_empty());
-        assert!(!ops.close);
-        assert!(ops.opens.is_empty());
+        let ops = dispatch(&mut bg, KeyCode::Char('g'));
+        assert!(ops.intents().is_empty());
+        assert!(!ops.closed());
+        assert!(!ops.pushed());
         // 2nd g: ZoomToWorld.
-        let (_ops, msgs) = dispatch(&mut bg, KeyCode::Char('g'));
-        assert_eq!(msgs, vec![UserIntent::Map(MapAction::ZoomToWorld)]);
+        let ops = dispatch(&mut bg, KeyCode::Char('g'));
+        assert_eq!(ops.intents(), vec![UserIntent::Map(MapAction::ZoomToWorld)]);
     }
 
     #[test]
@@ -203,7 +194,7 @@ mod tests {
         dispatch(&mut bg, KeyCode::Char('g'));
         dispatch(&mut bg, KeyCode::Char('h')); // breaks
         // Now pending_g was reset; this g latches afresh, doesn't fire.
-        let (_ops, msgs) = dispatch(&mut bg, KeyCode::Char('g'));
-        assert!(msgs.is_empty());
+        let ops = dispatch(&mut bg, KeyCode::Char('g'));
+        assert!(ops.intents().is_empty());
     }
 }

--- a/src/frontend/compositor/mod.rs
+++ b/src/frontend/compositor/mod.rs
@@ -40,6 +40,7 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 
 use crate::frontend::{AppEvent, UserIntent};
+use crate::lua::op::Op;
 use crate::theme::ThemeId;
 use crate::theme::UiTheme;
 
@@ -305,58 +306,61 @@ impl Compositor {
             return;
         }
         let focused = self.focused_idx;
+        let focused_id = self.stack[focused].0;
         let mut ops = WindowOps::default();
         {
-            let mut win = Window::new(&mut ops, ctx, event_tx);
+            let mut win = Window::new(&mut ops, ctx, focused_id);
             self.stack[focused].1.handle_event(event, &mut win);
         }
         // Fall-through: only when the hook queued nothing *and*
         // explicitly called `ignore()`, and the focus isn't already
         // on the base layer.
         if ops.is_ignorable_noop() && ops.ignored && focused != 0 {
+            let base_id = self.stack[0].0;
             let mut ops = WindowOps::default();
             {
-                let mut win = Window::new(&mut ops, ctx, event_tx);
+                let mut win = Window::new(&mut ops, ctx, base_id);
                 self.stack[0].1.handle_event(event, &mut win);
             }
-            self.apply_ops(0, ops);
+            self.apply_ops(ops, event_tx);
             return;
         }
-        self.apply_ops(focused, ops);
+        self.apply_ops(ops, event_tx);
     }
 
-    /// Drain a [`WindowOps`] queue in the documented order:
-    /// `close` → `opens`. Intent emission already happened during
-    /// the hook (via `Window::emit` → bus); nothing left to return.
-    /// Always pushes new instances on `open` — nvim-style, no
-    /// identity dedup. Plugins that want toggle behavior implement
-    /// it inside their own `handle_event` (return `close = true`
-    /// when the activation key fires).
-    fn apply_ops(&mut self, idx: usize, ops: WindowOps) {
-        if ops.close {
-            self.stack.remove(idx);
-            self.clamp_focus_after_shrink();
-        }
-        for c in ops.opens {
-            self.push(c);
+    /// Drain the [`WindowOps`] queue in call order: stack mutations
+    /// hit `close_by_id` / `push_with_id`, intent ops relay onto the
+    /// App's [`AppEvent`] bus. The `Op::Close` path is silent on
+    /// stale ids (component already off the stack), so duplicate
+    /// or out-of-order closes from buggy plugins don't blow up.
+    fn apply_ops(&mut self, ops: WindowOps, event_tx: &std::sync::mpsc::Sender<AppEvent>) {
+        for op in ops.ops {
+            match op {
+                Op::Close(id) => self.close_by_id(id),
+                Op::Push { id, component } => self.push_with_id(id, component),
+                Op::Intent(intent) => {
+                    let _ = event_tx.send(AppEvent::Intent(intent));
+                }
+            }
         }
     }
 
-    /// Poll every component. Intent emission inside the hook fires
-    /// directly onto the event bus via `Window::emit`; the only
-    /// queue-back work here is applying the `close` / `open` ops.
+    /// Poll every component. Intent emissions queued by the hook
+    /// (`win.emit`) ride the same [`WindowOps`] as stack ops; the
+    /// drain below relays them through `event_tx`.
     pub fn poll(&mut self, ctx: &Context, event_tx: &std::sync::mpsc::Sender<AppEvent>) {
         // Walk in reverse so closing a component doesn't disturb
         // indices of later ones. Collect ops per index first; apply
         // after the borrow of `stack` is released.
         let len = self.stack.len();
         for i in (0..len).rev() {
+            let id = self.stack[i].0;
             let mut ops = WindowOps::default();
             {
-                let mut win = Window::new(&mut ops, ctx, event_tx);
+                let mut win = Window::new(&mut ops, ctx, id);
                 self.stack[i].1.poll(&mut win);
             }
-            self.apply_ops(i, ops);
+            self.apply_ops(ops, event_tx);
         }
     }
 

--- a/src/frontend/compositor/window.rs
+++ b/src/frontend/compositor/window.rs
@@ -37,8 +37,6 @@
 //! the compositor is the sole applier of the queue, so invariants
 //! (focus, dedup, clamp) remain framework-enforced.
 
-use std::sync::mpsc;
-
 use ratatui::Frame;
 use ratatui::layout::{Margin, Rect};
 use ratatui::style::Style;
@@ -47,35 +45,34 @@ use ratatui::widgets::{
     TableState,
 };
 
-use crate::frontend::compositor::{Component, Context};
-use crate::frontend::{AppEvent, UserIntent};
+use crate::frontend::UserIntent;
+use crate::frontend::compositor::{CardId, Component, Context};
+use crate::lua::op::Op;
 use crate::theme::{StyleKind, UiTheme};
 
-/// Queue of stack-mutation actions a [`Component`] hook recorded
-/// through [`Window`]. Drained and applied by the compositor after
-/// the hook returns. Intent emission (`win.emit`) is **not** queued
-/// here — it fires directly onto the App's [`AppEvent`] bus.
+/// Queue of [`Op`]s a [`Component`] hook recorded through [`Window`].
+/// Drained and applied by the compositor after the hook returns —
+/// stack mutations (`close` / `open`) hit the compositor's own
+/// methods, intent emissions (`emit`) flow onto the App's
+/// [`AppEvent`] bus.
+///
+/// Single Op-typed queue replaces the prior split (close: bool +
+/// opens: Vec + did_emit: bool + direct event_tx send for emit).
+/// All four behaviours land as separate variants in `ops`, preserving
+/// the order the component called them.
 #[derive(Default)]
 pub(crate) struct WindowOps {
-    /// `true` if the plugin called [`Window::close`]. Pops the
-    /// calling component. Applied before `opens` so `close + open`
-    /// replaces the component in the stack slot.
-    pub close: bool,
-    /// Components queued by [`Window::open`]. Each pushes a fresh
-    /// stack entry — nvim-style, no identity dedup. Plugins that
-    /// want toggle semantics ("close if already open") handle that
-    /// themselves in their own `handle_event`.
-    pub opens: Vec<Box<dyn Component>>,
-    /// `true` if the plugin called [`Window::emit`] at least once.
-    /// Tracked so the fall-through logic in `Compositor::handle_event`
-    /// can tell "the hook only signalled ignore()" from "the hook
-    /// did emit something" — without this flag, an emit-then-ignore
-    /// component would leak its key down to the base layer.
-    pub did_emit: bool,
-    /// `true` if the plugin called [`Window::ignore`]. Meaningful
-    /// only when no other op was queued — in that case the
-    /// compositor re-delivers the event to the base layer (unless
-    /// the handler already was the base). Ignored otherwise.
+    /// Stack mutations + intent emissions the hook recorded, in
+    /// call order. Drained by [`Compositor`](super::Compositor)
+    /// after the hook returns:
+    /// - [`Op::Close`] → `Compositor::close_by_id`
+    /// - [`Op::Push`] → `Compositor::push_with_id`
+    /// - [`Op::Intent`] → relayed to the App's `AppEvent` channel
+    pub ops: Vec<Op>,
+    /// `true` if the hook called [`Window::ignore`]. Meaningful only
+    /// when no [`Op`] was queued — in that case the compositor
+    /// re-delivers the event to the base layer (unless the handler
+    /// already was the base). Ignored otherwise.
     pub ignored: bool,
 }
 
@@ -84,7 +81,32 @@ impl WindowOps {
     /// hook's only effect was `ignore()`, this is also true (ignore
     /// itself is a signal, not an op).
     pub(crate) fn is_ignorable_noop(&self) -> bool {
-        !self.close && self.opens.is_empty() && !self.did_emit
+        self.ops.is_empty()
+    }
+
+    /// Test helper: did the hook queue any [`Op::Close`]?
+    #[cfg(test)]
+    pub(crate) fn closed(&self) -> bool {
+        self.ops.iter().any(|op| matches!(op, Op::Close(_)))
+    }
+
+    /// Test helper: did the hook queue any [`Op::Push`]?
+    #[cfg(test)]
+    pub(crate) fn pushed(&self) -> bool {
+        self.ops.iter().any(|op| matches!(op, Op::Push { .. }))
+    }
+
+    /// Test helper: every [`UserIntent`] the hook queued via
+    /// [`Window::emit`], in call order.
+    #[cfg(test)]
+    pub(crate) fn intents(&self) -> Vec<UserIntent> {
+        self.ops
+            .iter()
+            .filter_map(|op| match op {
+                Op::Intent(intent) => Some(intent.clone()),
+                _ => None,
+            })
+            .collect()
     }
 }
 
@@ -100,16 +122,17 @@ impl WindowOps {
 pub struct Window<'a> {
     ops: &'a mut WindowOps,
     ctx: &'a Context,
-    event_tx: &'a mpsc::Sender<AppEvent>,
+    /// Stable id of the component this `Window` was created for.
+    /// `close()` enqueues `Op::Close(my_id)`; the compositor pops
+    /// the matching entry by id rather than by stack index, so
+    /// hooks remain valid even when ops queued before `close`
+    /// reorder the stack.
+    my_id: CardId,
 }
 
 impl<'a> Window<'a> {
-    pub(crate) fn new(
-        ops: &'a mut WindowOps,
-        ctx: &'a Context,
-        event_tx: &'a mpsc::Sender<AppEvent>,
-    ) -> Self {
-        Self { ops, ctx, event_tx }
+    pub(crate) fn new(ops: &'a mut WindowOps, ctx: &'a Context, my_id: CardId) -> Self {
+        Self { ops, ctx, my_id }
     }
 
     /// App-level snapshot passed for this hook (map center, theme id).
@@ -118,11 +141,11 @@ impl<'a> Window<'a> {
     }
 
     /// Pop the calling component from the stack after the hook
-    /// returns. Idempotent — a second call is a no-op. Applied
-    /// before `open()`s so `close(); open(c);` replaces this
-    /// component with `c`.
+    /// returns. Idempotent — a second call queues a redundant
+    /// `Op::Close(my_id)` that the compositor silently ignores
+    /// once this component is already off the stack.
     pub fn close(&mut self) {
-        self.ops.close = true;
+        self.ops.ops.push(Op::Close(self.my_id));
     }
 
     /// Push `c` on top of the stack after the hook returns. Always
@@ -131,19 +154,20 @@ impl<'a> Window<'a> {
     /// inside its own `handle_event` (return `close` when already
     /// open, push otherwise).
     pub fn open(&mut self, c: Box<dyn Component>) {
-        self.ops.opens.push(c);
+        self.ops.ops.push(Op::Push {
+            id: CardId::next(),
+            component: c,
+        });
     }
 
-    /// Send `msg` onto the App's unified [`AppEvent`] bus, wrapped
-    /// as [`AppEvent::Intent`]. The App's main loop drains the bus
-    /// in the same iteration's `try_recv` pass after this hook
-    /// returns, so `emit + close` still results in the msg being
-    /// dispatched (against the post-pop state). A failed send means
-    /// the bus receiver has been dropped (App teardown) — silently
-    /// ignored.
+    /// Queue `msg` as an [`Op::Intent`]; the compositor relays it
+    /// onto the App's unified [`AppEvent`] bus when it drains this
+    /// `WindowOps`. The App's main loop picks it up in the same
+    /// iteration's `try_recv` pass after this hook returns, so
+    /// `emit + close` still dispatches the msg (against the
+    /// post-pop state).
     pub fn emit(&mut self, msg: UserIntent) {
-        self.ops.did_emit = true;
-        let _ = self.event_tx.send(AppEvent::Intent(msg));
+        self.ops.ops.push(Op::Intent(msg));
     }
 
     /// Signal "this event isn't mine". With no other op queued,

--- a/src/frontend/palette/mod.rs
+++ b/src/frontend/palette/mod.rs
@@ -317,38 +317,25 @@ mod tests {
             .collect()
     }
 
-    use crate::frontend::AppEvent;
+    use crate::frontend::compositor::CardId;
     use crate::frontend::compositor::window::WindowOps;
 
-    /// Dispatch a key into the palette and return the queued stack
-    /// ops + the `UserIntent`s the hook emitted onto a disposable bus.
-    /// Tests that only care about ops can ignore the second tuple
-    /// element via `let (ops, _) = ...;`.
-    fn dispatch(
-        p: &mut PaletteComponent,
-        code: KeyCode,
-        mods: KeyModifiers,
-    ) -> (WindowOps, Vec<UserIntent>) {
-        let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
+    /// Dispatch a key into the palette and return the queued
+    /// [`WindowOps`]; tests inspect via the `closed()` / `pushed()` /
+    /// `intents()` helpers.
+    fn dispatch(p: &mut PaletteComponent, code: KeyCode, mods: KeyModifiers) -> WindowOps {
         let mut ops = WindowOps::default();
         {
-            let mut win = Window::new(&mut ops, &CTX, &tx);
+            let mut win = Window::new(&mut ops, &CTX, CardId::next());
             p.handle_event(KeyEvent::new(code, mods), &mut win);
         }
-        let mut msgs = Vec::new();
-        while let Ok(ev) = rx.try_recv() {
-            match ev {
-                AppEvent::Intent(m) => msgs.push(m),
-                other => panic!("unexpected event from palette: {other:?}"),
-            }
-        }
-        (ops, msgs)
+        ops
     }
 
-    fn expect_consumed((ops, msgs): (WindowOps, Vec<UserIntent>)) {
-        assert!(!ops.close);
-        assert!(ops.opens.is_empty());
-        assert!(msgs.is_empty());
+    fn expect_consumed(ops: WindowOps) {
+        assert!(!ops.closed());
+        assert!(!ops.pushed());
+        assert!(ops.intents().is_empty());
     }
 
     #[test]
@@ -425,10 +412,10 @@ mod tests {
     fn enter_closes_with_selected_msgs() {
         let mut p = palette_with(&["A", "B", "C"]);
         expect_consumed(dispatch(&mut p, KeyCode::Down, NONE));
-        let (ops, msgs) = dispatch(&mut p, KeyCode::Enter, NONE);
-        assert!(ops.close);
-        assert_eq!(msgs, vec![UserIntent::Map(MapAction::None)]);
-        assert!(ops.opens.is_empty());
+        let ops = dispatch(&mut p, KeyCode::Enter, NONE);
+        assert!(ops.closed());
+        assert_eq!(ops.intents(), vec![UserIntent::Map(MapAction::None)]);
+        assert!(!ops.pushed());
     }
 
     #[test]
@@ -436,17 +423,17 @@ mod tests {
         let mut p = palette_with(&["Zoom in"]);
         dispatch(&mut p, KeyCode::Char('x'), NONE);
         assert!(filtered_labels(&p).is_empty());
-        let (ops, msgs) = dispatch(&mut p, KeyCode::Enter, NONE);
-        assert!(ops.close);
-        assert!(msgs.is_empty());
+        let ops = dispatch(&mut p, KeyCode::Enter, NONE);
+        assert!(ops.closed());
+        assert!(ops.intents().is_empty());
     }
 
     #[test]
     fn esc_closes() {
         let mut p = palette_with(&["A"]);
-        let (ops, msgs) = dispatch(&mut p, KeyCode::Esc, NONE);
-        assert!(ops.close);
-        assert!(msgs.is_empty());
+        let ops = dispatch(&mut p, KeyCode::Esc, NONE);
+        assert!(ops.closed());
+        assert!(ops.intents().is_empty());
     }
 
     /// Provider that counts how many times `cancel` is invoked. Used
@@ -485,8 +472,8 @@ mod tests {
             cancel_calls: cancels.clone(),
         };
         let mut p = PaletteComponent::with_provider(Box::new(prov));
-        let (ops, _msgs) = dispatch(&mut p, KeyCode::Esc, NONE);
-        assert!(ops.close);
+        let ops = dispatch(&mut p, KeyCode::Esc, NONE);
+        assert!(ops.closed());
         assert_eq!(cancels.get(), 1);
     }
 
@@ -498,8 +485,8 @@ mod tests {
             cancel_calls: cancels.clone(),
         };
         let mut p = PaletteComponent::with_provider(Box::new(prov));
-        let (ops, _msgs) = dispatch(&mut p, KeyCode::Enter, NONE);
-        assert!(ops.close);
+        let ops = dispatch(&mut p, KeyCode::Enter, NONE);
+        assert!(ops.closed());
         assert_eq!(cancels.get(), 1);
     }
 
@@ -514,8 +501,8 @@ mod tests {
             cancel_calls: cancels.clone(),
         };
         let mut p = PaletteComponent::with_provider(Box::new(prov));
-        let (ops, _msgs) = dispatch(&mut p, KeyCode::Enter, NONE);
-        assert!(ops.close);
+        let ops = dispatch(&mut p, KeyCode::Enter, NONE);
+        assert!(ops.closed());
         assert_eq!(cancels.get(), 0);
     }
 
@@ -592,10 +579,9 @@ mod tests {
         dispatch(&mut p, KeyCode::Char('t'), NONE);
         dispatch(&mut p, KeyCode::Char('o'), NONE);
         // pending; poll should flush since interval is 0.
-        let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
         let mut ops = WindowOps::default();
         {
-            let mut win = Window::new(&mut ops, &CTX, &tx);
+            let mut win = Window::new(&mut ops, &CTX, CardId::next());
             p.poll(&mut win);
         }
         assert_eq!(*calls.borrow(), vec!["".to_string(), "to".to_string()]);
@@ -656,8 +642,8 @@ mod tests {
         let mut p = PaletteComponent::with_provider(Box::new(prov));
         dispatch(&mut p, KeyCode::Char('t'), NONE);
         dispatch(&mut p, KeyCode::Char('o'), NONE);
-        let (ops, _msgs) = dispatch(&mut p, KeyCode::Enter, NONE);
-        assert!(!ops.close, "OnEnter Enter+empty must keep palette open");
+        let ops = dispatch(&mut p, KeyCode::Enter, NONE);
+        assert!(!ops.closed(), "OnEnter Enter+empty must keep palette open");
         assert_eq!(*calls.borrow(), vec!["".to_string(), "to".to_string()]);
     }
 
@@ -670,8 +656,8 @@ mod tests {
         };
         let mut p = PaletteComponent::with_provider(Box::new(prov));
         dispatch(&mut p, KeyCode::Char('t'), NONE);
-        let (ops, _msgs) = dispatch(&mut p, KeyCode::Esc, NONE);
-        assert!(ops.close);
+        let ops = dispatch(&mut p, KeyCode::Esc, NONE);
+        assert!(ops.closed());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Component handlers' \`Window\` used a 4-field accumulator (\`close: bool\`, \`opens: Vec<Box>\`, \`did_emit: bool\`, \`ignored: bool\`) and bypassed it for intent emission (\`win.emit\` sent directly via \`event_tx\`). After the Phase 1 unification, \`Op\` already covers close / push / intent for the Lua → Frontend path; this PR folds the component-handler path onto the same vocabulary.

## Changes

- **\`WindowOps\`** becomes \`Vec<Op>\` + \`ignored: bool\` — the split \`close\` / \`opens\` / \`did_emit\` fields retire
- **\`Window\`** tracks the calling component's \`CardId\` (passed in by compositor); \`close()\` enqueues \`Op::Close(my_id)\` so the compositor pops by id (not by stack index — index can shift between earlier ops in the same hook)
- **\`open()\`** enqueues \`Op::Push { id: CardId::next(), component: c }\`
- **\`emit()\`** enqueues \`Op::Intent(msg)\` instead of sending via \`event_tx\` directly. Order is preserved: \`emit(a); close(); emit(b)\` lands as \`[Intent(a), Close, Intent(b)]\` and the compositor's \`apply_ops\` drains in that order, relaying \`Op::Intent\` onto the bus
- **\`Compositor::handle_event\` / \`poll\`** look up the component's id before constructing the \`Window\` and pass it in; \`apply_ops\` matches on \`Op\` variants and routes to \`close_by_id\` / \`push_with_id\` / \`event_tx.send(AppEvent::Intent(_))\`
- Test helpers on \`WindowOps\` (\`closed()\` / \`pushed()\` / \`intents()\`) replace bare-field reads; disposable mpsc channels in test \`dispatch\` helpers retire

After this PR, every "deferred same-thread op from a Lua plugin or Component handler" rides the same \`Op\` vocabulary.

## Test plan

- [x] \`cargo test\` — 388 / 388 pass
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

## Remaining same-thread mechanism

\`Compositor::poll\`'s per-iteration sweep — only \`PaletteComponent\` uses it (debounce timer fire). A follow-up PR can lift that onto the wake / tick path and retire \`Component::poll\` entirely.