### PR TITLE
refactor(engine): Result on the public boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3001,6 +3001,7 @@ dependencies = [
  "rstar",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "unicode-width 0.2.2",
 ]
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -254,3 +254,47 @@ labelling, polygon fill, Braille packing) to the render thread
 where it belongs. If a plugin's `on_tick` ever became the bottleneck,
 the right move is to push *that* plugin's compute back to a worker
 thread, not to redesign the boundary.
+
+## Error boundary policy
+
+The engine has one explicit error boundary: **anything reachable
+from `ttymap-tui` through `pub` items in `ttymap-engine` must
+return `Result<_, EngineError>` instead of panicking**. Inside
+that boundary, hot paths keep `unwrap` / `expect`.
+
+The cut, in concrete terms:
+
+- **Public boundary** (`Result<_, EngineError>`): `map::build`,
+  `map::tile::build`, `shared::http::HttpClient::new` /
+  `with_timeout`, and any future public spawn / construction
+  helpers. The TUI binary is the sole external caller — it
+  funnels these to `log::error!` / stderr instead of crashing.
+  `EngineError` is defined in `ttymap-engine/src/error.rs`
+  (thiserror) and folds the existing `shared::http::FetchError`
+  in as a `#[from]` variant so narrow callers (e.g. the Lua
+  `ttymap.http` bridge) can keep using the tighter type.
+- **Internal hot paths** keep their `unwrap`s: the decoder's
+  zigzag stream, the renderer's coordinate / clipping math,
+  Braille bit packing, earcut triangulation, polyline antimeridian
+  split. These are per-frame / per-tile invariants — surfacing
+  them through `Result` would only add an error path on every
+  draw with no real recovery for the caller.
+- **`catch_unwind` islands** (`render::thread::run_loop`,
+  `tile::decoder::spawn_decoder`) are intentional: a panic
+  inside one render frame or one tile decode is contained,
+  logged, and the worker keeps serving. These are *not* a
+  replacement for the public-boundary `Result` rule — they
+  exist because we cannot afford to tear down the whole
+  pipeline for one bad tile.
+- **Mutex poisoning** (`fetch/lane.rs`) currently panics on
+  poison. This is out of scope here — issue #86 owns the
+  mutex-poison policy.
+
+When adding a new engine public API: if the operation can fail
+in a way the caller might want to recover from (config / disk /
+network / spawn), return `Result<_, EngineError>` and add a
+variant if needed. If the failure is an internal invariant
+violation, `unwrap`/`expect` is fine — but consider whether the
+call site really belongs on the public boundary or should be
+hidden behind a constructor that already absorbed the
+invariant.

--- a/ttymap-engine/Cargo.toml
+++ b/ttymap-engine/Cargo.toml
@@ -21,6 +21,7 @@ unicode-width = "0.2"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde_json = "1"
 directories = "6"
+thiserror = "2"
 
 [build-dependencies]
 prost-build = "0.14"

