### PR TITLE
ci: matrix on linux/macos/windows + README troubleshooting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,15 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    # Cross-platform matrix: Linux is primary, macOS / Windows are
+    # smoke-tested every push so OS-specific regressions surface
+    # before release. `fail-fast: false` so a single OS failure does
+    # not mask the others' status.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -27,6 +35,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
+          # `runner.os` keeps each OS's cache isolated — Linux,
+          # macOS, Windows binaries are not interchangeable.
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       # All four steps need --all / --workspace explicitly: the

--- a/README.md
+++ b/README.md
@@ -111,6 +111,34 @@ PMTiles), error handling policy
 - **Write a plugin** — see [docs/lua-plugin-migration.md](docs/lua-plugin-migration.md). Drop a `*.lua` into `~/.config/ttymap/plugin/` to test without rebuilding. Simplest fetch+render: `runtime/plugin/quake.lua`. Full panel + selection + modal: `runtime/plugin/wiki/`. Debounced palette picker: `runtime/plugin/search/`.
 - **Fix a bug** — PRs welcome. The pre-commit hook runs tests, clippy, and rustfmt.
 
+## Platform support
+
+CI runs on Linux, macOS, and Windows for every push (see
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml)). Linux is the
+primary daily-driver target; macOS and Windows are smoke-tested but
+get less interactive testing.
+
+### Troubleshooting
+
+- **Windows: install via `cargo` directly** — `make install` assumes a
+  POSIX shell. Until the Makefile grows a Windows path, build with
+  `cargo build --release` and copy `target/release/ttymap.exe` plus
+  the `ttymap-tui/runtime/` directory to wherever you want them. Set
+  `TTYMAP_RUNTIME=path\to\runtime` if you don't place it under the
+  platform-default data dir (`%APPDATA%\ttymap\runtime`).
+- **Windows: use Windows Terminal, not legacy ConHost** — Braille
+  glyphs and xterm-256 colours need a font with full Braille coverage
+  (Cascadia Mono works) and a terminal that respects 256-colour ANSI.
+  Legacy ConHost (the default `cmd.exe` window pre-Windows 11) renders
+  Braille as boxes and clamps to 16 colours.
+- **macOS: tile cache & exported frames live under
+  `~/Library/Caches/ttymap` and `~/Library/Application Support/ttymap`**
+  — different from Linux's XDG paths. The `directories` crate handles
+  this transparently; only relevant if you script around the cache.
+- **Mouse drag/scroll on Windows** — works in Windows Terminal; some
+  third-party emulators don't forward mouse events. Toggle off via
+  config if your terminal traps them.
+
 ## License
 
 Dual-licensed under either of


### PR DESCRIPTION
## Summary

- `ci.yml` `check` job now runs on \`\${{ matrix.os }}\` for `[ubuntu-latest, macos-latest, windows-latest]` with `fail-fast: false` so each OS reports independently
- README gains a Platform support / Troubleshooting section covering the Windows install workaround (no POSIX make), Windows Terminal vs ConHost rendering, macOS data-dir locations, and Windows mouse caveats

Closes #77 once CI is green on all three runners. Sister of #76 (release pipeline) which will consume the same matrix.

## Test plan

- [x] Local: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (216 + 172 = 388 passing)
- [x] CI green on `ubuntu-latest`
- [x] CI green on `macos-latest`
- [x] CI green on `windows-latest`
- [x] If any OS fails: follow-up commit on this branch with the fix (likely candidates: TLS root store on windows-msvc, line-ending sensitivity in tests, path-separator assumptions)