### PR TITLE
feat(lua): ttymap.animation.fly_to — frame-based pan animation

### DIFF
--- a/ttymap-tui/runtime/lua/ttymap/animation.lua
+++ b/ttymap-tui/runtime/lua/ttymap/animation.lua
@@ -1,0 +1,117 @@
+-- ttymap.animation — frame-based camera animation library.
+--
+-- Wraps `ttymap.map:fly_to` into a multi-frame interpolated transition
+-- so plugins that previously called `:jump(lon, lat)` can hand the
+-- view off to an animated pan instead. The visible behaviour is "the
+-- map glides toward the target over ~30 frames" — implemented by
+-- dispatching a fresh `:fly_to(lerp_value)` every frame from
+-- `on_tick`. Each per-tick dispatch is the existing instant composite,
+-- so there are no intermediate frames at half-applied state.
+--
+-- Usage:
+--   local anim = require "ttymap.animation"
+--   anim.fly_to(lon, lat)                            -- pan only, default frames
+--   anim.fly_to(lon, lat, zoom)                      -- with zoom change
+--   anim.fly_to(lon, lat, zoom, { frames = 60 })     -- override duration
+--
+-- Cancellation: a single animation is in flight at a time. A new
+-- `fly_to` call replaces the previous one (smoothly — the new `from`
+-- is whatever centre/zoom the map happens to be at). Manual user
+-- input (h/j/k/l pan, +/- zoom, mouse drag) interrupts the animation:
+-- detected by comparing the live map state against the value we
+-- dispatched last frame. If they diverge beyond tolerance, someone
+-- else moved the map, so we yield.
+
+local M = {}
+
+-- Tolerances for "did the user touch it" detection. Loose enough to
+-- absorb the float round-trip through `geo::normalize` + Mercator
+-- clamps, tight enough that a single keystroke pan (one cell) trips
+-- it.
+local TOL_LL   = 0.0005
+local TOL_ZOOM = 0.001
+
+-- Default ~500ms at 60fps. Frame-count rather than ms because
+-- `on_tick` doesn't surface dt; if the loop runs slower the
+-- animation just takes longer wall-clock.
+local DEFAULT_FRAMES = 30
+
+local active = nil  -- { from, to, frames, elapsed, expected }
+
+local function ease_in_out_cubic(t)
+    if t < 0.5 then
+        return 4 * t * t * t
+    end
+    local p = -2 * t + 2
+    return 1 - p * p * p / 2
+end
+
+local function lerp(a, b, t)
+    return a + (b - a) * t
+end
+
+-- Shortest-arc lon interpolation — same fix ping_simulation.lua uses
+-- so e.g. Tokyo→NY traces over the Pacific (146°) instead of via
+-- Eurasia (213°).
+local function lerp_lon(a, b, t)
+    local d = b - a
+    if d > 180 then
+        d = d - 360
+    elseif d < -180 then
+        d = d + 360
+    end
+    local lon = a + d * t
+    if lon > 180 then
+        lon = lon - 360
+    elseif lon < -180 then
+        lon = lon + 360
+    end
+    return lon
+end
+
+function M.fly_to(target_lon, target_lat, target_zoom, opts)
+    opts = opts or {}
+    local lon, lat = ttymap.map:center()
+    local zoom = ttymap.map:zoom()
+    active = {
+        from     = { lon, lat, zoom },
+        to       = { target_lon, target_lat, target_zoom or zoom },
+        frames   = opts.frames or DEFAULT_FRAMES,
+        elapsed  = 0,
+        expected = nil,
+    }
+end
+
+ttymap.api.frame.on_tick(function()
+    if not active then return end
+
+    -- Cancel if the map state diverged from what we dispatched last
+    -- frame. Skipped on the first tick (expected == nil) since we
+    -- haven't dispatched anything yet.
+    if active.expected then
+        local lon, lat = ttymap.map:center()
+        local zoom = ttymap.map:zoom()
+        if math.abs(lon - active.expected[1]) > TOL_LL
+            or math.abs(lat - active.expected[2]) > TOL_LL
+            or math.abs(zoom - active.expected[3]) > TOL_ZOOM then
+            active = nil
+            return
+        end
+    end
+
+    active.elapsed = active.elapsed + 1
+    local t = math.min(active.elapsed / active.frames, 1)
+    local et = ease_in_out_cubic(t)
+    local lon = lerp_lon(active.from[1], active.to[1], et)
+    local lat = lerp(active.from[2], active.to[2], et)
+    local z   = lerp(active.from[3], active.to[3], et)
+
+    ttymap.map:fly_to(lon, lat, z)
+    active.expected = { lon, lat, z }
+
+    if t >= 1 then
+        active = nil
+    end
+end)
+
+return M

--- a/ttymap-tui/runtime/plugin/aircraft/init.lua
+++ b/ttymap-tui/runtime/plugin/aircraft/init.lua
@@ -8,6 +8,7 @@
 local opensky = require("aircraft.opensky")
 local display = require("aircraft.display")
 local sidebar = require("ttymap.sidebar")