--- a/ttymap-engine/src/error.rs
+++ b/ttymap-engine/src/error.rs
@@ -1,0 +1,41 @@
+//! Engine-wide error type returned across the public boundary.
+//!
+//! Internal hot paths (decoder zigzag, renderer math, Braille bit
+//! packing, …) keep their `unwrap`s — surfacing those would just add
+//! an error path on every frame for invariants that cannot recover.
+//! See `docs/design.md` "Error boundary policy" for the full cut.
+
+use std::io;
+use std::path::PathBuf;
+
+use crate::shared::http::FetchError;
+
+/// Error returned by every public engine API. The variants are
+/// classified by the boundary that produces them so callers can
+/// decide policy (retry / surface to UI / fail fast) without
+/// downcasting.
+#[derive(Debug, thiserror::Error)]
+pub enum EngineError {
+    /// Failed to create the on-disk tile cache directory. The user
+    /// can usually fix this (perms / disk full) — surface the path
+    /// in the error.
+    #[error("create cache directory {path}: {source}")]
+    CacheDir {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    /// `reqwest::Client` builder failed at construction. In
+    /// practice this almost never fires (no I/O happens at build
+    /// time), but it's reachable so we route it instead of
+    /// panicking on the public boundary.
+    #[error("HTTP client init: {0}")]
+    HttpInit(#[source] reqwest::Error),
+
+    /// Per-request HTTP fetch error from `shared::http`. Kept as a
+    /// distinct variant so narrow callers can keep using
+    /// `Result<_, FetchError>` and have it auto-convert via `?`.
+    #[error(transparent)]
+    Fetch(#[from] FetchError),
+}

--- a/ttymap-engine/src/lib.rs
+++ b/ttymap-engine/src/lib.rs
@@ -22,9 +22,11 @@
 //!   runtime/geoip fields.
 
 pub mod config;
+pub mod error;
 pub mod geo;
 pub mod map;
 pub mod shared;
 pub mod theme;
 
 pub use config::Config;
+pub use error::EngineError;

--- a/ttymap-engine/src/map/mod.rs
+++ b/ttymap-engine/src/map/mod.rs
@@ -118,7 +118,7 @@ pub fn build(
     rows: u16,
     frame_sink: FrameSink,
     theme_id: ThemeId,
-) -> (RenderHandle, MapHandle) {
+) -> Result<(RenderHandle, MapHandle), crate::EngineError> {
     let (width, height) = render::canvas_size(cols, rows);
 
     log::info!(
@@ -129,7 +129,7 @@ pub fn build(
         height
     );
 
-    let (tile_cache, wake_rx) = tile::build(config);
+    let (tile_cache, wake_rx) = tile::build(config)?;
     let attribution = tile_cache.attribution();
 
     let styler = Arc::new(Styler::new(theme_id));
@@ -156,12 +156,12 @@ pub fn build(
         height,
     );
 
-    (
+    Ok((
         render_handle,
         MapHandle {
             state,
             render_client,
             attribution,
         },
-    )
+    ))
 }

--- a/ttymap-engine/src/map/tile/fetch/http.rs
+++ b/ttymap-engine/src/map/tile/fetch/http.rs
@@ -27,24 +27,18 @@ pub struct HttpFetcher {
 
 impl HttpFetcher {
     /// Build a fetcher with the default `mapscii.me` base.
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self, crate::EngineError> {
         Self::with_base_url(BASE_URL.to_string())
     }
 
     /// Build a fetcher with a custom base URL — useful for tests
     /// against a local mock server, and for future config-driven
     /// alternative tile sources.
-    pub fn with_base_url(base_url: String) -> Self {
-        Self {
-            http: HttpClient::with_timeout("tile", Duration::from_secs(10)),
+    pub fn with_base_url(base_url: String) -> Result<Self, crate::EngineError> {
+        Ok(Self {
+            http: HttpClient::with_timeout("tile", Duration::from_secs(10))?,
             base_url,
-        }
-    }
-}
-
-impl Default for HttpFetcher {
-    fn default() -> Self {
-        Self::new()
+        })
     }
 }
 
@@ -67,14 +61,14 @@ mod tests {
 
     #[test]
     fn url_uses_base_plus_zxy_pbf() {
-        let fetcher = HttpFetcher::with_base_url("http://example.test".to_string());
+        let fetcher = HttpFetcher::with_base_url("http://example.test".to_string()).unwrap();
         assert_eq!(fetcher.base_url, "http://example.test");
         assert_eq!(fetcher.attribution(), ATTRIBUTION);
     }
 
     #[test]
     fn default_uses_mapscii_me_https_base() {
-        let fetcher = HttpFetcher::new();
+        let fetcher = HttpFetcher::new().unwrap();
         assert_eq!(fetcher.base_url, "https://mapscii.me");
     }
 }

--- a/ttymap-engine/src/map/tile/mod.rs
+++ b/ttymap-engine/src/map/tile/mod.rs
@@ -55,7 +55,9 @@ use crate::config::Config;
 /// would pick a different `TileFetcher`. `FetchLane` provides queue
 /// / dedup / priority for any of them; `decoder::spawn_decoder` and
 /// the cache are backend-agnostic.
-pub fn build(config: &Config) -> (TileCache, crossbeam_channel::Receiver<()>) {
+pub fn build(
+    config: &Config,
+) -> Result<(TileCache, crossbeam_channel::Receiver<()>), crate::EngineError> {
     use directories::ProjectDirs;
     use std::fs;
 
@@ -69,17 +71,23 @@ pub fn build(config: &Config) -> (TileCache, crossbeam_channel::Receiver<()>) {
     const HTTP_WORKERS: usize = 6;
 
     let cache_dir = if config.cache.tiles {
-        ProjectDirs::from("", "", "ttymap").map(|proj_dirs| {
-            let dir = proj_dirs.cache_dir().to_path_buf();
-            let _ = fs::create_dir_all(&dir);
-            dir
-        })
+        match ProjectDirs::from("", "", "ttymap") {
+            Some(proj_dirs) => {
+                let dir = proj_dirs.cache_dir().to_path_buf();
+                fs::create_dir_all(&dir).map_err(|source| crate::EngineError::CacheDir {
+                    path: dir.clone(),
+                    source,
+                })?;
+                Some(dir)
+            }
+            None => None,
+        }
     } else {
         None
     };
 
     let (bytes_tx, bytes_rx) = std::sync::mpsc::channel();
-    let http = HttpFetcher::new();
+    let http = HttpFetcher::new()?;
 
     // The lane wraps an HTTP fetcher; if disk cache is enabled, layer
     // a `DiskCachedFetcher` decorator on top so worker-side hits
@@ -102,8 +110,8 @@ pub fn build(config: &Config) -> (TileCache, crossbeam_channel::Receiver<()>) {
     // lane below.
     let disk_fast_path = cache_dir.map(|cache_dir| DiskFastPath { cache_dir });
 
-    (
+    Ok((
         TileCache::new(lane, decoded_rx, config.cache.memory_tiles, disk_fast_path),
         wake_rx,
-    )
+    ))
 }

--- a/ttymap-engine/src/shared/http/mod.rs
+++ b/ttymap-engine/src/shared/http/mod.rs
@@ -54,16 +54,16 @@ pub struct HttpClient {
 }
 
 impl HttpClient {
-    pub fn new(tag: &'static str) -> Self {
+    pub fn new(tag: &'static str) -> Result<Self, crate::EngineError> {
         Self::with_timeout(tag, DEFAULT_TIMEOUT)
     }
 
-    pub fn with_timeout(tag: &'static str, timeout: Duration) -> Self {
+    pub fn with_timeout(tag: &'static str, timeout: Duration) -> Result<Self, crate::EngineError> {
         let inner = builder()
             .timeout(timeout)
             .build()
-            .expect("reqwest client build");
-        Self { inner, tag }
+            .map_err(crate::EngineError::HttpInit)?;
+        Ok(Self { inner, tag })
     }
 
     /// GET + deserialize as JSON. Low-level `debug!` is emitted per

--- a/ttymap-tui/src/cli/mod.rs
+++ b/ttymap-tui/src/cli/mod.rs
@@ -3,11 +3,9 @@
 //! on CLI parsing + process-level setup.
 //!
 //! Adding a subcommand:
-//!   1. Create `src/commands/<name>.rs` with `pub fn run(...) -> io::Result<()>`
+//!   1. Create `src/commands/<name>.rs` with `pub fn run(...) -> Result<(), Box<dyn std::error::Error>>`
 //!   2. Add a `pub mod <name>;` line below.
 //!   3. Add the variant to [`Command`] and a match arm in [`Command::run`].
-
-use std::io;
 
 use clap::Subcommand;
 
@@ -21,7 +19,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub fn run(self) -> io::Result<()> {
+    pub fn run(self) -> Result<(), Box<dyn std::error::Error>> {
         match self {
             Self::Snap(args) => snap::run(args),
         }

--- a/ttymap-tui/src/cli/snap.rs
+++ b/ttymap-tui/src/cli/snap.rs
@@ -78,7 +78,7 @@ pub struct SnapArgs {
     pub timeout_ms: u64,
 }
 
-pub fn run(args: SnapArgs) -> io::Result<()> {
+pub fn run(args: SnapArgs) -> Result<(), Box<dyn std::error::Error>> {
     // snap is headless and doesn't react to keymap, so we drop the
     // keymap overrides and the Lua state returned by load_init_lua.
     // `Config` carries every other init.lua-tunable knob
@@ -93,9 +93,9 @@ pub fn run(args: SnapArgs) -> io::Result<()> {
                 config.engine.map.lon = lon;
             }
             None => {
-                return Err(io::Error::other(
+                return Err(Box::new(io::Error::other(
                     "geoip lookup failed; pass --lat/--lon explicitly or check network",
-                ));
+                )));
             }
         }
     } else {
@@ -131,7 +131,7 @@ pub fn run(args: SnapArgs) -> io::Result<()> {
     // tile::build spawns 6 worker threads fetching tiles in
     // parallel — they run independently of us, so we can drive the
     // pipeline synchronously and just poll for completed tiles.
-    let (tile_cache, _wake_rx) = ttymap_engine::map::tile::build(&config.engine);
+    let (tile_cache, _wake_rx) = ttymap_engine::map::tile::build(&config.engine)?;
     let theme_id = ThemeId::from_name(&config.engine.render.style);
     let styler = Arc::new(Styler::new(theme_id));
     let mut pipeline = RenderPipeline::new(

--- a/ttymap-tui/src/lua/api/mod.rs
+++ b/ttymap-tui/src/lua/api/mod.rs
@@ -158,7 +158,7 @@ pub fn install(
     ttymap.set(
         "http",
         lua.create_userdata(http::HostHttp {
-            http: HttpClient::new("lua"),
+            http: HttpClient::new("lua").map_err(mlua::Error::external)?,
         })?,
     )?;
     ttymap.set(

--- a/ttymap-tui/src/main.rs
+++ b/ttymap-tui/src/main.rs
@@ -150,7 +150,7 @@ fn run_event_loop(
     lua_vm: mlua::Lua,
     config: Config,
     keymap_overrides: KeybindingOverrides,
-) -> std::io::Result<()> {
+) -> Result<(), Box<dyn std::error::Error>> {
     let (event_tx, event_rx) = std::sync::mpsc::channel();
 
     // Active theme — owned by App, consumed by the map only at
@@ -176,7 +176,7 @@ fn run_event_loop(
     // `_render_handle` is a peer to `_input` / `_frame_timer` — held
     // here for `Drop`-driven shutdown, not used otherwise.
     let (_render_handle, map) =
-        ttymap_engine::map::build(&config.engine, cols, rows, frame_sink, theme_id);
+        ttymap_engine::map::build(&config.engine, cols, rows, frame_sink, theme_id)?;
 
     // Keymap is shared input by both the Lua subsystem (help plugin
     // displays it; palette uses it for prefix matching) and the

--- a/ttymap-tui/src/shared/geoip.rs
+++ b/ttymap-tui/src/shared/geoip.rs
@@ -17,7 +17,7 @@ use ttymap_engine::shared::http::HttpClient;
 /// on any network / parse error or rate-limit response; callers fall
 /// back to their configured default.
 pub fn lookup(endpoint: &str, timeout_ms: u64) -> Option<(f64, f64)> {
-    let http = HttpClient::with_timeout("geoip", Duration::from_millis(timeout_ms));
+    let http = HttpClient::with_timeout("geoip", Duration::from_millis(timeout_ms)).ok()?;
     debug!("geoip: lookup {}", endpoint);
 
     let json: serde_json::Value = http.get_json(endpoint).ok()?;


### PR DESCRIPTION
Closes #247. First concrete slice of #17 — lift every panic / silent-fail on engine-public entry points to `Result<_, EngineError>`. Internal hot paths stay unchanged.

## What changed

| Layer | Before | After |
|---|---|---|
| `shared::http::HttpClient::new` / `with_timeout` | `.expect(\"reqwest client build\")` panic | `Result<Self, EngineError>` |
| `tile::build` cache dir | `let _ = fs::create_dir_all(&dir)` (silent) | `EngineError::CacheDir { path, source }` |
| `tile::build` signature | `(TileCache, Receiver)` | `Result<…, EngineError>` |
| `map::build` signature | `(RenderHandle, MapHandle)` | `Result<…, EngineError>` |
| `shared::http::FetchError` | standalone enum | folded under `EngineError::Fetch(#[from] FetchError)` — narrow callers can keep using the tighter type |

New file: `ttymap-engine/src/error.rs` (thiserror).

## TUI cascade

| call site | resolution |
|---|---|
| `main.rs::run_event_loop` | promote return type to `Box<dyn std::error::Error>`; use `?` on `engine::map::build` |
| `cli::Command::run` / `snap::run` | same promotion to `Box<dyn std::error::Error>`; existing `io::Error::other` calls wrapped in `Box::new` |
| `shared::geoip::lookup` | `HttpClient::with_timeout(...).ok()?` (preserves the existing `Option`-returning shape) |
| `lua::api::mod` | `HttpClient::new(\"lua\").map_err(mlua::Error::external)?` |

## Out of scope (per issue)

- decoder zigzag / renderer math / Braille / earcut / polyline antimeridian split — internal hot path unwraps stay
- `fetch/lane.rs` mutex-poison `expect`s — owned by #86
- TUI-side `unwrap` reduction beyond the cascade above — separate issue
- Notify popup UI for engine errors — followup; logging-via-stderr is the first cut

## Audit (`grep -nE 'unwrap\(|expect\(|panic!\(' ttymap-engine/src/`)

Remaining hits classified:
- All test bodies (under `#[cfg(test)] mod tests`) ✅
- `map/render/overlay.rs:85` — `current.last().unwrap()` in antimeridian split; `current` is push-only after `vec![coords[0]]`, so infallible by construction (hot path)
- `tile/cache.rs:65` — `NonZeroUsize::new(cache_size.max(1)).unwrap()`; comment already explains the clamp
- `fetch/lane.rs` — mutex poisons (#86)

## Docs

`docs/design.md` gets a new \"Error boundary policy\" section so the cut between \"public = Result\" and \"internal hot path = unwrap\" is written down for future contributors.

## Test plan

- [x] `cargo build` / `cargo test` (180 passed) / `cargo clippy --all-targets -D warnings` / `cargo fmt --check` all clean
- [x] `ttymap snap --lat 35.68 --lon 139.76 --zoom 5 -o /tmp/...` renders normally (engine builds via the new `Result` path)
- [x] grep audit confirms no unwrap/expect on engine public boundary