### PR TITLE
fix(tile): restore cache hit logs lost in three-layer-pipe refactor

### DIFF
--- a/ttymap-engine/src/map/tile/cache.rs
+++ b/ttymap-engine/src/map/tile/cache.rs
@@ -150,6 +150,7 @@ impl TileCache {
         let key = TileKey::new(z, x, y);
 
         if self.memory_cache.contains(&key) {
+            debug!("cache: memory hit {}", key);
             return self.memory_cache.get(&key);
         }
 
@@ -157,6 +158,12 @@ impl TileCache {
             && let Some(bytes) = disk::read_disk(&fast.cache_dir, &key)
         {
             let decoded = super::decode::decode(&bytes);
+            debug!(
+                "cache: disk hit {} ({} bytes, {} layers)",
+                key,
+                bytes.len(),
+                decoded.layers.len()
+            );
             self.memory_cache.put(key.clone(), decoded);
             return self.memory_cache.get(&key);
         }


### PR DESCRIPTION
Closes #225.

## Summary

PR #129 (three-layer-pipe refactor) moved disk I/O around but didn't re-add the \`debug!\` line at the new disk-fast-path location. The memory-LRU branch never had one. Result: with \`--log debug\`, the tile subsystem was silent on every cache hit — only \`worker: ...\` (network fetch) and \`decoder: ...\` (async decode) lines fired, so warm-cache pan/zoom looked like nothing was happening at all.

## Change

\`TileCache::get_tile\` (\`ttymap-engine/src/map/tile/cache.rs\`) now emits \`debug!\` at both hit branches, matching the existing \`worker: ...\` / \`decoder: ...\` log line shape:

\`\`\`
cache: memory hit 8/227/100
cache: disk hit 8/227/100 (314332 bytes, 9 layers)
\`\`\`

7 lines added, no behaviour change.

## Test plan

- [x] \`cargo build\` / \`cargo test\` (180 passed) / \`cargo clippy --all-targets -D warnings\` / \`cargo fmt --check\` clean
- [x] \`rm ~/.local/state/ttymap/ttymap.log; cargo run -- snap --lat 35.68 --lon 139.76 --zoom 8 --log debug -o /tmp/x\` shows \`cache: disk hit ...\` lines for tiles served from \`~/.cache/ttymap\` (memory hit fires under interactive pan; not exercised by single-frame \`snap\`, but the branch is structurally identical)