### PR TITLE
demo: add VHS-recorded nav tape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 termap.log
 .claude/
 docs/superpowers/
+
+# VHS recording outputs — regenerate from vhs/*.tape
+assets/*.mp4
+assets/*.gif
+!assets/ttymap-*.png

--- a/vhs/nav.tape
+++ b/vhs/nav.tape
@@ -1,0 +1,51 @@
+# ttymap nav demo —
+#   help (?) → world → Japan zoom → London search → zoom out → pan back east.
+# Run from repo root: `vhs vhs/nav.tape` → assets/nav.gif + assets/nav.mp4
+
+Output assets/nav.mp4
+
+Set FontSize 16
+Set Width 1920
+Set Height 1080
+Set Framerate 24
+Set Theme "TokyoNight"
+Set TypingSpeed 50ms
+Set PlaybackSpeed 1.0
+
+# Start at a world-ish zoom centered on Japan.
+Type "ttymap --lat 35.68 --lon 139.76 --zoom 2"
+Enter
+Sleep 1500ms
+
+# `?` opens the help cheatsheet — leave it open through the rest of
+# the demo as a viewer-side reference.
+Type "?"
+Sleep 2s
+
+# Zoom in deep with `a` (≈50 presses → zoom ~13).
+Type "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+Sleep 1500ms
+
+# `/` opens the palette pre-loaded with the search provider.
+# search uses submit_mode = "on_enter": first Enter triggers the
+# Nominatim fetch (typing buffers silently), wait for the response,
+# then a second Enter selects the top result and jumps.
+Type "/"
+Sleep 400ms
+Type "London"
+Sleep 400ms
+Enter
+Sleep 2500ms
+Enter
+Sleep 3500ms
+
+# Zoom out fully back to a world view.
+Type "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+Sleep 1500ms
+
+# `w` is fast pan east — travel back from London all the way to Japan.
+Type "wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww"
+Sleep 2500ms
+
+Type "q"
+Sleep 200ms


### PR DESCRIPTION
## Demo

https://github.com/user-attachments/assets/63c6415f-9d3e-4d0c-957c-92ca5f326e43

## Summary

Adds `vhs/nav.tape` — a VHS recording script that walks through ttymap's basic navigation surface. Regenerates `assets/nav.mp4` (1920×1080, 24 fps, ~25 s) on demand.

The flow:
- launch with `--lat 35.68 --lon 139.76 --zoom 2`
- `?` opens the help cheatsheet (kept open through the rest of the demo as a viewer-side reference)
- `a` × 50 to deep-zoom into Tokyo
- `/` opens the search palette → `London` → first `Enter` triggers the Nominatim fetch (search uses `submit_mode = "on_enter"`), second `Enter` selects the top result and jumps
- `z` × 50 zooms back out to a world view
- `w` × 36 fast-pans east, ending back over Japan

Recording deps: `vhs` + `ttyd` + `ffmpeg`.

The mp4 itself is gitignored — the tape is the source of truth. To embed the demo in README, regenerate locally and drag-drop the file onto a PR / issue / release: GitHub returns a `user-attachments/...` URL that plays inline in markdown (as above).

## Test plan

- [x] `vhs vhs/nav.tape` produces a working `assets/nav.mp4`
- [x] Frame samples confirm: help → Tokyo deep zoom → London jump → world-view pan back to Japan
- [x] `cargo test` / `cargo clippy` / `cargo fmt --check` (pre-commit hook)