### PR TITLE
feat(compositor): auto-close sidebar when last card is removed (#228)

### DIFF
--- a/ttymap-tui/src/app/sidebar.rs
+++ b/ttymap-tui/src/app/sidebar.rs
@@ -32,26 +32,34 @@ impl SidebarPolicy {
         self.open = !self.open;
     }
 
-    /// Apply the auto-open-on-increase invariant.
+    /// Apply the auto-open / auto-close invariant.
     ///
-    /// Returns `true` when a *new* section has just landed and the
-    /// sidebar was hidden — the caller should trigger a resize so
-    /// the map canvas shrinks for the now-visible rail.
+    /// Returns `true` when visibility flipped (in either direction) —
+    /// the caller triggers a resize so the map canvas adjusts for
+    /// the new rail state.
     ///
-    /// Triggering off "any sidebar component exists" instead would
-    /// force the sidebar back open on every poll tick after the user
-    /// closed it via `\` — they could never hide the sidebar while a
-    /// wiki / aircraft panel was alive on the stack. Tracking the
-    /// previous count lets the user toggle freely; opening a *new*
-    /// section still asserts itself, since asking for new content is
-    /// an implicit "show me this".
+    /// Two symmetric transitions:
+    /// - **Auto-open** on `count > prev_count` while hidden: a new
+    ///   section just landed; opening it is an implicit "show me".
+    /// - **Auto-close** on `prev_count > 0 → count == 0` while open:
+    ///   the last card just left; an empty rail eating ~56 cols is
+    ///   strictly worse than reclaiming the map area.
+    ///
+    /// Both fire on the *transition* — not on the steady state —
+    /// so the user toggling `\` against the current count stays
+    /// free. Steady-state `count == 0` with a manually-opened rail
+    /// keeps the rail open until the next toggle. Mirrors VS Code's
+    /// Explorer / Helix completion popup behaviour.
     pub(super) fn observe_count(&mut self, count: usize) -> bool {
         let should_open = count > self.prev_count && !self.open;
+        let should_close = count == 0 && self.prev_count > 0 && self.open;
         if should_open {
             self.open = true;
+        } else if should_close {
+            self.open = false;
         }
         self.prev_count = count;
-        should_open
+        should_open || should_close
     }
 
     /// Terminal-cell width of the visible map area, accounting for
@@ -64,5 +72,64 @@ impl SidebarPolicy {
         } else {
             full_cols
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observe_count_auto_opens_on_first_card() {
+        let mut p = SidebarPolicy::new(56);
+        assert!(p.observe_count(1));
+        assert!(p.open);
+    }
+
+    #[test]
+    fn observe_count_auto_closes_on_last_card_removed() {
+        let mut p = SidebarPolicy::new(56);
+        p.observe_count(2); // open
+        p.observe_count(1); // shrink, still open
+        let flipped = p.observe_count(0);
+        assert!(flipped, "0-transition must signal a flip");
+        assert!(!p.open, "rail closes when the last card leaves");
+    }
+
+    #[test]
+    fn observe_count_does_not_close_on_steady_zero() {
+        // Manual `\` open against an empty stack must persist —
+        // the auto-close only fires on the >0 → 0 transition,
+        // not on subsequent ticks while count stays 0.
+        let mut p = SidebarPolicy::new(56);
+        p.toggle(); // user opens with `\`, prev_count still 0
+        let flipped = p.observe_count(0);
+        assert!(!flipped);
+        assert!(p.open, "manual open against empty stack must stay open");
+    }
+
+    #[test]
+    fn observe_count_does_not_reopen_after_user_closes_with_cards_alive() {
+        // Auto-open fires on increase only. User closes manually
+        // (`\`) while a card is alive — subsequent steady ticks at
+        // the same count must not flip back open.
+        let mut p = SidebarPolicy::new(56);
+        p.observe_count(1); // auto-opens
+        p.toggle(); // user closes
+        let flipped = p.observe_count(1);
+        assert!(!flipped);
+        assert!(!p.open);
+    }
+
+    #[test]
+    fn manual_toggle_against_empty_stack_then_count_arrives_does_not_flip() {
+        // If the user has already toggled the rail open with `\`
+        // and a card subsequently lands, observe_count should NOT
+        // signal a flip (the rail is already open).
+        let mut p = SidebarPolicy::new(56);
+        p.toggle(); // user opens
+        let flipped = p.observe_count(1);
+        assert!(!flipped, "no flip when rail was already open");
+        assert!(p.open);
     }
 }


### PR DESCRIPTION
## Summary

Symmetric to the existing auto-open-on-increase invariant. Closing the last sidebar component (wiki / aircraft / satellite / ...) left the rail open as a ~56-col empty strip until the user manually toggled it with \`\\\`.

\`SidebarPolicy::observe_count\` now also flips \`open = false\` on the \`prev_count > 0 → count == 0\` transition. Triggering on the **transition** (not steady-state count == 0) preserves manual toggle freedom: \`\\\` against an empty stack still opens and stays open.

## Test plan

5 unit tests in \`app::sidebar::tests\` cover:
- auto-open on first card
- auto-close on last card removed
- manual open against empty stack stays open (no auto-close on steady 0)
- manual close while card alive doesn't auto-reopen on subsequent ticks
- already-open + count arrives = no flip

- [x] \`cargo test --workspace\` (216 + 179 pass; 5 new)
- [x] \`cargo clippy --workspace --all-targets\`
- [x] \`cargo fmt --check\`

Closes #228.