### PR TITLE
refactor(compositor): rename handle_event → handle_key

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,9 +52,9 @@ through the Compositor; mouse events go through a pure adapter:
 
 ```
 key event
-  ↓ Compositor::handle_event(event, ctx):
+  ↓ Compositor::handle_key(event, ctx):
     [reserved]  Tab / Shift-Tab   → UserCommand::CycleFocus(…)
-    [focused]   focused component's handle_event(event, &mut win)
+    [focused]   focused component's handle_key(event, &mut win)
                   ↓ win.emit / win.open / win.close / win.ignore
     [fallback]  only if the focused component called win.ignore()
                 and focus isn't already on BaseLayer
@@ -103,7 +103,7 @@ cycling — only which component receives keys first.
 **No framework-side dedup.** nvim-style: pressing an activation key
 twice produces two instances of the plugin on the stack. Plugins
 that want toggle behaviour close themselves in their own
-`handle_event` (typically: capture the `CardHandle` returned by
+`handle_key` (typically: capture the `CardHandle` returned by
 `api.card.open`, and on the activation key call `:close()` and nil
 out the handle). This keeps the Rust core ignorant of plugin
 identity — the concrete-type / `dedup_tag` schemes the compositor

--- a/docs/design.md
+++ b/docs/design.md
@@ -69,7 +69,7 @@ Current examples:
 Surface activations (palette open, plugin activate) deliberately do
 *not* go through `UserCommand` — they're expressed as a `Component` push
 onto the compositor stack, queued through `Window::open` from inside
-a `Component`'s `handle_event` (or directly from
+a `Component`'s `handle_key` (or directly from
 `api.card.open` / `api.palette.open` on the Lua side) and applied
 atomically after the hook returns. Routing focus through `UserCommand`
 would force the dispatch table to know which surfaces exist; keeping
@@ -187,7 +187,7 @@ its `close()`.
 
 ### Why a `&mut Window` queue instead of returning a result enum
 
-Hooks (`handle_event`, `poll`) receive a `&mut Window`. Plugins
+Hooks (`handle_key`, `poll`) receive a `&mut Window`. Plugins
 record intent through it — `win.close()`, `win.open(c)`,
 `win.emit(msg)`, `win.ignore()` — and the compositor drains the
 queue after the hook returns, applying ops atomically. The drain

--- a/docs/lua-architecture.md
+++ b/docs/lua-architecture.md
@@ -165,7 +165,7 @@ Called from inside callbacks (palette invoke, keybind, on_tick):
 
 - **`ttymap.api.card.open(spec) -> CardHandle`** — push a focused
   side-panel `LuaCardComponent` onto the compositor stack. Spec
-  carries `layout`, `render`, `handle_event`, `footer_hints`, `name`.
+  carries `layout`, `render`, `handle_key`, `footer_hints`, `name`.
 - **`ttymap.api.palette.open(spec) -> PaletteHandle`** — push a
   palette-mode component. Spec carries `prompt`, `submit_mode`,
   `filter`, `items`, `execute`, `cancel`, `is_loading`. (No `poll` —

--- a/docs/lua-plugin-migration.md
+++ b/docs/lua-plugin-migration.md
@@ -82,7 +82,7 @@ local function open()
     if w then return end
     w = ttymap.api.card.open({
         render = build_lines,
-        handle_event = function(key) if key.code == "Esc" then close() end end,
+        handle_key = function(key) if key.code == "Esc" then close() end end,
     })
 end
 ttymap.register_keybind("a", function() if w then close() else open() end end)

--- a/ttymap-tui/runtime/plugin/aircraft/init.lua
+++ b/ttymap-tui/runtime/plugin/aircraft/init.lua
@@ -85,7 +85,7 @@ local function open()
         render   = build_lines,
         items    = build_items,
         selected = function() return state.selected end,
-        handle_event = function(key)
+        handle_key = function(key)
             local n = #state.aircraft
             if sidebar.up_pressed(key) then
                 state.selected = sidebar.cycle(state.selected, n, -1)

--- a/ttymap-tui/runtime/plugin/help.lua
+++ b/ttymap-tui/runtime/plugin/help.lua
@@ -90,7 +90,7 @@ local function open()
             { key = "q / Esc",      label = "close" },
         },
         render = build_lines,
-        handle_event = function(key)
+        handle_key = function(key)
             if sidebar.is_close_key(key) then
                 close()
                 return nil

--- a/ttymap-tui/runtime/plugin/quake.lua
+++ b/ttymap-tui/runtime/plugin/quake.lua
@@ -189,7 +189,7 @@ local function open_panel()
         render   = build_lines,
         items    = build_items,
         selected = function() return state.selected end,
-        handle_event = function(key)
+        handle_key = function(key)
             local n = #state.quakes
             if sidebar.up_pressed(key) then
                 state.selected = sidebar.cycle(state.selected, n, -1)

--- a/ttymap-tui/runtime/plugin/satellite/satellites.lua
+++ b/ttymap-tui/runtime/plugin/satellite/satellites.lua
@@ -105,7 +105,7 @@ function M.make(specs)
         })
     end
 
-    -- Map char → index for handle_event dispatch + window-local
+    -- Map char → index for handle_key dispatch + window-local
     -- footer hint list (visible only while the panel is focused).
     local key_to_idx = {}
     local hints = {}
@@ -309,7 +309,7 @@ function M.make(specs)
             footer_hints = hints,
             items    = build_items,
             selected = selected_index,
-            handle_event = function(key)
+            handle_key = function(key)
                 local code = key.code
                 local ch = key.char
                 local ctrl = key.ctrl

--- a/ttymap-tui/runtime/plugin/wiki/init.lua
+++ b/ttymap-tui/runtime/plugin/wiki/init.lua
@@ -243,7 +243,7 @@ local function open()
         render   = build_lines,
         items    = build_items,
         selected = function() return state.selected end,
-        handle_event = function(key)
+        handle_key = function(key)
             local code = key.code
             local ch = key.char
             local ctrl = key.ctrl

--- a/ttymap-tui/src/app/dispatcher.rs
+++ b/ttymap-tui/src/app/dispatcher.rs
@@ -149,7 +149,7 @@ impl Dispatcher {
     /// events.
     pub(super) fn handle_key_event(&mut self, key: KeyEvent, frame: Option<&MapFrame>) {
         let ctx = self.context();
-        let ops = self.compositor.handle_event(key, &ctx);
+        let ops = self.compositor.handle_key(key, &ctx);
         self.apply_ops(ops, frame);
     }
 

--- a/ttymap-tui/src/compositor/activation.rs
+++ b/ttymap-tui/src/compositor/activation.rs
@@ -36,7 +36,7 @@ pub struct Activation {
 /// Palette entry description. Selection always pushes a fresh
 /// component on the stack — there's no toggle/spawn distinction now
 /// that the compositor doesn't dedup. A plugin that wants "close on
-/// re-select" closes itself in its own `handle_event`.
+/// re-select" closes itself in its own `handle_key`.
 pub struct PaletteEntry {
     pub label: String,
     pub hint: String,

--- a/ttymap-tui/src/compositor/base.rs
+++ b/ttymap-tui/src/compositor/base.rs
@@ -17,7 +17,7 @@
 //! BaseLayer doesn't need to know about it.
 //!
 //! Because it's always at the very bottom of the stack, its
-//! `handle_event` only runs when the focused (possibly higher)
+//! `handle_key` only runs when the focused (possibly higher)
 //! component called `win.ignore()` — exactly the old
 //! "pass through to background" cases.
 //!
@@ -91,7 +91,7 @@ impl BaseLayer {
 }
 
 impl Component for BaseLayer {
-    fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
+    fn handle_key(&mut self, event: KeyEvent, win: &mut Window) {
         let KeyEvent {
             code, modifiers, ..
         } = event;
@@ -170,7 +170,7 @@ mod tests {
         let mut ops = WindowOps::default();
         {
             let mut win = Window::new(&mut ops, &CTX, CardId::next());
-            bg.handle_event(KeyEvent::new(code, NONE), &mut win);
+            bg.handle_key(KeyEvent::new(code, NONE), &mut win);
         }
         ops
     }

--- a/ttymap-tui/src/compositor/component.rs
+++ b/ttymap-tui/src/compositor/component.rs
@@ -50,10 +50,10 @@ pub enum Placement {
 /// nvim-style: the compositor never deduplicates pushes. Pressing an
 /// activation key twice produces two instances of the plugin on the
 /// stack. Plugins that want toggle behavior implement self-close in
-/// their own `handle_event` (return `win.close()` when the activation
+/// their own `handle_key` (return `win.close()` when the activation
 /// key fires while focused).
 ///
-/// The event-producing hooks ([`handle_event`](Self::handle_event)
+/// The event-producing hooks ([`handle_key`](Self::handle_key)
 /// and [`poll`](Self::poll)) receive a
 /// [`&mut Window`](super::window::Window) and express intent through it
 /// (`win.close()`, `win.open(c)`, `win.emit(msg)`, `win.ignore()`).
@@ -69,7 +69,7 @@ pub trait Component {
     /// Default impl is `win.ignore()` — the non-modal "I don't bind
     /// any keys, pass through to the base layer" behaviour. Plugins
     /// that consume keys override this.
-    fn handle_event(&mut self, _event: KeyEvent, win: &mut Window) {
+    fn handle_key(&mut self, _event: KeyEvent, win: &mut Window) {
         win.ignore();
     }
 

--- a/ttymap-tui/src/compositor/mod.rs
+++ b/ttymap-tui/src/compositor/mod.rs
@@ -189,7 +189,7 @@ impl Compositor {
     /// like a `w` window handle, an `enabled` feed flag, …).
     /// Closing from the outside via `stack.remove` would leave
     /// the lua-side state pointing at a stale handle.
-    pub fn handle_event(&mut self, event: KeyEvent, ctx: &Context) -> Vec<Op> {
+    pub fn handle_key(&mut self, event: KeyEvent, ctx: &Context) -> Vec<Op> {
         if let Some(msg) = intercept_focus_key(event) {
             return vec![Op::Command(msg)];
         }
@@ -201,7 +201,7 @@ impl Compositor {
         let mut ops = WindowOps::default();
         {
             let mut win = Window::new(&mut ops, ctx, focused_id);
-            self.stack[focused].1.handle_event(event, &mut win);
+            self.stack[focused].1.handle_key(event, &mut win);
         }
         // Fall-through: only when the hook queued nothing *and*
         // explicitly called `ignore()`, and the focus isn't already
@@ -211,7 +211,7 @@ impl Compositor {
             let mut ops = WindowOps::default();
             {
                 let mut win = Window::new(&mut ops, ctx, base_id);
-                self.stack[0].1.handle_event(event, &mut win);
+                self.stack[0].1.handle_key(event, &mut win);
             }
             return ops.ops;
         }
@@ -324,7 +324,7 @@ mod tests {
     struct TagComponent(&'static str);
 
     impl Component for TagComponent {
-        fn handle_event(&mut self, _: KeyEvent, _: &mut Window) {}
+        fn handle_key(&mut self, _: KeyEvent, _: &mut Window) {}
         fn render(&self, _: &mut window::RenderWindow) {}
         fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
             vec![(self.0, "")]
@@ -409,7 +409,7 @@ mod tests {
     }
 
     impl Component for Spawner {
-        fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
+        fn handle_key(&mut self, event: KeyEvent, win: &mut Window) {
             if event.code == self.spawn_key {
                 win.open(Box::new(TagComponent(self.spawn_label)));
             }
@@ -425,7 +425,7 @@ mod tests {
     /// ops the same way App would: stack mutations are applied
     /// to `c` itself, intents are returned to the test for assertion.
     fn drive(c: &mut Compositor, event: KeyEvent, ctx: &Context) -> Vec<UserCommand> {
-        let ops = c.handle_event(event, ctx);
+        let ops = c.handle_key(event, ctx);
         let mut intents = Vec::new();
         for op in ops {
             match op {
@@ -469,7 +469,7 @@ mod tests {
 
         // Press `i` again — pushes a second wiki on top. Plugins
         // that want toggle behavior implement self-close in their
-        // own handle_event.
+        // own handle_key.
         drive(
             &mut c,
             KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE),
@@ -491,7 +491,7 @@ mod tests {
         /// plugin" that would swallow Tab if Tab reached it.
         struct SwallowsAll;
         impl Component for SwallowsAll {
-            fn handle_event(&mut self, _: KeyEvent, win: &mut Window) {
+            fn handle_key(&mut self, _: KeyEvent, win: &mut Window) {
                 win.emit(UserCommand::Map(ttymap_engine::map::MapAction::None));
             }
             fn render(&self, _: &mut window::RenderWindow) {}

--- a/ttymap-tui/src/compositor/op.rs
+++ b/ttymap-tui/src/compositor/op.rs
@@ -7,7 +7,7 @@
 //! returns.
 //!
 //! Two producers ride this enum:
-//! - **Component hooks** (`handle_event` / `poll`) enqueue via the
+//! - **Component hooks** (`handle_key` / `poll`) enqueue via the
 //!   [`Window`](super::window::Window) handle into a stack-local
 //!   `WindowOps`; the compositor drains it the moment the hook returns.
 //! - **Lua callbacks** (handle `:close()`, `api.card.open`,

--- a/ttymap-tui/src/compositor/window.rs
+++ b/ttymap-tui/src/compositor/window.rs
@@ -1,10 +1,10 @@
 //! [`Window`] — capability-constrained handle passed to components.
 //!
-//! Components receive a `&mut Window` on every hook (`handle_event`
+//! Components receive a `&mut Window` on every hook (`handle_key`
 //! and `poll`). They express intent by calling methods on it:
 //!
 //! ```ignore
