### PR TITLE
fix(logging): surface --log init failures on stderr (#226)

### DIFF
--- a/ttymap-tui/src/main.rs
+++ b/ttymap-tui/src/main.rs
@@ -59,8 +59,14 @@ fn main() {
     // logger is registered and the `log::*!` macros are no-ops.
     // When set, logs land in ~/.local/state/ttymap/ttymap.log
     // (truncated on each launch, so debug sessions don't accumulate).
-    if let Some(level) = cli.log.as_deref() {
-        ttymap_tui::logging::init(level).ok();
+    // Init failure (state-dir missing, file open denied, logger
+    // already installed by something earlier in the process) is
+    // surfaced on stderr — the alternative was silent failure where
+    // `--log` had no observable effect and no error to grep for.
+    if let Some(level) = cli.log.as_deref()
+        && let Err(e) = ttymap_tui::logging::init(level)
+    {
+        eprintln!("ttymap: --log requested but logging init failed: {e}");
     }
 
     // Resolve runtime path before any Lua state spins up. Both the


### PR DESCRIPTION
## Summary

- `logging::init(level).ok()` discarded the `Result`, leaving `--log` a silent no-op when state-dir creation, file open, or `set_boxed_logger` failed
- Now print one stderr line naming the failure; fires before the TUI takes over the terminal so the message is visible
- No change when `--log` is omitted or init succeeds

Closes #226.

## Test plan

- [x] `cargo test --workspace` (216 + 174 pass)
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo fmt --check`
- [ ] Manual: `--log debug` happy path → no extra noise; `--log debug` after locking the state dir → visible stderr message