### PR TITLE
feat(notify): theme-aware severity colors via host keywords

### DIFF
--- a/ttymap-tui/runtime/plugin/notify.lua
+++ b/ttymap-tui/runtime/plugin/notify.lua
@@ -19,18 +19,14 @@ local RING_CAP = 32
 local MAX_TEXT_WIDTH = 60  -- truncate long messages so the popup
                            -- doesn't dominate the map area
 
--- xterm-256 indices that survive both DARK and BRIGHT themes
--- without disappearing into the map. Yellow / orange / red are the
--- universal "needs your eyes" palette and pop against any tile
--- colour the renderer has handed out.
-local COLOR_BY_LEVEL = {
-    info = 226,   -- bright yellow
-    warn = 208,   -- orange
-    error = 196,  -- bright red
-}
-
+-- Theme-aware severity keywords resolved by the host (info / warn /
+-- error map to per-theme xterm indices that read on both dark and
+-- bright backgrounds). Mirrors how chrome plugins like `info.lua`
+-- pass `"accent"` and let the host pick the right colour.
 local function color_for(level)
-    return COLOR_BY_LEVEL[level] or COLOR_BY_LEVEL.info
+    if level == "error" then return "error" end
+    if level == "warn" then return "warn" end
+    return "info"
 end
 
 -- Wall-clock seconds. `os.time()` ticks even while the host idles,

--- a/ttymap-tui/src/lua/api/map.rs
+++ b/ttymap-tui/src/lua/api/map.rs
@@ -22,9 +22,10 @@
 //!
 //! Color args: `point` / `label` / `polyline` / `text_anchored`
 //! accept either a theme-aware keyword (`"accent"` | `"accent_alt"` |
-//! `"muted"` | `"road"`) or a direct xterm-256 integer index
-//! (0..=255). Palette accessor methods (`accent_color`, `road_color`,
-//! etc.) return xterm indices for round-tripping.
+//! `"muted"` | `"road"` | `"info"` | `"warn"` | `"error"`) or a
+//! direct xterm-256 integer index (0..=255). Palette accessor
+//! methods (`accent_color`, `road_color`, etc.) return xterm
+//! indices for round-tripping.
 
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
@@ -231,6 +232,12 @@ fn resolve_keyword(p: &MapApi<'_>, keyword: &mlua::String) -> u8 {
         Ok("road") => p.road_color_xterm(),
         Ok("accent_alt") => xterm_index(p.accent_alt_color()),
         Ok("muted") => xterm_index(p.muted_color()),
+        // Severity keywords for chrome (notify popups). Theme-aware
+        // — DARK uses bright yellow / orange / red, BRIGHT uses
+        // darker variants that read on white.
+        Ok("info") => xterm_index(p.notify_info_color()),
+        Ok("warn") => xterm_index(p.notify_warn_color()),
+        Ok("error") => xterm_index(p.notify_error_color()),
         _ => xterm_index(p.accent_color()),
     }
 }

--- a/ttymap-tui/src/lua/map_api.rs
+++ b/ttymap-tui/src/lua/map_api.rs
@@ -165,6 +165,24 @@ impl<'a> MapApi<'a> {
         }
     }
 
+    /// Severity colour for `info`-level transient messages
+    /// (the bundled `notify.lua` uses the `"info"` keyword which
+    /// resolves here). Picked per theme so the same plugin code
+    /// reads on both dark and bright backgrounds.
+    pub fn notify_info_color(&self) -> Color {
+        self.theme.notify_info
+    }
+
+    /// Severity colour for `warn`-level transient messages.
+    pub fn notify_warn_color(&self) -> Color {
+        self.theme.notify_warn
+    }
+
+    /// Severity colour for `error`-level transient messages.
+    pub fn notify_error_color(&self) -> Color {
+        self.theme.notify_error
+    }
+
     // ── Drawing primitives ──────────────────────────────────────────
 
     /// Plot a single-cell glyph at the given world coordinate. No-op

--- a/ttymap-tui/src/theme/ui.rs
+++ b/ttymap-tui/src/theme/ui.rs
@@ -8,28 +8,75 @@ use ratatui::widgets::{Block, Borders};
 
 use super::ColorPalette;
 
