### PR TITLE
refactor(notify): drop severity colors, render all popups in accent

### DIFF
--- a/ttymap-tui/runtime/plugin/notify.lua
+++ b/ttymap-tui/runtime/plugin/notify.lua
@@ -7,6 +7,14 @@
 -- popup per message for `TTL_S` after arrival. Newest at the top;
 -- a blank row between popups separates them visually.
 --
+-- All popups render in `accent` regardless of `level` — severity
+-- gets conveyed by the message text (plugin authors free to prefix
+-- "warn:" / "error:" / icons themselves). Theme-coloured severity
+-- mapping was tried and dropped: `accent_alt` is cyan in DARK and
+-- red in BRIGHT, which inverts the warn/error semantic across
+-- themes. `level` stays in the event payload so future subscribers
+-- (audit log, sound, etc) can still filter by it.
+--
 -- The ring lives entirely here — Rust side has no notify state at
 -- all, just the generic event bus.
 
@@ -18,16 +26,6 @@ local TTL_S = 4
 local RING_CAP = 32
 local MAX_TEXT_WIDTH = 60  -- truncate long messages so the popup
                            -- doesn't dominate the map area
-
--- Theme-aware severity keywords resolved by the host (info / warn /
--- error map to per-theme xterm indices that read on both dark and
--- bright backgrounds). Mirrors how chrome plugins like `info.lua`
--- pass `"accent"` and let the host pick the right colour.
-local function color_for(level)
-    if level == "error" then return "error" end
-    if level == "warn" then return "warn" end
-    return "info"
-end
 
 -- Wall-clock seconds. `os.time()` ticks even while the host idles,
 -- which is what we need for "expire after N seconds even if the
@@ -85,12 +83,11 @@ ttymap.api.frame.on_tick(function(map)
     local n = #entries
     for i = n, 1, -1 do
         local e = entries[i]
-        local color = color_for(e.level)
         local inner = " " .. e.message .. " "
         local border = string.rep("─", dwidth(inner))
-        map:text_anchored("top-left", row,     "╭" .. border .. "╮", color)
-        map:text_anchored("top-left", row + 1, "│" .. inner .. "│",  color)
-        map:text_anchored("top-left", row + 2, "╰" .. border .. "╯", color)
+        map:text_anchored("top-left", row,     "╭" .. border .. "╮", "accent")
+        map:text_anchored("top-left", row + 1, "│" .. inner .. "│",  "accent")
+        map:text_anchored("top-left", row + 2, "╰" .. border .. "╯", "accent")
         row = row + 3
         if i > 1 then row = row + 1 end  -- gap before next popup
     end

--- a/ttymap-tui/src/lua/api/map.rs
+++ b/ttymap-tui/src/lua/api/map.rs
@@ -22,10 +22,9 @@
 //!
 //! Color args: `point` / `label` / `polyline` / `text_anchored`
 //! accept either a theme-aware keyword (`"accent"` | `"accent_alt"` |
-//! `"muted"` | `"road"` | `"info"` | `"warn"` | `"error"`) or a
-//! direct xterm-256 integer index (0..=255). Palette accessor
-//! methods (`accent_color`, `road_color`, etc.) return xterm
-//! indices for round-tripping.
+//! `"muted"` | `"road"`) or a direct xterm-256 integer index
+//! (0..=255). Palette accessor methods (`accent_color`, `road_color`,
+//! etc.) return xterm indices for round-tripping.
 
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
@@ -232,12 +231,6 @@ fn resolve_keyword(p: &MapApi<'_>, keyword: &mlua::String) -> u8 {
         Ok("road") => p.road_color_xterm(),
         Ok("accent_alt") => xterm_index(p.accent_alt_color()),
         Ok("muted") => xterm_index(p.muted_color()),
-        // Severity keywords for chrome (notify popups). Theme-aware
-        // — DARK uses bright yellow / orange / red, BRIGHT uses
-        // darker variants that read on white.
-        Ok("info") => xterm_index(p.notify_info_color()),
-        Ok("warn") => xterm_index(p.notify_warn_color()),
-        Ok("error") => xterm_index(p.notify_error_color()),
         _ => xterm_index(p.accent_color()),
     }
 }

--- a/ttymap-tui/src/lua/map_api.rs
+++ b/ttymap-tui/src/lua/map_api.rs
@@ -165,24 +165,6 @@ impl<'a> MapApi<'a> {
         }
     }
 
-    /// Severity colour for `info`-level transient messages
-    /// (the bundled `notify.lua` uses the `"info"` keyword which
-    /// resolves here). Picked per theme so the same plugin code
-    /// reads on both dark and bright backgrounds.
-    pub fn notify_info_color(&self) -> Color {
-        self.theme.notify_info
-    }
-
-    /// Severity colour for `warn`-level transient messages.
-    pub fn notify_warn_color(&self) -> Color {
-        self.theme.notify_warn
-    }
-
-    /// Severity colour for `error`-level transient messages.
-    pub fn notify_error_color(&self) -> Color {
-        self.theme.notify_error
-    }
-
     // ── Drawing primitives ──────────────────────────────────────────
 
     /// Plot a single-cell glyph at the given world coordinate. No-op

