### PR TITLE
docs(readme): add CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ttymap
 
+[![CI](https://github.com/Kohei-Wada/ttymap/actions/workflows/ci.yml/badge.svg)](https://github.com/Kohei-Wada/ttymap/actions/workflows/ci.yml)
+
 Terminal-based map viewer. Renders [Mapbox Vector Tiles](https://github.com/mapbox/vector-tile-spec) as Unicode Braille characters with ANSI 256-color in your terminal.
 
 Inspired by [mapscii](https://github.com/rastapasta/mapscii).


### PR DESCRIPTION
## Summary

Adds the GitHub Actions CI badge to the top of the README so the build status is visible at a glance.

## Test plan

- [x] `cargo test` / `cargo clippy` / `cargo fmt --check` (pre-commit hook)
- [ ] Verify badge renders + links to the workflow page after merge