### PR TITLE
fix(cli): make --log a global flag so subcommands accept it

### DIFF
--- a/ttymap-tui/src/main.rs
+++ b/ttymap-tui/src/main.rs
@@ -48,7 +48,7 @@ struct Cli {
     /// level argument: `--log` alone is `debug`; `--log info` /
     /// `--log trace` etc. select an explicit level. Without the flag
     /// no logger is installed (log macros become no-ops).
-    #[arg(long, value_name = "LEVEL", num_args = 0..=1, default_missing_value = "debug")]
+    #[arg(long, value_name = "LEVEL", num_args = 0..=1, default_missing_value = "debug", global = true)]
     log: Option<String>,
 }
 


### PR DESCRIPTION
Closes #224.

## Summary
- `--log` was defined on the top-level `Cli` without `global = true`, so clap rejected `ttymap snap ... --log debug` and `snap --help` didn't list the flag.
- Added `global = true` to the `#[arg(...)]`. The field still lives on `Cli` so the existing call site (`if let Some(level) = cli.log.as_deref() ...`) is unchanged.

## Test plan
- [x] `ttymap snap --lat ... --log debug ...` writes `~/.local/state/ttymap/ttymap.log`
- [x] `ttymap --log debug snap ...` (pre-subcommand position) still writes the log
- [x] `ttymap snap --help` lists `--log` under Options
- [x] `cargo build` / `cargo test` / `cargo clippy` clean