+local anim    = require("ttymap.animation")
 
 local state = {
     aircraft       = {},  -- list of { callsign, lon, lat, on_ground, alt, heading }
@@ -121,7 +122,7 @@ local function open()
             end
             if key.code == "Enter" then
                 local a = state.aircraft[state.selected]
-                if a then ttymap.map:jump(a.lon, a.lat) end
+                if a then anim.fly_to(a.lon, a.lat) end
                 return nil
             end
             if sidebar.is_close_key(key) then

--- a/ttymap-tui/runtime/plugin/here.lua
+++ b/ttymap-tui/runtime/plugin/here.lua
@@ -4,9 +4,13 @@
 -- Windowless: nothing is pushed onto the compositor stack. The
 -- palette `invoke` kicks a geoip GET if one isn't already in flight;
 -- the per-frame `on_tick` callback polls the inflight job and, when
--- the response lands, fires `ttymap.map:jump(...)` and clears state.
+-- the response lands, hands the centre to `ttymap.animation.fly_to`
+-- so the view glides over instead of teleporting (avoids the brief
+-- black-tile gap from landing on un-prefetched coordinates).
 --
 -- The endpoint comes from `ttymap.config:geoip_endpoint()`.
+
+local anim = require "ttymap.animation"
 
 local state = { job = nil }
 
@@ -18,9 +22,9 @@ ttymap.api.frame.on_tick(function()
         if p
             and type(p.latitude) == "number"
             and type(p.longitude) == "number" then
-            ttymap.map:jump(p.longitude, p.latitude)
+            anim.fly_to(p.longitude, p.latitude)
             ttymap.notify(string.format(
-                "Jumped to %.4f, %.4f", p.latitude, p.longitude
+                "Flew to %.4f, %.4f", p.latitude, p.longitude
             ))
         else
             ttymap.notify("here: geoip response missing lat/lon",

--- a/ttymap-tui/runtime/plugin/quake.lua
+++ b/ttymap-tui/runtime/plugin/quake.lua
@@ -19,6 +19,7 @@
 -- meaningful.
 
 local sidebar = require("ttymap.sidebar")
+local anim = require("ttymap.animation")
 
 local URL = "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.geojson"
 local INTERVAL_SEC = 300
@@ -152,7 +153,7 @@ ttymap.api.frame.on_tick(function(map)
                 local top = highest_magnitude(state.quakes)
                 if top then
                     state.initial_jump_done = true
-                    ttymap.map:jump(top.lon, top.lat)
+                    anim.fly_to(top.lon, top.lat)
                     ttymap.notify(string.format(
                         "quake: %d recent", #state.quakes
                     ))
@@ -211,7 +212,7 @@ local function open_panel()
             end
             if key.code == "Enter" then
                 local q = state.quakes[state.selected]
-                if q then ttymap.map:jump(q.lon, q.lat) end
+                if q then anim.fly_to(q.lon, q.lat) end
                 return nil
             end
             if sidebar.is_close_key(key) then

--- a/ttymap-tui/runtime/plugin/satellite/satellites.lua
+++ b/ttymap-tui/runtime/plugin/satellite/satellites.lua
@@ -28,6 +28,7 @@
 -- prior body for an hour anyway, so this is a non-issue.
 
 local sidebar = require "ttymap.sidebar"
+local anim = require "ttymap.animation"
 
 local M = {}
 
@@ -157,7 +158,7 @@ function M.make(specs)
             if sats[idx].visible then
                 selected = idx
                 local lon, lat = focus_point(sats[idx])
-                if lon then ttymap.map:jump(lon, lat) end
+                if lon then anim.fly_to(lon, lat) end
                 return
             end
         end
@@ -300,7 +301,7 @@ function M.make(specs)
                 local lon, lat = focus_point(sat)
                 if lon then
                     initial_jump_done = true
-                    ttymap.map:jump(lon, lat)
+                    anim.fly_to(lon, lat)
                     break
                 end
             end
@@ -359,7 +360,7 @@ function M.make(specs)
                     -- Re-centre on the focused sat — handy after the
                     -- user pans away to look at something else.
                     local lon, lat = focus_point(sats[selected])
-                    if lon then ttymap.map:jump(lon, lat) end
+                    if lon then anim.fly_to(lon, lat) end
                     return nil
                 end
 

--- a/ttymap-tui/runtime/plugin/search/init.lua
+++ b/ttymap-tui/runtime/plugin/search/init.lua
@@ -15,6 +15,7 @@
 -- `search.nominatim`.
 
 local nominatim = require("search.nominatim")
+local anim = require("ttymap.animation")
 
 local state = {
     job = nil,
@@ -90,7 +91,7 @@ local function open()
 
         execute = function(idx)
             local c = state.candidates[idx]
-            if c then ttymap.map:jump(c.lon, c.lat) end
+            if c then anim.fly_to(c.lon, c.lat) end
         end,
 
         is_loading = function() return state.pending end,

--- a/ttymap-tui/runtime/plugin/wiki/init.lua
+++ b/ttymap-tui/runtime/plugin/wiki/init.lua
@@ -15,6 +15,7 @@
 
 local fmt = require "ttymap.fmt"
 local sidebar = require "ttymap.sidebar"
+local anim = require "ttymap.animation"
 
 local LANGUAGE = "en"
 local LIMIT = 50
@@ -180,7 +181,7 @@ local function move_selection(direction)
     if n == 0 then return end
     state.selected = sidebar.cycle(state.selected, n, direction)
     local a = state.articles[state.selected]
-    if a then ttymap.map:jump(a.lon, a.lat) end
+    if a then anim.fly_to(a.lon, a.lat) end
 end
 
 -- Detail mode and the empty-state placeholder both render as
@@ -315,7 +316,7 @@ local function open()
                 local a = state.articles[state.selected]
                 if a then
                     state.detail = a
-                    ttymap.map:jump(a.lon, a.lat)
+                    anim.fly_to(a.lon, a.lat)
                 end
                 return nil
             end


### PR DESCRIPTION
## Summary

- New Lua lib `ttymap.animation` (~80 lines) that replaces `:jump` with a frame-based interpolated animation.
- **Engine untouched** — just calls the existing instant `:fly_to` composite once per frame from `on_tick`. Same pattern `ping_simulation.lua` already proved.
- Migrated all 8 bundled plugin `:jump` call sites (here / aircraft / wiki ×2 / search / quake ×2 / satellite ×3) to `anim.fly_to`.

## Motivation

Every `:jump` to another continent left a black-tile gap on screen until the new viewport's tiles arrived (here.lua, search, wiki, quake, satellite all hit this). Animating through intermediate viewpoints prefetches tiles along the path, so by the time the camera lands the cache is warm. The "looks broken for a moment" gap goes away — the smooth motion is mostly a side benefit.

#214 covers the engine-side smooth `fly_to` for the same problem. The Lua-side approach turned out to be enough in practice, so this PR ships it without touching `MapState` / `MapAction`.

## Design

### API
```lua
local anim = require "ttymap.animation"
anim.fly_to(lon, lat)                          -- pan only, default 30 frames (~500ms @ 60fps)
anim.fly_to(lon, lat, zoom)                    -- with zoom change
anim.fly_to(lon, lat, zoom, { frames = 60 })   -- override duration
```

### How it animates
On every `on_tick`:
1. Compute an intermediate point with `lerp(from, to, ease_in_out_cubic(t))`.
2. Dispatch `ttymap.map:fly_to(lerped_lon, lerped_lat, lerped_z)` — the existing instant composite, so center + zoom land in the same frame (no half-applied intermediate state visible).
3. Clear `active` once `t >= 1`.

### Cancellation
Manual user input (h/j/k/l pan, +/- zoom, mouse drag) cancels the animation:
- Record the value dispatched last frame in `expected`.
- At the start of the next tick, read `:center()` / `:zoom()` and compare against `expected`. If they diverge beyond tolerance, "someone else moved the map" → drop the animation.
- Tolerances: 0.0005° for lon/lat, 0.001 for zoom (loose enough to absorb float round-trip through `geo::normalize` / Mercator clamps, tight enough to catch a single-cell manual pan).

### Continuous fly_to
A new `fly_to` call re-reads `:center()` for its `from`, so it picks up wherever the in-flight animation happens to be at that frame and glides smoothly to the new target.

### Shortest-arc lon
Tokyo→NY traces over the Pacific (146°) instead of via Eurasia (213°), borrowed from `ping_simulation.lua`'s `interp_lon`.

## Trade-offs vs #214 (engine-side)

| | this PR (Lua) | #214 (engine) |
|---|---|---|
| size | ~80 lines Lua | 300-450 lines Rust+Lua |
| dt | frame-count (assumes 60fps; sensitive to loop-rate variance) | wall-clock (frame-rate independent) |
| cancel | tolerance check for "moved away" | deterministic (4 cancel points at apply boundary) |
| extensibility | already general — same pattern can tween anything | engine API needs another primitive |

User-visible result is identical frame-by-frame motion. The engine-side polish is overkill for the actual UX problem this addresses.

## Test plan
- [ ] `:` → "Jump to here" — geoip jump animates (notify text is `Flew to ...`)
- [ ] `/` → search → Enter — animates toward the result
- [ ] aircraft / wiki / quake / satellite sidebars: list nav + Enter animates to the chosen entry
- [ ] Press h/j/k/l mid-animation → animation stops immediately, manual pan takes over
- [ ] Trigger another `search` Enter mid-animation → smooth handoff from the in-flight midpoint to the new target