### PR TITLE
feat(travel): curated multi-country itineraries with animated tour mode

### DIFF
--- a/ttymap-tui/runtime/lua/ttymap/animation.lua
+++ b/ttymap-tui/runtime/lua/ttymap/animation.lua
@@ -13,6 +13,10 @@
 --   anim.fly_to(lon, lat)                            -- pan only, default frames
 --   anim.fly_to(lon, lat, zoom)                      -- with zoom change
 --   anim.fly_to(lon, lat, zoom, { frames = 60 })     -- override duration
+--   anim.fly_to(lon, lat, zoom, {                    -- with completion hooks
+--       on_done   = function() ... end,              --   fired when animation reaches target
+--       on_cancel = function() ... end,              --   fired when animation gets pre-empted
+--   })
 --
 -- Cancellation: a single animation is in flight at a time. A new
 -- `fly_to` call replaces the previous one (smoothly — the new `from`
@@ -20,7 +24,10 @@
 -- input (h/j/k/l pan, +/- zoom, mouse drag) interrupts the animation:
 -- detected by comparing the live map state against the value we
 -- dispatched last frame. If they diverge beyond tolerance, someone
--- else moved the map, so we yield.
+-- else moved the map, so we yield. The `on_cancel` callback (if any)
+-- fires once on pre-emption — by manual input *or* by a fresh
+-- `fly_to` call replacing the in-flight animation. `on_done` fires
+-- only on natural completion.
 
 local M = {}
 
@@ -69,16 +76,33 @@ local function lerp_lon(a, b, t)
     return lon
 end
 
+-- Helper: clear `active` and fire its `on_cancel` callback (if any).
+-- Used by both manual-input pre-emption and by a fresh `fly_to` that
+-- replaces an in-flight animation. Defensive against the callback
+-- itself triggering side effects that re-read `active`.
+local function cancel_active()
+    if not active then return end
+    local cb = active.on_cancel
+    active = nil
+    if cb then cb() end
+end
+
 function M.fly_to(target_lon, target_lat, target_zoom, opts)
     opts = opts or {}
+    -- A fresh fly_to over an in-flight animation is a pre-emption —
+    -- the previous target won't be reached, so its `on_cancel` fires
+    -- (mirrors manual-input pre-emption semantics).
+    cancel_active()
     local lon, lat = ttymap.map:center()
     local zoom = ttymap.map:zoom()
     active = {
-        from     = { lon, lat, zoom },
-        to       = { target_lon, target_lat, target_zoom or zoom },
-        frames   = opts.frames or DEFAULT_FRAMES,
-        elapsed  = 0,
-        expected = nil,
+        from      = { lon, lat, zoom },
+        to        = { target_lon, target_lat, target_zoom or zoom },
+        frames    = opts.frames or DEFAULT_FRAMES,
+        elapsed   = 0,
+        expected  = nil,
+        on_done   = opts.on_done,
+        on_cancel = opts.on_cancel,
     }
 end
 
@@ -94,7 +118,7 @@ ttymap.api.frame.on_tick(function()
         if math.abs(lon - active.expected[1]) > TOL_LL
             or math.abs(lat - active.expected[2]) > TOL_LL
             or math.abs(zoom - active.expected[3]) > TOL_ZOOM then
-            active = nil
+            cancel_active()
             return
         end
     end
@@ -110,7 +134,9 @@ ttymap.api.frame.on_tick(function()
     active.expected = { lon, lat, z }
 
     if t >= 1 then
+        local cb = active.on_done
         active = nil
+        if cb then cb() end
     end
 end)
 

--- a/ttymap-tui/runtime/plugin/travel/init.lua
+++ b/ttymap-tui/runtime/plugin/travel/init.lua
@@ -1,0 +1,411 @@
+-- travel — curated multi-country travel itineraries with an animated
+-- tour mode that flies the camera through each stop.
+--
+-- Three sidebar states (transitions on Enter / Esc):
+--
+--   1. **list**: every bundled route across all countries. C-n / C-p
+--      navigates, Enter opens detail.
+--   2. **detail**: full itinerary for the selected route — country,
+--      days, summary, stop-by-stop notes. Map preview shows the
+--      whole polyline + all markers so the geographic shape of the
+--      trip is visible at a glance. Enter starts the tour, Esc /
+--      Backspace returns to list.
+--   3. **tour**: three sub-phases drive the camera. **pre** flies
+--      to a bounding-box overview so the user sees the whole trip
+--      laid out before plunging in (no jarring teleport-to-Tokyo);
+--      **stop** loops through each `route.stops` entry, firing a
+--      `ttymap.notify` per arrival; **post** returns to overview
+--      for a final wrap-up beat. Manual pan / zoom (or palette
+--      re-toggle) cancels at any phase. No polyline during tour
+--      (Braille pixel-snapping ripples a static line as the camera
+--      glides) — markers carry the journey on their own; future
+--      stops show muted, current accent, past accent_alt.
+--
+-- Activation: `:` palette → "Travel". Re-invoking always exits
+-- completely (cancels any tour, closes the panel).
+--
+-- Adding a country: see `travel/routes/init.lua`.
+
+local sidebar   = require("ttymap.sidebar")
+local anim      = require("ttymap.animation")
+local countries = require("travel.routes")
+
+-- Flatten the per-country tables into a single list of routes,
+-- annotating each with the country name so the sidebar can show
+-- "Japan · Golden Route" without needing to maintain a parallel
+-- index. Shallow-copy each route so we don't mutate the requires
+-- cache (Lua caches requires; mutating would compound on reload).
+local routes = {}
+for _, c in ipairs(countries) do
+    for _, r in ipairs(c.routes) do
+        local annotated = {}
+        for k, v in pairs(r) do annotated[k] = v end
+        annotated.country = c.country
+        table.insert(routes, annotated)
+    end
+end
+
+-- Phase budgets (60fps assumption — frame counts, not ms, since
+-- on_tick doesn't surface dt). Tight 2-second beats keep momentum:
+-- long enough to read the notify popup and absorb the view, short
+-- enough that a 5-stop tour finishes in ~15s.
+local PRE_DWELL_FRAMES  = 120   -- ~2s overview before the journey starts
+local DWELL_FRAMES      = 120   -- ~2s parked at each stop
+local POST_DWELL_FRAMES = 120   -- ~2s overview after final stop
+
+-- Compute a (centre, zoom) that fits all stops with margin. Logarithmic
+-- zoom heuristic: span doubles → zoom drops by 1. Clamped to a sensible
+-- range so single-city routes don't zoom in past street level and
+-- continent-spanning ones don't blow past world view.
+local function overview_view(route)
+    local min_lon, max_lon = math.huge, -math.huge
+    local min_lat, max_lat = math.huge, -math.huge
+    for _, s in ipairs(route.stops) do
+        if s.lon < min_lon then min_lon = s.lon end
+        if s.lon > max_lon then max_lon = s.lon end
+        if s.lat < min_lat then min_lat = s.lat end
+        if s.lat > max_lat then max_lat = s.lat end
+    end
+    local center_lon = (min_lon + max_lon) / 2
+    local center_lat = (min_lat + max_lat) / 2
+    local span = math.max(max_lon - min_lon, max_lat - min_lat, 0.1)
+    -- 8.5 - log2(span) clamped to [3, 11]:
+    --   span ≥ 11°  → zoom 5    (continent / large country)
+    --   span ≈  3°  → zoom 7    (Italian classic, Snow Monkey + Alps)
+    --   span ≈  1°  → zoom 8-9  (Hokkaido, Sicily)
+    --   span ≈ 0.5° → zoom 9-10 (Amalfi)
+    local zoom = math.floor(8.5 - math.log(span) / math.log(2))
+    if zoom < 3 then zoom = 3 elseif zoom > 11 then zoom = 11 end
+    return center_lon, center_lat, zoom
+end
+
+local state = {
+    selected = 1,    -- 1-based index into routes (list mode)
+    w        = nil,  -- sidebar card handle while open
+    detail   = nil,  -- nil = list mode; a route table = detail mode
+    tour     = nil,  -- nil when not playing; else a tour table
+    --                  { route, phase = "pre"|"stop"|"post",
+    --                    stop_idx, dwell_left }
+}
+
+local function close_panel()
+    if state.w then
+        state.w:close()
+        state.w = nil
+    end
+end
+
+local advance_tour  -- forward decl
+
+local function finish_tour(message)
+    state.tour = nil
+    if message then
+        ttymap.notify(message)
+    end
+end
+
+-- Generic on_cancel handler — every fly_to in the state machine bails
+-- the whole tour the same way.
+local function on_cancel_bail()
+    finish_tour("Tour cancelled")
+end
+
+-- Schedule a fly_to whose `on_done` parks the camera for `dwell_frames`
+-- before the next state-machine transition.
+local function fly_then_dwell(lon, lat, zoom, dwell_frames)
+    anim.fly_to(lon, lat, zoom, {
+        on_done = function()
+            if state.tour then
+                state.tour.dwell_left = dwell_frames
+            end
+        end,
+        on_cancel = on_cancel_bail,
+    })
+end
+
+advance_tour = function()
+    local t = state.tour
+    if not t then return end
+
+    if t.phase == "pre" then
+        -- Pre-overview done. Enter stop loop at index 1.
+        t.phase = "stop"
+        t.stop_idx = 1
+        local stop = t.route.stops[1]
+        if not stop then
+            finish_tour("Tour: empty route")
+            return
+        end
+        ttymap.notify(stop.note)
+        fly_then_dwell(stop.lon, stop.lat, stop.zoom, DWELL_FRAMES)
+        return
+    end
+
+    if t.phase == "stop" then
+        t.stop_idx = t.stop_idx + 1
+        local stop = t.route.stops[t.stop_idx]
+        if stop then
+            ttymap.notify(stop.note)
+            fly_then_dwell(stop.lon, stop.lat, stop.zoom, DWELL_FRAMES)
+            return
+        end
+        -- All stops visited. Enter post-overview wrap-up.
+        t.phase = "post"
+        ttymap.notify(string.format("Tour complete: %s · %s",
+            t.route.country, t.route.name))
+        local lon, lat, z = overview_view(t.route)
+        fly_then_dwell(lon, lat, z, POST_DWELL_FRAMES)
+        return
+    end
+
+    -- Post-overview dwell expired — tour is done.
+    finish_tour(nil)
+end
+
+local function start_tour(route)
+    state.tour = {
+        route      = route,
+        phase      = "pre",
+        stop_idx   = 0,
+        dwell_left = 0,
+    }
+    ttymap.notify(string.format("Starting: %s · %s",
+        route.country, route.name))
+    local lon, lat, z = overview_view(route)
+    fly_then_dwell(lon, lat, z, PRE_DWELL_FRAMES)
+end
+
+-- Per-frame map paint. Three cases, in priority order:
+--
+--   * **tour active**: paint markers for every stop, coloured by
+--     phase + position (current accent, past accent_alt, future
+--     muted). Future stops let the user see what's coming. No
+--     polyline (Braille pixel-snapping ripples a static line as
+--     the camera glides). Tour state advances via `advance_tour`
+--     from the dwell countdown here and from the `on_done` callback
+--     in `fly_then_dwell`.
+--   * **detail mode**: no tour, but a route is selected — paint the
+--     whole polyline + all markers as a preview. Camera is static
+--     here (the user hasn't started flying), so the line is stable.
+--   * **list mode**: nothing to paint.
+ttymap.api.frame.on_tick(function(map)
+    local t = state.tour
+    if t then
+        local route = t.route
+        local current_idx = (t.phase == "stop") and t.stop_idx or 0
+
+        -- Route polyline: visible only during the pre/post overview
+        -- *dwells* (camera parked at the bbox view = stable line).
+        -- The pre dwell is the "here is the whole journey" moment
+        -- before the stop-by-stop flight; the post dwell mirrors it
+        -- as a wrap-up. Hidden during all camera motion (pre fly,
+        -- stop fly, post fly) because Braille pixel-snapping ripples
+        -- a static line as the camera glides.
+        if (t.phase == "pre" or t.phase == "post") and t.dwell_left > 0 then
+            local coords = {}
+            for _, s in ipairs(route.stops) do
+                table.insert(coords, { s.lon, s.lat })
+            end
+            map:polyline(coords, "muted")
+        end
+
+        for i, s in ipairs(route.stops) do
+            local color
+            if i == current_idx then
+                color = "accent"
+            elseif t.phase == "post" or i < current_idx then
+                color = "accent_alt"
+            else
+                color = "muted"
+            end
+            map:point(s.lon, s.lat, "●", color)
+            map:label(s.lon, s.lat, s.name, color)
+        end
+        if t.dwell_left > 0 then
+            t.dwell_left = t.dwell_left - 1
+            if t.dwell_left == 0 then
+                advance_tour()
+            end
+        end
+        return
+    end
+
+    local d = state.detail
+    if d then
+        local coords = {}
+        for _, s in ipairs(d.stops) do
+            table.insert(coords, { s.lon, s.lat })
+        end
+        map:polyline(coords, "muted")
+        for _, s in ipairs(d.stops) do
+            map:point(s.lon, s.lat, "●", "accent_alt")
+        end
+    end
+end)
+
+-- ── Detail-mode rendering ─────────────────────────────────────────
+local function render_detail(route)
+    local lines = {
+        { { text = route.country, style = "muted" },
+          { text = " · ",          style = "muted" },
+          { text = route.name,     style = "accent" } },
+        { { text = route.days, style = "muted" } },
+        { { text = "" } },
+        { { text = route.summary, style = "body" } },
+        { { text = "" } },
+        { { text = "Itinerary:", style = "muted" } },
+    }
+    -- Highlight stops only during the actual stop loop. Pre / post
+    -- overview phases don't single out a row — they're whole-route
+    -- moments.
+    local current_idx = 0
+    if state.tour and state.tour.route == route and state.tour.phase == "stop" then
+        current_idx = state.tour.stop_idx
+    end
+    for i, s in ipairs(route.stops) do
+        local marker, name_style
+        if i == current_idx then
+            marker, name_style = "▶ ", "accent"
+        elseif state.tour and state.tour.route == route
+            and (state.tour.phase == "post" or i < current_idx) then
+            marker, name_style = "✓ ", "accent_alt"
+        else
+            marker, name_style = "  ", "accent_alt"
+        end
+        table.insert(lines, {
+            { text = marker, style = "body" },
+            { text = string.format("%d. %s", i, s.name), style = name_style },
+        })
+        table.insert(lines, {
+            { text = "    " .. s.note, style = "body" },
+        })
+    end
+    table.insert(lines, { { text = "" } })
+    if state.tour and state.tour.route == route then
+        local phase_label
+        if state.tour.phase == "pre" then
+            phase_label = "Overview — orienting…"
+        elseif state.tour.phase == "post" then
+            phase_label = "Wrap-up — overview…"
+        else
+            phase_label = "Tour playing — pan / zoom to cancel."
+        end
+        table.insert(lines, { { text = phase_label, style = "muted" } })
+    else
+        table.insert(lines, { { text = "Enter: play tour",          style = "muted" } })
+        table.insert(lines, { { text = "q / Esc / Backspace: back", style = "muted" } })
+    end
+    return lines
+end
+
+local function build_lines()
+    if state.detail then
+        return render_detail(state.detail)
+    end
+    -- Empty list never happens (we always have routes), so this is
+    -- only reached if items() returned [] for some other reason.
+    return {
+        { { text = "No routes available.", style = "muted" } },
+    }
+end
+
+local function build_items()
+    if state.detail then return {} end
+    local items = {}
+    for _, route in ipairs(routes) do
+        table.insert(items, {
+            { { text = route.country, style = "muted" },
+              { text = " · ",          style = "muted" },
+              { text = route.name,     style = "accent" },
+              { text = "  ",           style = "body" },
+              { text = route.days,     style = "muted" } },
+            { { text = "  " .. route.summary, style = "body" } },
+        })
+    end
+    return items
+end
+
+local function open_panel()
+    if state.w then return end
+    local n = #routes
+    state.w = ttymap.api.card.open({
+        name = "travel",
+        -- footer_hints is read once at construction (static table —
+        -- the bridge expects a sequence, not a function), so list /
+        -- detail / tour all share one general hint row.
+        footer_hints = {
+            { key = "C-n/C-p", label = "select" },
+            { key = "Enter",   label = "details / play" },
+            { key = "q / Esc", label = "back / close" },
+        },
+        render       = build_lines,
+        items        = build_items,
+        selected     = function() return state.selected end,
+        handle_key = function(key)
+            -- Tour active: any cancellation key drops back to detail
+            -- mode. Manual pan / zoom is handled by the animation
+            -- lib (its tolerance check fires on_cancel which clears
+            -- state.tour); we only catch keys that don't reach the
+            -- map (Esc, etc.).
+            if state.tour then
+                if sidebar.is_close_key(key) or key.code == "Backspace" then
+                    finish_tour("Tour cancelled")
+                    return nil
+                end
+                return { ignore = true }
+            end
+
+            -- Detail mode: Enter plays, Esc / Backspace returns to list.
+            if state.detail then
+                if key.code == "Enter" then
+                    start_tour(state.detail)
+                    return nil
+                end
+                if sidebar.is_close_key(key) or key.code == "Backspace" then
+                    state.detail = nil
+                    return nil
+                end
+                return { ignore = true }
+            end
+
+            -- List mode: navigate + open detail.
+            if sidebar.up_pressed(key) then
+                state.selected = sidebar.cycle(state.selected, n, -1)
+                return nil
+            end
+            if sidebar.down_pressed(key) then
+                state.selected = sidebar.cycle(state.selected, n, 1)
+                return nil
+            end
+            if key.code == "Enter" then
+                state.detail = routes[state.selected]
+                return nil
+            end
+            if sidebar.is_close_key(key) then
+                close_panel()
+                return nil
+            end
+            return { ignore = true }
+        end,
+    })
+end
+
+local function toggle()
+    -- Re-pressing the palette command always exits completely:
+    -- cancel any tour, drop detail, close panel. One keypress to
+    -- dismiss everything regardless of which sub-state we're in.
+    if state.tour or state.detail or state.w then
+        if state.tour then
+            finish_tour(nil)
+        end
+        state.detail = nil
+        close_panel()
+        return
+    end
+    open_panel()
+end
+
+ttymap.register_palette_command({
+    label  = "Travel",
+    invoke = toggle,
+})

--- a/ttymap-tui/runtime/plugin/travel/routes/init.lua
+++ b/ttymap-tui/runtime/plugin/travel/routes/init.lua
@@ -1,0 +1,20 @@
+-- travel.routes — manifest of all bundled country route packs.
+--
+-- Each entry is a country table `{ country, routes }` returned from a
+-- sibling file. Adding a new country is a two-step:
+--
+--   1. Drop a `<country>.lua` next to this file with the same shape
+--      as `japan.lua`.
+--   2. Append a `(require "travel.routes.<country>")` line to the
+--      list below — note the parentheses, they are load-bearing
+--      (Lua 5.4 `require` returns the module *and* loader info; the
+--      parens truncate to a single value so the list doesn't grow
+--      phantom string entries from the trailing position).
+--
+-- We don't auto-discover via filesystem walk — Lua has no portable
+-- `readdir`, and the explicit list keeps load order deterministic.
+
+return {
+    (require "travel.routes.japan"),
+    (require "travel.routes.italy"),
+}

--- a/ttymap-tui/runtime/plugin/travel/routes/italy.lua
+++ b/ttymap-tui/runtime/plugin/travel/routes/italy.lua
@@ -1,0 +1,60 @@
+-- travel.routes.italy — curated Italian itineraries.
+--
+-- Same shape as `japan.lua`: { country, routes }. Mountains, coast,
+-- and Mediterranean islands cover most of what a first-time visitor
+-- would book.
+
+return {
+    country = "Italy",
+    routes = {
+        {
+            name    = "Classic Italy",
+            days    = "10-14 days",
+            summary = "Big four — Rome, Florence, Venice, Milan",
+            stops = {
+                { lon = 12.50, lat = 41.90, zoom = 11, name = "Rome",
+                  note = "Rome — Colosseum, Vatican, espresso at every corner" },
+                { lon = 11.25, lat = 43.77, zoom = 12, name = "Florence",
+                  note = "Florence — Duomo, Uffizi, birthplace of the Renaissance" },
+                { lon = 12.34, lat = 45.44, zoom = 12, name = "Venice",
+                  note = "Venice — gondolas, mask shops, sinking-island vibes" },
+                { lon = 9.19,  lat = 45.46, zoom = 11, name = "Milan",
+                  note = "Milan — Duomo, fashion, Last Supper at Santa Maria delle Grazie" },
+            },
+        },
+        {
+            name    = "Amalfi Coast + Naples",
+            days    = "5-7 days",
+            summary = "Cliffside villages, lemon groves, Pompeii",
+            stops = {
+                { lon = 14.27, lat = 40.85, zoom = 11, name = "Naples",
+                  note = "Naples — birthplace of pizza, raw and chaotic charm" },
+                { lon = 14.49, lat = 40.75, zoom = 12, name = "Pompeii",
+                  note = "Pompeii — frozen 79 AD city under Vesuvius ash" },
+                { lon = 14.37, lat = 40.63, zoom = 12, name = "Sorrento",
+                  note = "Sorrento — limoncello, cliffs, gateway to the coast" },
+                { lon = 14.49, lat = 40.63, zoom = 13, name = "Positano",
+                  note = "Positano — pastel houses cascading to the sea" },
+                { lon = 14.24, lat = 40.55, zoom = 12, name = "Capri",
+                  note = "Capri — Blue Grotto, jet-set island day trip" },
+            },
+        },
+        {
+            name    = "Sicily Loop",
+            days    = "7 days",
+            summary = "Volcano + Greek ruins + arancini",
+            stops = {
+                { lon = 13.36, lat = 38.12, zoom = 11, name = "Palermo",
+                  note = "Palermo — markets, mosaics, street food capital" },
+                { lon = 14.02, lat = 38.04, zoom = 12, name = "Cefalù",
+                  note = "Cefalù — medieval seaside town under a great rock" },
+                { lon = 15.29, lat = 37.85, zoom = 12, name = "Taormina",
+                  note = "Taormina — Greek theatre with Mt. Etna in the backdrop" },
+                { lon = 15.00, lat = 37.75, zoom = 11, name = "Mt. Etna",
+                  note = "Mt. Etna — Europe's most active volcano, hike the craters" },
+                { lon = 15.29, lat = 37.07, zoom = 12, name = "Syracuse",
+                  note = "Syracuse — Ortigia island, Greek temples, Aretusa fountain" },
+            },
+        },
+    },
+}

--- a/ttymap-tui/runtime/plugin/travel/routes/japan.lua
+++ b/ttymap-tui/runtime/plugin/travel/routes/japan.lua
@@ -1,0 +1,106 @@
+-- travel.routes.japan — curated Japan itineraries for foreign visitors.
+--
+-- Each route lists 5-6 stops. The `note` field is used twice:
+--   1. As the secondary line in the sidebar list view (one-liner about
+--      the city or its attraction).
+--   2. As the per-stop notify popup during the animated tour.
+--
+-- Coordinates are city-centric where the route lands a tourist (e.g.
+-- Hakone is the Tougendai cable-car area, not the township office;
+-- Jigokudani is the snow monkey park itself, not Yamanouchi station).
+-- Zoom levels are tuned so the named place is recognisable in the
+-- terminal grid — denser cities get z=10, single-attraction stops
+-- get z=11/12.
+
+return {
+    country = "Japan",
+    routes = {
+    {
+        name    = "Golden Route",
+        days    = "10-14 days",
+        summary = "First-timer classic — Tokyo, Mt. Fuji, Kyoto, Nara, Osaka",
+        stops = {
+            { lon = 139.69, lat = 35.69, zoom = 10, name = "Tokyo",
+              note = "Tokyo — neon nights, ramen mornings, ancient shrines" },
+            { lon = 139.03, lat = 35.23, zoom = 11, name = "Hakone",
+              note = "Hakone — onsen + Mt. Fuji on a clear day" },
+            { lon = 135.77, lat = 35.01, zoom = 11, name = "Kyoto",
+              note = "Kyoto — 1000-year capital, Fushimi Inari's red gates" },
+            { lon = 135.83, lat = 34.69, zoom = 12, name = "Nara",
+              note = "Nara — friendly deer, the giant Buddha at Todai-ji" },
+            { lon = 135.50, lat = 34.69, zoom = 11, name = "Osaka",
+              note = "Osaka — takoyaki, neon Dotonbori, Japan's kitchen" },
+        },
+    },
+    {
+        name    = "Hokkaido Winter Loop",
+        days    = "7 days",
+        summary = "Snow + onsen + seafood — Sapporo to Hakodate",
+        stops = {
+            { lon = 141.35, lat = 43.06, zoom = 10, name = "Sapporo",
+              note = "Sapporo — snow festival, miso ramen, Susukino nightlife" },
+            { lon = 140.99, lat = 43.19, zoom = 12, name = "Otaru",
+              note = "Otaru — gas-lamp canal at dusk, glassware, sushi" },
+            { lon = 140.69, lat = 42.85, zoom = 11, name = "Niseko",
+              note = "Niseko — world-class powder, ski + onsen combo" },
+            { lon = 140.85, lat = 42.62, zoom = 11, name = "Lake Toya",
+              note = "Lake Toya — caldera lake, hot springs by the water" },
+            { lon = 140.73, lat = 41.77, zoom = 11, name = "Hakodate",
+              note = "Hakodate — million-dollar night view from Mt. Hakodate" },
+        },
+    },
+    {
+        name    = "Kyushu Onsen Trail",
+        days    = "7 days",
+        summary = "Active volcanoes + steaming hot springs",
+        stops = {
+            { lon = 130.40, lat = 33.59, zoom = 10, name = "Fukuoka",
+              note = "Fukuoka — Hakata ramen, riverside yatai food stalls" },
+            { lon = 131.50, lat = 33.28, zoom = 11, name = "Beppu",
+              note = "Beppu — eight steaming 'hells' of coloured hot springs" },
+            { lon = 131.36, lat = 33.26, zoom = 11, name = "Yufuin",
+              note = "Yufuin — quiet onsen town, art galleries, soft pudding" },
+            { lon = 131.10, lat = 32.88, zoom = 11, name = "Mt. Aso",
+              note = "Mt. Aso — peer into one of the world's largest active calderas" },
+            { lon = 130.55, lat = 31.59, zoom = 11, name = "Kagoshima",
+              note = "Kagoshima — Sakurajima volcano puffing across the bay" },
+        },
+    },
+    {
+        name    = "Snow Monkey + Japan Alps",
+        days    = "7 days",
+        summary = "Mountain heritage — bathing macaques, gassho farmhouses",
+        stops = {
+            { lon = 139.69, lat = 35.69, zoom = 10, name = "Tokyo",
+              note = "Start: Tokyo — board a Shinkansen north" },
+            { lon = 138.46, lat = 36.73, zoom = 12, name = "Jigokudani",
+              note = "Jigokudani — wild macaques bathing in a hot spring" },
+            { lon = 137.97, lat = 36.24, zoom = 11, name = "Matsumoto",
+              note = "Matsumoto — original 16th-century black 'Crow' castle" },
+            { lon = 137.25, lat = 36.14, zoom = 11, name = "Takayama",
+              note = "Takayama — Edo-era streets, sake breweries" },
+            { lon = 136.91, lat = 36.26, zoom = 12, name = "Shirakawa-go",
+              note = "Shirakawa-go — UNESCO gassho-zukuri farmhouses" },
+            { lon = 136.66, lat = 36.56, zoom = 11, name = "Kanazawa",
+              note = "Kanazawa — Kenroku-en garden, gold leaf, geisha district" },
+        },
+    },
+    {
+        name    = "Hiroshima + Setouchi",
+        days    = "5 days",
+        summary = "West Japan highlights — peace, castles, floating torii",
+        stops = {
+            { lon = 135.50, lat = 34.69, zoom = 10, name = "Osaka",
+              note = "Start: Osaka — board the Sanyo Shinkansen west" },
+            { lon = 134.69, lat = 34.84, zoom = 12, name = "Himeji",
+              note = "Himeji — gleaming white 'White Heron' castle" },
+            { lon = 132.46, lat = 34.39, zoom = 11, name = "Hiroshima",
+              note = "Hiroshima — Peace Memorial Park, okonomiyaki" },
+            { lon = 132.32, lat = 34.30, zoom = 12, name = "Miyajima",
+              note = "Miyajima — floating torii gate at high tide" },
+            { lon = 132.18, lat = 34.17, zoom = 12, name = "Iwakuni",
+              note = "Iwakuni — five-arched Kintai-kyo bridge" },
+        },
+    },
+    },
+}

--- a/ttymap-tui/src/lua/mod.rs
+++ b/ttymap-tui/src/lua/mod.rs
@@ -256,6 +256,7 @@ mod tests {
             "export",
             "help",
             "search",
+            "travel",
         ] {
             assert!(
                 palette.iter().any(|l| l.contains(stem)),


### PR DESCRIPTION
## Summary

A bundled `travel` plugin that packages popular foreign-tourist itineraries (Japan + Italy out of the box, **8 routes** total) and plays them as an animated camera tour over the map.

Built on top of `ttymap.animation.fly_to` (PR #256) — no engine changes, pure Lua plugin.

## Tour structure

Three phases:

| Phase | Duration | What you see |
|---|---|---|
| **pre**  | ~2s | Camera flies to a bounding-box overview, then dwells with the **full polyline + all markers** painted on the static frame — "here's the whole journey laid out" beat |
| **stop** | ~2s × N | Loops through `route.stops`, fly_to each, fires the stop's `note` as a notify popup, dwells |
| **post** | ~2s | Camera flies back to overview, dwells with the line for a wrap-up beat |

Total: a 5-stop route runs in ~15 seconds.

Markers carry the journey through every phase: **current** = `accent`, **past** = `accent_alt`, **future** = `muted`. The polyline only paints during the pre/post overview dwells where the camera is parked — Braille pixel-snapping ripples a static line as the camera glides, and the dwell-only gate avoids the flicker without losing the framing.

## Sidebar — three sub-states

- **list**: all routes across countries (`C-n`/`C-p` navigates, `Enter` opens detail)
- **detail**: full itinerary text + map preview (camera static, polyline shown). `Enter` starts tour, `Esc`/`Backspace` returns to list
- **tour**: panel stays open with detail visible; current stop marked `▶`, past `✓`, future blank — readable progress alongside the camera animation

`:` palette → `Travel` re-toggle exits everything completely (cancel tour, drop detail, close panel) regardless of sub-state.

Manual pan / zoom (or palette re-toggle) cancels at any phase via the animation lib's tolerance check → `on_cancel`.

## Routes shipped

**Japan** (5):
- Golden Route (10-14d) — Tokyo → Hakone → Kyoto → Nara → Osaka
- Hokkaido Winter Loop (7d) — Sapporo → Otaru → Niseko → Lake Toya → Hakodate
- Kyushu Onsen Trail (7d) — Fukuoka → Beppu → Yufuin → Mt. Aso → Kagoshima
- Snow Monkey + Japan Alps (7d) — Tokyo → Jigokudani → Matsumoto → Takayama → Shirakawa-go → Kanazawa
- Hiroshima + Setouchi (5d) — Osaka → Himeji → Hiroshima → Miyajima → Iwakuni

**Italy** (3):
- Classic Italy (10-14d) — Rome → Florence → Venice → Milan
- Amalfi Coast + Naples (5-7d) — Naples → Pompeii → Sorrento → Positano → Capri
- Sicily Loop (7d) — Palermo → Cefalù → Taormina → Mt. Etna → Syracuse

Per-stop `note` strings double as the sidebar description and the per-stop notify popup.

## Adding a country

Two-step:

1. Drop `runtime/plugin/travel/routes/<country>.lua` returning `{ country, routes }` (mirror `japan.lua`).
2. Append `(require \"travel.routes.<country>\")` to the manifest in `routes/init.lua`.

The trailing parens are **load-bearing** — Lua 5.4 `require` returns the module *and* loader info, and a bare trailing call inside a table constructor expands both into the array, growing phantom string entries that crash the flatten loop. The manifest comment spells this out (this trap silently broke the first commit until an extra entry showed up).

## Animation lib changes

`ttymap.animation.fly_to` gains `on_done` / `on_cancel` opts:

```lua
anim.fly_to(lon, lat, zoom, {
    on_done   = function() ... end,   -- natural arrival
    on_cancel = function() ... end,   -- pre-empted (manual input or fresh fly_to)
})
```

A fresh `fly_to` over an in-flight one now fires the previous `on_cancel` — pre-emption semantics now match manual pan / zoom (consistent observer view of "your animation got pre-empted, do whatever").

This is what the tour state machine uses to chain pre → stop loop → post without polling.

## Defensive

`every_bundled_script_registers` test now also asserts a `travel`-stem palette entry, so a future regression like the Lua 5.4 trailing-`require` trap (which silently broke load) trips the test instead of disappearing into the runtime.

## Test plan

- [ ] `:` palette → `Travel` opens the panel with 8 routes
- [ ] `C-n`/`C-p` navigates, `Enter` opens detail with the full plan + map preview line
- [ ] `Enter` from detail starts tour: pre-overview → stops → post-overview, panel stays open with `▶`/`✓` progress
- [ ] notify popups appear at each stop with the route note
- [ ] manual `h`/`j`/`k`/`l` pan during any phase cancels with "Tour cancelled"
- [ ] `:` palette → `Travel` again at any time exits completely
- [ ] `Esc`/`Backspace` from detail returns to list
- [ ] Polyline visible only during the pre/post overview dwells (not during fly motion)
- [ ] Adding a fake country file + manifest line picks it up in the list