-//! fn handle_event(&mut self, ev: KeyEvent, win: &mut Window) {
+//! fn handle_key(&mut self, ev: KeyEvent, win: &mut Window) {
 //!     if ev.code == KeyCode::Esc {
 //!         win.close();
 //!     } else if enter_with_selection {
@@ -152,7 +152,7 @@ impl<'a> Window<'a> {
     /// Push `c` on top of the stack after the hook returns. Always
     /// pushes a fresh entry — no identity dedup. A plugin that
     /// wants "open or focus existing" semantics implements that
-    /// inside its own `handle_event` (return `close` when already
+    /// inside its own `handle_key` (return `close` when already
     /// open, push otherwise).
     pub fn open(&mut self, c: Box<dyn Component>) {
         self.ops.ops.push(Op::Push {

--- a/ttymap-tui/src/lua/api/imperative.rs
+++ b/ttymap-tui/src/lua/api/imperative.rs
@@ -73,7 +73,7 @@ fn build_card_table(lua: &Lua, tag: &'static str, ops: OpsBuffer) -> mlua::Resul
                 let id = CardId::next();
                 // Build the component on the **same** Lua VM that ran
                 // `card.open` — i.e. the setup state. The spec's
-                // callbacks (`render`, `handle_event`, …) capture
+                // callbacks (`render`, `handle_key`, …) capture
                 // upvalues in this state, so the per-window Lua handle
                 // must be a clone of it (cheap Arc bump, no copy of the
                 // VM). When `LuaCardComponent` later calls into those

--- a/ttymap-tui/src/lua/bridge/card_component.rs
+++ b/ttymap-tui/src/lua/bridge/card_component.rs
@@ -4,7 +4,7 @@
 //! Spec table fields (all optional):
 //! - `name = "..."` — display label shown in the focused-footer chip
 //! - `render = function() return lines end` — panel body
-//! - `handle_event = function(key) return action end` — focused keys
+//! - `handle_key = function(key) return action end` — focused keys
 //! - `footer_hints = { {key, label}, ... }` — focused footer hints
 //!
 //! All `LuaCardComponent`s render in the left sidebar — there's no
@@ -62,7 +62,7 @@ use crate::theme::StyleKind;
 /// the matching [`CardHandle`](super::card_handle::CardHandle)
 /// enqueues an [`Op::Close`](crate::compositor::op::Op::Close) keyed by the
 /// reserved [`CardId`](crate::compositor::CardId), or when
-/// the spec's `handle_event` returns `{ close = true }`.
+/// the spec's `handle_key` returns `{ close = true }`.
 pub struct LuaCardComponent {
     /// Bridge plumbing — fresh `Lua` VM, registered spec table,
     /// log tag (= identification used in warnings).
@@ -98,8 +98,8 @@ pub struct LuaCardComponent {
     scroll_offset: std::cell::Cell<u16>,
     /// Last rendered inner height of this section's panel (i.e.
     /// `area - frame border`). Cached so PageUp / PageDown / C-d /
-    /// C-u in `handle_event` can use the *current* slot height as
-    /// the page step size — `handle_event` itself has no Rect.
+    /// C-u in `handle_key` can use the *current* slot height as
+    /// the page step size — `handle_key` itself has no Rect.
     /// Defaults to a sane fallback (10) when no frame has rendered
     /// yet.
     last_inner_height: std::cell::Cell<u16>,
@@ -198,11 +198,11 @@ impl LuaCardComponent {
         }
     }
 
-    /// Run the Lua side of `handle_event` and return the host action
+    /// Run the Lua side of `handle_key` and return the host action
     /// the script asked for.
     ///
     /// Three outcomes:
-    /// - **No `handle_event` field** → `KeyAction::Ignore`. Mirrors
+    /// - **No `handle_key` field** → `KeyAction::Ignore`. Mirrors
     ///   the Component trait's default impl: the spec opts out of
     ///   keymap consumption and the event flows to the base layer.
     /// - **Lua returned `nil`** → `KeyAction::Consume`. The handler
@@ -213,7 +213,7 @@ impl LuaCardComponent {
     ///   else (including a malformed table or a runtime error) logs
     ///   a warning and falls back to `Consume` so a buggy plugin
     ///   can't accidentally leak its keys to the rest of the app.
-    fn dispatch_event(&self, event: KeyEvent) -> KeyAction {
+    fn dispatch_key(&self, event: KeyEvent) -> KeyAction {
         let key = match self.build_key_table(event) {
             Ok(k) => k,
             Err(e) => {
@@ -225,7 +225,7 @@ impl LuaCardComponent {
                 return KeyAction::Consume;
             }
         };
-        match self.handle.try_call::<_, mlua::Value>("handle_event", key) {
+        match self.handle.try_call::<_, mlua::Value>("handle_key", key) {
             CallOutcome::Ok(ret) => KeyAction::from_lua_return(ret),
             CallOutcome::Missing => KeyAction::Ignore,
             CallOutcome::Errored => KeyAction::Consume,
@@ -347,8 +347,8 @@ impl LuaCardComponent {
 }
 
 impl Component for LuaCardComponent {
-    fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
-        let action = self.dispatch_event(event);
+    fn handle_key(&mut self, event: KeyEvent, win: &mut Window) {
+        let action = self.dispatch_key(event);
 
         // When the Lua spec didn't consume the event, the bridge
         // applies built-in scroll keys so overflow content is
@@ -406,7 +406,7 @@ impl Component for LuaCardComponent {
         // or width logic needed.
         let area = win.area();
         let inner = win.panel(area, self.display);
-        // Snapshot the slot's content height so handle_event can use
+        // Snapshot the slot's content height so handle_key can use
         // it as the page step for PageUp / PageDown / C-d / C-u
         // without computing layout itself.
         self.last_inner_height.set(inner.height);
@@ -520,7 +520,7 @@ mod tests {
     #[test]
     fn missing_handler_dispatches_to_ignore() {
         let c = make(r#"return { name = "noop" }"#, "noop");
-        assert_eq!(c.dispatch_event(key(KeyCode::Esc)), KeyAction::Ignore);
+        assert_eq!(c.dispatch_key(key(KeyCode::Esc)), KeyAction::Ignore);
     }
 
     #[test]
@@ -528,14 +528,11 @@ mod tests {
         let c = make(
             r#"return {
                 name = "modal",
-                handle_event = function(_) return nil end,
+                handle_key = function(_) return nil end,
             }"#,
             "modal",
         );
-        assert_eq!(
-            c.dispatch_event(key(KeyCode::Char('a'))),
-            KeyAction::Consume
-        );
+        assert_eq!(c.dispatch_key(key(KeyCode::Char('a'))), KeyAction::Consume);
     }
 
     #[test]
@@ -543,18 +540,15 @@ mod tests {
         let c = make(
             r#"return {
                 name = "esc",
-                handle_event = function(k)
+                handle_key = function(k)
                     if k.code == "Esc" then return { close = true } end
                     return nil
                 end,
             }"#,
             "esc",
         );
-        assert_eq!(c.dispatch_event(key(KeyCode::Esc)), KeyAction::Close);
-        assert_eq!(
-            c.dispatch_event(key(KeyCode::Char('x'))),
-            KeyAction::Consume
-        );
+        assert_eq!(c.dispatch_key(key(KeyCode::Esc)), KeyAction::Close);
+        assert_eq!(c.dispatch_key(key(KeyCode::Char('x'))), KeyAction::Consume);
     }
 
     #[test]
@@ -562,11 +556,11 @@ mod tests {
         let c = make(
             r#"return {
                 name = "passthrough",
-                handle_event = function(_) return { ignore = true } end,
+                handle_key = function(_) return { ignore = true } end,
             }"#,
             "passthrough",
         );
-        assert_eq!(c.dispatch_event(key(KeyCode::Char('q'))), KeyAction::Ignore);
+        assert_eq!(c.dispatch_key(key(KeyCode::Char('q'))), KeyAction::Ignore);
     }
 
     #[test]
@@ -574,14 +568,11 @@ mod tests {
         let c = make(
             r#"return {
                 name = "broken",
-                handle_event = function(_) error("kaboom") end,
+                handle_key = function(_) error("kaboom") end,
             }"#,
             "broken",
         );
-        assert_eq!(
-            c.dispatch_event(key(KeyCode::Char('a'))),
-            KeyAction::Consume
-        );
+        assert_eq!(c.dispatch_key(key(KeyCode::Char('a'))), KeyAction::Consume);
     }
 
     #[test]
@@ -589,14 +580,11 @@ mod tests {
         let c = make(
             r#"return {
                 name = "weird",
-                handle_event = function(_) return "yolo" end,
+                handle_key = function(_) return "yolo" end,
             }"#,
             "weird",
         );
-        assert_eq!(
-            c.dispatch_event(key(KeyCode::Char('z'))),
-            KeyAction::Consume
-        );
+        assert_eq!(c.dispatch_key(key(KeyCode::Char('z'))), KeyAction::Consume);
     }
 
     // Close coverage moved to `card_handle::tests::close_enqueues_op_close_idempotent`:

--- a/ttymap-tui/src/lua/bridge/card_parse.rs
+++ b/ttymap-tui/src/lua/bridge/card_parse.rs
@@ -138,7 +138,7 @@ pub(super) fn style_from_str(name: Option<&str>) -> StyleKind {
     }
 }
 
-/// What the Lua `handle_event` handler asked the host to do.
+/// What the Lua `handle_key` handler asked the host to do.
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum KeyAction {
     /// Pass the event to the base layer (Component default).

--- a/ttymap-tui/src/lua/bridge/handle.rs
+++ b/ttymap-tui/src/lua/bridge/handle.rs
@@ -75,7 +75,7 @@ impl LuaBridgeHandle {
     /// want different recovery for "plugin opted out of this hook"
     /// vs "plugin tried but threw" — e.g.
     /// [`LuaCardComponent`](super::card_component::LuaCardComponent)'s
-    /// `handle_event` maps the former to `KeyAction::Ignore`
+    /// `handle_key` maps the former to `KeyAction::Ignore`
     /// (forward to base) and the latter to `KeyAction::Consume`
     /// (don't leak buggy keys).
     pub fn try_call<A, R>(&self, method: &str, args: A) -> CallOutcome<R>

--- a/ttymap-tui/src/lua/registrar.rs
+++ b/ttymap-tui/src/lua/registrar.rs
@@ -75,7 +75,7 @@ impl Registrar {
 
     /// Add a palette entry that pushes a fresh component on
     /// selection. Plugins that want toggle behavior implement self-
-    /// close in their own `handle_event`.
+    /// close in their own `handle_key`.
     pub fn add_palette<F, C>(
         &mut self,
         label: impl Into<String>,

--- a/ttymap-tui/src/palette/mod.rs
+++ b/ttymap-tui/src/palette/mod.rs
@@ -121,7 +121,7 @@ impl PaletteComponent {
 }
 
 impl Component for PaletteComponent {
-    fn handle_event(&mut self, event: KeyEvent, win: &mut Window) {
+    fn handle_key(&mut self, event: KeyEvent, win: &mut Window) {
         let ctrl = event.modifiers.contains(KeyModifiers::CONTROL);
         let up = matches!(event.code, KeyCode::Up) || (ctrl && event.code == KeyCode::Char('p'));
         let down =
@@ -327,7 +327,7 @@ mod tests {
         let mut ops = WindowOps::default();
         {
             let mut win = Window::new(&mut ops, &CTX, CardId::next());
-            p.handle_event(KeyEvent::new(code, mods), &mut win);
+            p.handle_key(KeyEvent::new(code, mods), &mut win);
         }
         ops
     }


### PR DESCRIPTION
## Summary

- The `Component` trait's `handle_event` only ever receives `KeyEvent` — the generic name leaked into the Lua spec field as a misnomer plugin authors kept asking about
- Renames everything on the consume-key axis: trait + every impl (`BaseLayer` / `LuaCardComponent` / `PaletteComponent` / test impls), the `Compositor::handle_event` dispatcher, the bridge helper `dispatch_event` → `dispatch_key`, the Lua `card.open` spec field, every bundled plugin's spec, plus comments and 4 docs
- `App::handle_event(AppEvent)` keeps its name — that one is genuinely multi-variant (`Command` / `FrameReady` / `Input` / `Wake`), so the generic name fits

This unblocks #218 (footer_hints drift), #217 (Lua-side declarative SDK), and #216 (focus-aware keys panel) where having an accurate per-component-key hook name matters for the SDK surface.

## Test plan

- [x] `cargo test` (172 passed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] No remaining `handle_event` refs other than `App::handle_event(AppEvent)`