### PR TITLE
docs(readme): embed nav demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,14 @@ Inspired by [mapscii](https://github.com/rastapasta/mapscii).
 > APIs (CLI flags, Lua surface, config schema) may change without
 > notice and bugs are expected.
 
-![ttymap default view with help panel and satellite tracker](assets/ttymap-default.png)
+https://github.com/user-attachments/assets/63c6415f-9d3e-4d0c-957c-92ca5f326e43
 
 <details>
-<summary>More screenshots</summary>
+<summary>Screenshots</summary>
+
+Default view with help panel and satellite tracker:
+
+![ttymap default view with help panel and satellite tracker](assets/ttymap-default.png)
 
 Bright theme:
 


### PR DESCRIPTION
## Summary

The default screenshot was the only above-the-fold visual in the README. Replace it with the nav-tape video upload (the `user-attachments` URL renders inline as a video player on github.com) and fold the three static screenshots into the existing collapsible block as a fallback for non-github viewers.

Source for the video: `vhs/nav.tape` (added in #243).

## Preview

https://github.com/user-attachments/assets/63c6415f-9d3e-4d0c-957c-92ca5f326e43

## Test plan

- [x] `cargo test` / `cargo clippy` / `cargo fmt --check` (pre-commit hook)
- [ ] Verify the video renders inline in the README on github.com after merge