### PR TITLE
fix(main): restore terminal on app.run error path

### DIFF
--- a/ttymap-tui/src/main.rs
+++ b/ttymap-tui/src/main.rs
@@ -222,7 +222,12 @@ fn run_event_loop(
     let _frame_timer = FrameTimer::spawn(event_tx.clone(), app.poll_timeout());
 
     log::info!("event loop started");
-    app.run(&mut terminal, &event_rx, &event_tx)?;
+    // Capture the result so terminal teardown runs on both success and
+    // error paths. Without this, an Err from `app.run` would short-
+    // circuit via `?` and skip the kitty / mouse-capture / ratatui
+    // restore below — leaving the terminal in raw mode + alternate
+    // screen while main's error-print fires.
+    let run_result = app.run(&mut terminal, &event_rx, &event_tx);
     log::info!("event loop ended");
 
     if kitty_pushed {
@@ -231,8 +236,8 @@ fn run_event_loop(
             crossterm::event::PopKeyboardEnhancementFlags
         );
     }
-    crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture)?;
+    let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture);
     ratatui::restore();
     log::info!("terminal restored, exiting");
-    Ok(())
+    run_result.map_err(Into::into)
 }


### PR DESCRIPTION
Closes #252.

## Problem

In \`run_event_loop\`, \`app.run(...)?\` short-circuits the function on \`Err\`. The kitty pop / \`DisableMouseCapture\` / \`ratatui::restore()\` calls below it are then skipped, so a runtime error leaves the terminal in raw mode + alternate screen + mouse capture while \`main\`'s \`eprintln!(\"Error: {e}\")\` fires — the message is invisible or scrambled.

## Fix

Capture \`app.run\`'s result instead of \`?\`-ing it, run teardown unconditionally, then propagate. Also switch \`DisableMouseCapture\` from \`?\` to \`let _ =\` so a teardown error can't hide the original \`run_result\`.

\`\`\`rust
let run_result = app.run(&mut terminal, &event_rx, &event_tx);
log::info!(\"event loop ended\");

if kitty_pushed {
    let _ = crossterm::execute!(std::io::stdout(), PopKeyboardEnhancementFlags);
}
let _ = crossterm::execute!(std::io::stdout(), DisableMouseCapture);
ratatui::restore();
log::info!(\"terminal restored, exiting\");
run_result.map_err(Into::into)
\`\`\`

8 lines changed, no behaviour change on the happy path.

## Test plan

- [x] \`cargo build\` / \`cargo test\` (180 passed) / \`cargo clippy --all-targets -D warnings\` / \`cargo fmt --check\` clean
- [x] Happy-path \`q\` exit still restores terminal cleanly (manual)