--- a/ttymap-tui/src/theme/ui.rs
+++ b/ttymap-tui/src/theme/ui.rs
@@ -8,75 +8,28 @@ use ratatui::widgets::{Block, Borders};
 
 use super::ColorPalette;
 
-/// Computed UI theme from a [`ColorPalette`]. The `Color` fields are
-/// `Color::Indexed(u8)` — xterm-256 palette entries.
-///
-/// Severity colours (`notify_info` / `notify_warn` / `notify_error`)
-/// are TUI-side chrome only — the engine palette stays focused on
-/// map features. Picked per theme so the bundled `notify.lua`'s
-/// `"info"` / `"warn"` / `"error"` keywords (resolved by the Lua
-/// bridge) read on both light and dark backgrounds.
+/// Computed UI theme from a [`ColorPalette`]. The five `Color` fields
+/// are `Color::Indexed(u8)` — xterm-256 palette entries.
 pub struct UiTheme {
     pub accent: Color,
     pub accent_alt: Color,
     pub fg: Color,
     pub muted_color: Color,
     pub bg: Color,
-    pub notify_info: Color,
-    pub notify_warn: Color,
-    pub notify_error: Color,
     /// Raw palette retained so callers (e.g. the Lua bridge's colour
     /// resolver) can access palette indices that aren't promoted to
     /// `Color` fields here.
     pub palette: ColorPalette,
 }
 
-/// xterm-256 indices for one severity tier across (info, warn, error).
-struct SeverityPalette {
-    info: u8,
-    warn: u8,
-    error: u8,
-}
-
-/// Severity tier for a dark background — saturated/bright values
-/// so the popup pops on black.
-const DARK_SEVERITY: SeverityPalette = SeverityPalette {
-    info: 226,  // bright yellow
-    warn: 208,  // orange
-    error: 196, // bright red
-};
-
-/// Severity tier for a light background — darker values so the
-/// popup remains legible on white. Bright yellow on white is
-/// nearly invisible, hence the swap.
-const BRIGHT_SEVERITY: SeverityPalette = SeverityPalette {
-    info: 130,  // DarkGoldenrod3
-    warn: 166,  // DarkOrange3
-    error: 124, // Red3
-};
-
-/// Resolve a palette to its severity tier. Today there are two
-/// presets so the dispatch is a single equality check on the bg
-/// index; future light themes register here alongside the rest.
-fn severity_for(p: &ColorPalette) -> &'static SeverityPalette {
-    match p.background {
-        231 => &BRIGHT_SEVERITY,
-        _ => &DARK_SEVERITY,
-    }
-}
-
 impl UiTheme {
     pub fn from_palette(p: &ColorPalette) -> Self {
-        let sev = severity_for(p);
         Self {
             accent: Color::Indexed(p.accent),
             accent_alt: Color::Indexed(p.accent_alt),
             fg: Color::Indexed(p.fg),
             muted_color: Color::Indexed(p.muted),
             bg: Color::Indexed(p.background),
-            notify_info: Color::Indexed(sev.info),
-            notify_warn: Color::Indexed(sev.warn),
-            notify_error: Color::Indexed(sev.error),
             palette: ColorPalette { ..*p },
         }
     }


### PR DESCRIPTION
## Summary

The severity-coloured popups from #232 didn't fit either theme's palette gracefully. \`accent_alt\` is cyan in DARK and red in BRIGHT — same Lua keyword inverts the warn/error semantic across themes — and the hand-picked per-theme table felt foreign to the BRIGHT palette (dark blue + dark red, no warm tones).

Switch to the simplest theme-coherent option: render every popup in \`accent\`, the primary keyword chrome plugins like \`info.lua\` use. Notify now visually belongs to the active theme; severity is the message's job (plugin authors prefix \`error:\` / icons themselves when they want it visible).

\`level\` stays on \`Event::Notify\` so future subscribers (audit log, sound cue, …) can still filter by it.

## Removes

- \`UiTheme::notify_info / notify_warn / notify_error\` fields
- \`SeverityPalette\` + \`DARK_SEVERITY\` / \`BRIGHT_SEVERITY\` consts
- \`severity_for(palette)\` dispatcher
- \`MapApi::notify_*_color()\` accessors
- \`"info"\` / \`"warn"\` / \`"error"\` cases in \`resolve_keyword\`

## Test plan

- [x] \`cargo test --workspace\` (216 + 174 pass)
- [x] \`cargo clippy --workspace --all-targets\`
- [x] \`cargo fmt --check\`
- [ ] Manual: trigger plugins under both themes; popup readable on each, visually matches accent