-/// Computed UI theme from a [`ColorPalette`]. The five `Color` fields
-/// are `Color::Indexed(u8)` — xterm-256 palette entries.
+/// Computed UI theme from a [`ColorPalette`]. The `Color` fields are
+/// `Color::Indexed(u8)` — xterm-256 palette entries.
+///
+/// Severity colours (`notify_info` / `notify_warn` / `notify_error`)
+/// are TUI-side chrome only — the engine palette stays focused on
+/// map features. Picked per theme so the bundled `notify.lua`'s
+/// `"info"` / `"warn"` / `"error"` keywords (resolved by the Lua
+/// bridge) read on both light and dark backgrounds.
 pub struct UiTheme {
     pub accent: Color,
     pub accent_alt: Color,
     pub fg: Color,
     pub muted_color: Color,
     pub bg: Color,
+    pub notify_info: Color,
+    pub notify_warn: Color,
+    pub notify_error: Color,
     /// Raw palette retained so callers (e.g. the Lua bridge's colour
     /// resolver) can access palette indices that aren't promoted to
     /// `Color` fields here.
     pub palette: ColorPalette,
 }
 
+/// xterm-256 indices for one severity tier across (info, warn, error).
+struct SeverityPalette {
+    info: u8,
+    warn: u8,
+    error: u8,
+}
+
+/// Severity tier for a dark background — saturated/bright values
+/// so the popup pops on black.
+const DARK_SEVERITY: SeverityPalette = SeverityPalette {
+    info: 226,  // bright yellow
+    warn: 208,  // orange
+    error: 196, // bright red
+};
+
+/// Severity tier for a light background — darker values so the
+/// popup remains legible on white. Bright yellow on white is
+/// nearly invisible, hence the swap.
+const BRIGHT_SEVERITY: SeverityPalette = SeverityPalette {
+    info: 130,  // DarkGoldenrod3
+    warn: 166,  // DarkOrange3
+    error: 124, // Red3
+};
+
+/// Resolve a palette to its severity tier. Today there are two
+/// presets so the dispatch is a single equality check on the bg
+/// index; future light themes register here alongside the rest.
+fn severity_for(p: &ColorPalette) -> &'static SeverityPalette {
+    match p.background {
+        231 => &BRIGHT_SEVERITY,
+        _ => &DARK_SEVERITY,
+    }
+}
+
 impl UiTheme {
     pub fn from_palette(p: &ColorPalette) -> Self {
+        let sev = severity_for(p);
         Self {
             accent: Color::Indexed(p.accent),
             accent_alt: Color::Indexed(p.accent_alt),
             fg: Color::Indexed(p.fg),
             muted_color: Color::Indexed(p.muted),
             bg: Color::Indexed(p.background),
+            notify_info: Color::Indexed(sev.info),
+            notify_warn: Color::Indexed(sev.warn),
+            notify_error: Color::Indexed(sev.error),
             palette: ColorPalette { ..*p },
         }
     }


### PR DESCRIPTION
## Summary

Bright theme made the notify popup nearly unreadable — bright yellow on white has no contrast. Switch to the same pattern the chrome plugins (info / scalebar / attribution) use: pass a keyword string and let the host pick the colour for the active theme.

## Layering

Engine palette stays focused on map features. Severity is **TUI / chrome only** — lives in \`ttymap-tui/src/theme/ui.rs\` next to \`UiTheme\`.

\`\`\`
ttymap-tui/src/theme/ui.rs
    UiTheme { …, notify_info, notify_warn, notify_error: Color }
    DARK_SEVERITY  = { 226, 208, 196 }   -- bg=16 系 (bright on black)
    BRIGHT_SEVERITY = { 130, 166, 124 }  -- bg=231 系 (dark on white)
    severity_for(palette) → dispatch on bg index

ttymap-tui/src/lua/map_api.rs
    notify_info_color() / notify_warn_color() / notify_error_color()

ttymap-tui/src/lua/api/map.rs
    resolve_keyword: \"info\" / \"warn\" / \"error\" を追加

ttymap-tui/runtime/plugin/notify.lua
    keyword 文字列を渡すだけ — 自前の theme detection を撤去
\`\`\`

## Test plan

- [x] \`cargo test --workspace\` (216 + 174 pass)
- [x] \`cargo clippy --workspace --all-targets\`
- [x] \`cargo fmt --check\`
- [ ] Manual: dark theme → 黄/橙/赤、bright theme → 暗黄/暗橙/暗赤、both readable