### PR TITLE
refactor(map): collapse TileCache::prefetch into RenderPipeline::prefetch

### DIFF
--- a/ttymap-engine/src/map/render/pipeline.rs
+++ b/ttymap-engine/src/map/render/pipeline.rs
@@ -71,21 +71,40 @@ impl RenderPipeline {
     /// instant instead of flashing black while HTTP fetches run.
     ///
     /// Three layers:
-    /// 1. Pan ring at the current zoom (inherited from
-    ///    `tile_cache::prefetch` — a 2-tile ring around the center).
+    /// 1. Outer ring at distance 2 from the center tile at the current
+    ///    zoom — pre-warms tiles for short pans before they enter the
+    ///    visible window.
     /// 2. **Every visible tile's four children at z+1**, so a
     ///    zoom-in lands on already-warm tiles wherever the user is
     ///    looking (not just near the center).
     /// 3. **Every visible tile's parent at z-1** (deduped because
     ///    adjacent tiles share a parent), so zoom-out is also warm.
     pub fn prefetch(&mut self, vp: &Viewport) {
-        // Current-zoom pan ring + center-tile z±1 (kept as-is).
-        self.tile_cache
-            .prefetch(vp.center.lon, vp.center.lat, vp.zoom);
+        let z = crate::geo::base_zoom(vp.zoom);
+        let grid = crate::geo::tile_grid_size(z);
+        let center = crate::geo::ll2tile(vp.center.lon, vp.center.lat, z);
+        let cx = center.x.floor() as i32;
+        let cy = center.y.floor() as i32;
+
+        // Outer ring at distance 2 (5×5 minus inner 3×3 minus corners).
+        for dy in -2i32..=2 {
+            for dx in -2i32..=2 {
+                if (-1..=1).contains(&dx) && (-1..=1).contains(&dy) {
+                    continue;
+                }
+                if dx.abs() == 2 && dy.abs() == 2 {
+                    continue;
+                }
+                let ty = cy + dy;
+                if ty < 0 || ty >= grid {
+                    continue;
+                }
+                let tx = (cx + dx).rem_euclid(grid);
+                self.tile_cache.get_tile(z, tx, ty);
+            }
+        }
 
         let visible = self.visible_tiles_for(vp);
-
-        let z = crate::geo::base_zoom(vp.zoom);
 
         // z+1: every visible tile's four children.
         if z < 14 {

--- a/ttymap-engine/src/map/tile/cache.rs
+++ b/ttymap-engine/src/map/tile/cache.rs
@@ -1,4 +1,4 @@
-//! Tile cache (orchestrator) — memory LRU + view state + prefetch.
+//! Tile cache (orchestrator) — memory LRU + view state.
 //!
 //! After the three-layer-pipe refactor, decoding is on its own thread
 //! (`super::decoder`) and arrivals here are already `DecodedTile`s.
@@ -168,63 +168,6 @@ impl TileCache {
         };
         self.client.enqueue(&key, priority);
         None
-    }
-
-    /// Prefetch nearby tiles for smoother panning/zooming.
-    pub fn prefetch(&mut self, center_lon: f64, center_lat: f64, zoom: f64) {
-        let z = crate::geo::base_zoom(zoom);
-        let center = crate::geo::ll2tile(center_lon, center_lat, z);
-        let grid_size = crate::geo::tile_grid_size(z);
-        let cx = center.x.floor() as i32;
-        let cy = center.y.floor() as i32;
-
-        // 1-tile border (no corners)
-        for dy in -2i32..=2 {
-            for dx in -2i32..=2 {
-                if (-1..=1).contains(&dx) && (-1..=1).contains(&dy) {
-                    continue;
-                }
-                if dx.abs() == 2 && dy.abs() == 2 {
-                    continue;
-                }
-                let ty = cy + dy;
-                if ty < 0 || ty >= grid_size {
-                    continue;
-                }
-                let tx = (cx + dx).rem_euclid(grid_size);
-                self.get_tile(z, tx, ty);
-            }
-        }
-
-        // z+1: all 4 children of the center tile, so a zoom-in lands on
-        // already-warm tiles regardless of which quadrant the view
-        // fractionally sits on.
-        if z < 14 {
-            let g = crate::geo::tile_grid_size(z + 1);
-            let base_x = cx * 2;
-            let base_y = cy * 2;
-            for dy in 0..2 {
-                for dx in 0..2 {
-                    let ty = base_y + dy;
-                    if ty < 0 || ty >= g {
-                        continue;
-                    }
-                    let tx = (base_x + dx).rem_euclid(g);
-                    self.get_tile(z + 1, tx, ty);
-                }
-            }
-        }
-
-        // z-1 center
-        if z > 0 {
-            let c = crate::geo::ll2tile(center_lon, center_lat, z - 1);
-            let g = crate::geo::tile_grid_size(z - 1);
-            let tx = (c.x.floor() as i32).rem_euclid(g);
-            let ty = c.y.floor() as i32;
-            if ty >= 0 && ty < g {
-                self.get_tile(z - 1, tx, ty);
-            }
-        }
     }
 }
 

--- a/ttymap-engine/src/map/tile/mod.rs
+++ b/ttymap-engine/src/map/tile/mod.rs
@@ -14,7 +14,7 @@
 //!   property.rs  — feature property value type and accessors
 //!   decode/      — pure protobuf → `DecodedTile` (geometry / tags / decompress)
 //!   decoder.rs   — relay thread: bytes → `DecodedTile`, off the render thread
-//!   cache.rs     — memory LRU + view state + prefetch (orchestrator)
+//!   cache.rs     — memory LRU + view state (orchestrator)
 //!   fetch/       — backends that produce bytes (HTTP today, more later);
 //!                  `TileFetcher` is per-backend, `FetchLane<F>` is generic
 //!                  queue / workers / dedup / priority


### PR DESCRIPTION
Closes #162.

## Problem

\`RenderPipeline::prefetch\` and \`TileCache::prefetch\` both implement prefetch policy, and the cache version is mostly a strict subset of the pipeline version:

| layer | cache::prefetch | pipeline::prefetch |
|---|---|---|
| distance-2 ring (current z) | ✅ | ❌ — only here |
| z+1: center's 4 children | ✅ | covered by next ↓ |
| z+1: every visible tile's 4 children | ❌ | ✅ — superset |
| z-1: center tile | ✅ | covered by next ↓ |
| z-1: every visible tile's parent (dedup) | ❌ | ✅ — superset |

So z±1 is walked twice. The ring is the only piece unique to the cache. Two parallel ring-iteration routines means future polar-clamp / antimeridian-wrap fixes have two places to land.

## Fix

- Move the distance-2 ring loop inline into \`RenderPipeline::prefetch\`.
- Delete \`TileCache::prefetch\` entirely. \`TileCache\` reduces to pure storage: memory LRU + view state + disk fast path + completion drain. Prefetch policy now lives in one place (the pipeline).
- Update doc comments in \`cache.rs\` / \`tile/mod.rs\` / the pipeline's \`prefetch\` doc to drop the cross-references.

No behaviour change — the ring loop is moved verbatim, z±1 is unchanged.

## Stats

- **-37 LOC net** (28 inserts, 65 deletes across 3 files)
- One \`get_tile\` call per tile per prefetch pass instead of two for center-tile z±1

## Test plan
- [x] \`cargo build\` / \`cargo test\` (180 passed) / \`cargo clippy\` / \`cargo fmt --check\` — all clean
- [x] \`ttymap snap --lat 35.68 --lon 139.76 --zoom 8\` renders the expected ANSI grid
- [x] No callers outside \`render/thread.rs\` and \`render/pipeline.rs\` — \`grep -rn '\\.prefetch('\` confirms no test or external dependency on \`TileCache::prefetch\`