### PR TITLE
ci: add cargo-deny + scheduled cargo-audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,27 @@
+name: Security audit
+
+on:
+  schedule:
+    # Mondays 06:00 UTC. Catches RustSec advisories that landed
+    # without us touching the lockfile.
+    - cron: "0 6 * * 1"
+  push:
+    paths:
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - ".github/workflows/audit.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  checks: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,13 @@ jobs:
 
       - name: Test
         run: cargo test --workspace
+
+  # Supply-chain checks. Linux-only — output is platform-independent,
+  # so the matrix in `check` doesn't apply here.
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check all

--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,9 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
+# Intra-workspace path deps (`ttymap-engine = { path = ".." }`) read as
+# wildcards but are not real version-spec wildcards.
+allow-wildcard-paths = true
 deny = [
     # Don't ship two copies of TLS stacks in one binary.
     { name = "openssl", deny-multiple-versions = true },

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,49 @@
+# cargo-deny configuration.
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+
+[graph]
+all-features = false
+
+[advisories]
+version = 2
+yanked = "warn"
+ignore = []
+
+[licenses]
+version = 2
+confidence-threshold = 0.8
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "CC0-1.0",
+    "MPL-2.0",
+    "OpenSSL",
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+deny = [
+    # Don't ship two copies of TLS stacks in one binary.
+    { name = "openssl", deny-multiple-versions = true },
+    { name = "openssl-sys", deny-multiple-versions = true },
+    { name = "rustls", deny-multiple-versions = true },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/ttymap-tui/Cargo.toml
+++ b/ttymap-tui/Cargo.toml
@@ -30,7 +30,7 @@ name = "ttymap"
 path = "src/main.rs"
 
 [dependencies]
-ttymap-engine = { path = "../ttymap-engine" }
+ttymap-engine = { path = "../ttymap-engine", version = "0.1.0" }
 crossterm = "0.29"
 ratatui = "0.30"
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary

Closes #83.

- `deny.toml` at repo root: `[advisories]` (yanked=warn), `[licenses]` allow-list matching the `MIT OR Apache-2.0` workspace + the usual permissive set, `[bans]` blocking duplicate-major versions of `openssl` / `openssl-sys` / `rustls`, `[sources]` restricted to crates.io.
- `ci.yml`: new `deny` job runs `cargo-deny check all` on every PR (Linux-only — output is platform-independent).
- `audit.yml`: weekly Monday 06:00 UTC + on `Cargo.{lock,toml}` change + `workflow_dispatch`. `rustsec/audit-check` opens an issue automatically on findings.

## Test plan

- [ ] `deny` job passes on this PR's CI run (license allow-list covers all 191 transitive deps; bans don't trip on the current dep tree)
- [ ] `audit` job passes — no advisories outstanding against the current `Cargo.lock`
- [ ] If `deny` trips on an unforeseen license, adjust `deny.toml` rather than weakening the allow-list

## Notes

- Local `cargo deny check all` was not run before pushing (no `cargo-deny` installed locally and the workspace is opting to validate via CI). If anything fails in the `deny` job, the fix is in `deny.toml`, not the workflow.
- `audit.yml` needs `issues: write` permission to open issues on findings — granted in the workflow.