### PR TITLE
feat(plugins): add notify calls to network-bound plugins

### DIFF
--- a/ttymap-tui/runtime/plugin/aircraft/init.lua
+++ b/ttymap-tui/runtime/plugin/aircraft/init.lua
@@ -14,6 +14,7 @@ local state = {
     selected       = 1,   -- 1-based index
     job            = nil, -- pending fetch
     last_fetch_sec = 0,   -- wall-clock second of last fetch start
+    initial_done   = false, -- whether the first fetch after open landed
 }
 local w = nil  -- card handle while open; nil while closed (also acts as enabled flag)
 
@@ -46,9 +47,22 @@ ttymap.api.frame.on_tick(function(map)
         local body = state.job:try_take()
         if body then
             local payload = ttymap.json:parse(body)
+            if not payload then
+                ttymap.notify("aircraft: OpenSky response unparseable",
+                              { level = "warn" })
+            end
             state.aircraft = opensky.parse(payload)
             if state.selected > #state.aircraft then
                 state.selected = math.max(1, #state.aircraft)
+            end
+            -- One info popup on the first successful fetch after
+            -- opening the panel; subsequent refreshes stay quiet so
+            -- the corner doesn't get spammed every interval.
+            if not state.initial_done then
+                state.initial_done = true
+                ttymap.notify(string.format(
+                    "aircraft: %d in view", #state.aircraft
+                ))
             end
             state.job = nil
         end
@@ -71,6 +85,10 @@ local function close()
     if w then
         w:close()
         w = nil
+        -- Reset the first-fetch flag so the next open re-shows the
+        -- "N in view" popup. Without this, reopening would silently
+        -- reuse stale state.
+        state.initial_done = false
     end
 end
 

--- a/ttymap-tui/runtime/plugin/aircraft/init.lua
+++ b/ttymap-tui/runtime/plugin/aircraft/init.lua
@@ -48,8 +48,13 @@ ttymap.api.frame.on_tick(function(map)
         if body then
             local payload = ttymap.json:parse(body)
             if not payload then
+                -- Short-circuit so we don't follow up the warn with
+                -- a misleading "0 in view" info popup; the existing
+                -- panel state stays untouched until a healthy fetch.
                 ttymap.notify("aircraft: OpenSky response unparseable",
                               { level = "warn" })
+                state.job = nil
+                return
             end
             state.aircraft = opensky.parse(payload)
             if state.selected > #state.aircraft then

--- a/ttymap-tui/runtime/plugin/here.lua
+++ b/ttymap-tui/runtime/plugin/here.lua
@@ -19,6 +19,12 @@ ttymap.api.frame.on_tick(function()
             and type(p.latitude) == "number"
             and type(p.longitude) == "number" then
             ttymap.map:jump(p.longitude, p.latitude)
+            ttymap.notify(string.format(
+                "Jumped to %.4f, %.4f", p.latitude, p.longitude
+            ))
+        else
+            ttymap.notify("here: geoip response missing lat/lon",
+                          { level = "warn" })
         end
         state.job = nil
     end

--- a/ttymap-tui/runtime/plugin/quake.lua
+++ b/ttymap-tui/runtime/plugin/quake.lua
@@ -137,6 +137,8 @@ ttymap.api.frame.on_tick(function(map)
             if not payload then
                 ttymap.notify("quake: USGS response unparseable",
                               { level = "warn" })
+                state.job = nil
+                return
             end
             state.quakes = parse_features(payload)
             if state.selected > #state.quakes then

--- a/ttymap-tui/runtime/plugin/quake.lua
+++ b/ttymap-tui/runtime/plugin/quake.lua
@@ -134,18 +134,26 @@ ttymap.api.frame.on_tick(function(map)
         local body = state.job:try_take()
         if body then
             local payload = ttymap.json:parse(body)
+            if not payload then
+                ttymap.notify("quake: USGS response unparseable",
+                              { level = "warn" })
+            end
             state.quakes = parse_features(payload)
             if state.selected > #state.quakes then
                 state.selected = math.max(1, #state.quakes)
             end
             -- Auto-recentre on the first non-empty result so
             -- the user lands somewhere meaningful right after
-            -- toggling on.
+            -- toggling on. The same flag gates the one-time info
+            -- popup so subsequent refreshes stay quiet.
             if not state.initial_jump_done and #state.quakes > 0 then
                 local top = highest_magnitude(state.quakes)
                 if top then
                     state.initial_jump_done = true
                     ttymap.map:jump(top.lon, top.lat)
+                    ttymap.notify(string.format(
+                        "quake: %d recent", #state.quakes
+                    ))
                 end
             end
             state.job = nil

--- a/ttymap-tui/runtime/plugin/satellite/satellites.lua
+++ b/ttymap-tui/runtime/plugin/satellite/satellites.lua
@@ -256,6 +256,22 @@ function M.make(specs)
                     else
                         sat.tles = ttymap.sgp4:parse_tle(body)
                     end
+                    if not sat.tles then
+                        ttymap.notify(string.format(
+                            "satellite: TLE parse failed for %s",
+                            sat.display or "satellite"
+                        ), { level = "warn" })
+                    elseif sat.kind == "group" then
+                        ttymap.notify(string.format(
+                            "satellite: loaded %d TLEs (%s)",
+                            #sat.tles, sat.display or sat.group or "?"
+                        ))
+                    else
+                        ttymap.notify(string.format(
+                            "satellite: loaded %s",
+                            sat.display or "satellite"
+                        ))
+                    end
                     sat.fetch_job = nil
                 end
             end

--- a/ttymap-tui/runtime/plugin/search/init.lua
+++ b/ttymap-tui/runtime/plugin/search/init.lua
@@ -30,7 +30,17 @@ ttymap.api.frame.on_tick(function()
     if state.job then
         local body = state.job:try_take()
         if body then
-            state.candidates = nominatim.parse(ttymap.json:parse(body))
+            local payload = ttymap.json:parse(body)
+            if not payload then
+                ttymap.notify("search: Nominatim response unparseable",
+                              { level = "warn" })
+            end
+            state.candidates = nominatim.parse(payload)
+            if #state.candidates == 0 and state.last_query ~= "" then
+                ttymap.notify(string.format(
+                    "No results for \"%s\"", state.last_query
+                ))
+            end
             state.pending = false
             state.job = nil
         end

--- a/ttymap-tui/runtime/plugin/search/init.lua
+++ b/ttymap-tui/runtime/plugin/search/init.lua
@@ -32,8 +32,15 @@ ttymap.api.frame.on_tick(function()
         if body then
             local payload = ttymap.json:parse(body)
             if not payload then
+                -- Short-circuit so we don't follow up with a
+                -- misleading `No results for "X"` info popup —
+                -- there may well be results, we just couldn't read
+                -- the response.
                 ttymap.notify("search: Nominatim response unparseable",
                               { level = "warn" })
+                state.pending = false
+                state.job = nil
+                return
             end
             state.candidates = nominatim.parse(payload)
             if #state.candidates == 0 and state.last_query ~= "" then

--- a/ttymap-tui/runtime/plugin/wiki/init.lua
+++ b/ttymap-tui/runtime/plugin/wiki/init.lua
@@ -122,7 +122,12 @@ local function step_state_machine()
     if not body then return end
 
     if state.phase == "geosearching" then
-        local pages = parse_geosearch(ttymap.json:parse(body))
+        local payload = ttymap.json:parse(body)
+        if not payload then
+            ttymap.notify("wiki: geosearch response unparseable",
+                          { level = "warn" })
+        end
+        local pages = parse_geosearch(payload)
         state.job = nil
         if #pages == 0 then
             state.phase = "idle"
@@ -135,7 +140,12 @@ local function step_state_machine()
         state.phase = "extracting"
         state.job = ttymap.http:fetch(extracts_url(titles))
     elseif state.phase == "extracting" then
-        local extracts = parse_extracts(ttymap.json:parse(body))
+        local payload = ttymap.json:parse(body)
+        if not payload then
+            ttymap.notify("wiki: extracts response unparseable",
+                          { level = "warn" })
+        end
+        local extracts = parse_extracts(payload)
         local merged = {}
         for _, p in ipairs(state.pending_pages or {}) do
             table.insert(merged, {
@@ -150,6 +160,11 @@ local function step_state_machine()
         state.job = nil
         state.phase = "idle"
         merge_articles(merged)
+        if #merged > 0 then
+            ttymap.notify(string.format("wiki: %d articles nearby", #merged))
+        else
+            ttymap.notify("wiki: no articles nearby")
+        end
     end
 end
 

--- a/ttymap-tui/runtime/plugin/wiki/init.lua
+++ b/ttymap-tui/runtime/plugin/wiki/init.lua
@@ -126,6 +126,9 @@ local function step_state_machine()
         if not payload then
             ttymap.notify("wiki: geosearch response unparseable",
                           { level = "warn" })
+            state.job = nil
+            state.phase = "idle"
+            return
         end
         local pages = parse_geosearch(payload)
         state.job = nil
@@ -144,6 +147,10 @@ local function step_state_machine()
         if not payload then
             ttymap.notify("wiki: extracts response unparseable",
                           { level = "warn" })
+            state.pending_pages = nil
+            state.job = nil
+            state.phase = "idle"
+            return
         end
         local extracts = parse_extracts(payload)
         local merged = {}


### PR DESCRIPTION
## Summary

Surface success / failure for the bundled fetchers so the user isn't left guessing whether a remote endpoint replied at all.

| plugin | success | failure |
|---|---|---|
| **here** | `Jumped to LAT, LON` | `here: geoip response missing lat/lon` |
| **aircraft** | `aircraft: N in view` (once per panel open) | `aircraft: OpenSky response unparseable` |
| **quake** | `quake: N recent` (first non-empty fetch only) | `quake: USGS response unparseable` |
| **wiki** | `wiki: N articles nearby` / `no articles nearby` | `wiki: geosearch / extracts response unparseable` |
| **search** | `No results for "X"` (empty) | `search: Nominatim response unparseable` |
| **satellite** | `satellite: loaded N TLEs (group)` / `loaded NAME` | `satellite: TLE parse failed for NAME` |

Recurring fetchers (aircraft, quake) gate the success notify on a one-shot flag so refreshes don't spam the corner — closing the panel resets the flag for the next open.

## Test plan

- [x] `cargo test --workspace` (216 + 174 pass)
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo fmt --check`
- [ ] Manual: trigger each plugin and confirm popup appears top-left
- [ ] Manual: re-fetch path stays quiet (no info spam)