### PR TITLE
feat(lua): ttymap.director — coroutine-based scheduler for scripted scenes

### DIFF
--- a/docs/lua-architecture.md
+++ b/docs/lua-architecture.md
@@ -373,21 +373,21 @@ Errors at any layer are logged + recovered; the chain keeps walking.
 
 ## Bundled plugins (`runtime/plugin/`)
 
-14 total. Each plugin is a reference implementation of one shape —
+15 total. Each plugin is a reference implementation of one shape —
 always-on chrome (`attribution`, `scalebar`, `help`), toggleable
 overlay (`center`, `here`, `ping_simulation`), toggleable side panel
-(`info`, `notify`, `aircraft`, `satellite`, `wiki`), palette
-one-shot (`export`, `quake`), or palette provider (`search`):
+(`info`, `notify`, `aircraft`, `satellite`, `wiki`, `travel`),
+palette one-shot (`export`, `quake`), or palette provider (`search`):
 
 ```
 aircraft/        attribution.lua  center.lua         export.lua
 help.lua         here.lua         info.lua           notify.lua
 ping_simulation.lua  quake.lua    satellite/         scalebar.lua
-search/          wiki/
+search/          travel/          wiki/
 ```
 
-Directory plugins (`aircraft/`, `satellite/`, `search/`, `wiki/`) use
-`<plugin>/init.lua` as the entry; sibling files load via
+Directory plugins (`aircraft/`, `satellite/`, `search/`, `travel/`,
+`wiki/`) use `<plugin>/init.lua` as the entry; sibling files load via
 `require "<plugin>.<name>"`.
 
 `satellite` is a **single multi-sat tracker** — one palette entry,
@@ -396,6 +396,60 @@ plus whatever the user appends to `satellite/init.lua`'s spec list).
 Per-sat key chars (`i` / `h` …) inside the panel toggle individual
 visibility. TLE fetch (CelesTrak) and SGP4 propagation
 (`ttymap.sgp4`) run per visible sat from inside `on_tick`.
+
+`travel` packages curated multi-country itineraries (Japan + Italy
+out of the box) and choreographs an animated tour through each
+route's stops via `ttymap.director` — a perfect demonstration of
+the Lua-side scriptable-scenes layer (see below).
+
+## Shared libraries (`runtime/lua/ttymap/`)
+
+`require`-only Lua modules (no plugin discovery, no `register_*`
+side effects). Each is independently useful from any plugin or
+`init.lua`. Keep the Rust bridge primitive — composition lives
+here.
+
+| Module                  | Surface                                                        |
+| ----------------------- | -------------------------------------------------------------- |
+| `ttymap.fmt`            | `.distance(meters)` — short human-readable distance string    |
+| `ttymap.sidebar`        | `.up_pressed` / `.down_pressed` / `.is_close_key` / `.cycle`  |
+| `ttymap.animation`      | `.fly_to(lon, lat, zoom, opts?)` — frame-based pan animation  |
+| `ttymap.director`       | `.run(fn, opts?)` / `.fly` / `.wait` / `.tween` — coroutine-based scheduler |
+
+`ttymap.animation.fly_to` interpolates `ttymap.map:fly_to` over ~30
+frames (default), with optional `on_done` / `on_cancel` callbacks
+fired on natural completion / pre-emption. Cancellation: manual
+user pan / zoom is detected by comparing live map state against
+the value dispatched last frame (Braille cell tolerance). A fresh
+`fly_to` over an in-flight one fires the previous `on_cancel` —
+pre-emption semantics match manual input.
+
+`ttymap.director` builds a procedural-looking async API on top of
+animation + a frame timer:
+
+```lua
+local director = require "ttymap.director"
+director.run(function()
+    ttymap.notify("Starting tour")
+    director.fly(139.69, 35.69, 10)         -- yields until arrival
+    director.wait(120)                        -- yields 120 frames
+    for _, stop in ipairs(stops) do
+        director.fly(stop.lon, stop.lat, stop.zoom)
+        ttymap.notify(stop.note)
+        director.wait(120)
+    end
+end, { on_cancel = function() ... end })
+```
+
+Internally it's a coroutine + a directive enum (`fly` / `wait` /
+`tween`) yielded back to a single `on_tick` driver. Multiple
+`director.run` calls run in parallel — each registers its own
+coroutine. Cancellation propagates from the animation lib's
+`on_cancel` (manual input pre-empts the active `fly`), or from
+explicit `handle:cancel()`. A natural function return ends the
+script without firing `on_cancel`. The travel plugin's pre /
+stop / post tour is one such script — the whole choreography is
+top-to-bottom procedural Lua, no hand-written state machine.
 
 ## User plugins
 

--- a/ttymap-tui/runtime/lua/ttymap/director.lua
+++ b/ttymap-tui/runtime/lua/ttymap/director.lua
@@ -1,0 +1,201 @@
+-- ttymap.director — coroutine-based scheduler for choreographing
+-- async actions over time. Wraps `ttymap.animation.fly_to` and a
+-- frame-based wait timer behind a procedural API:
+--
+--   local director = require "ttymap.director"
+--
+--   director.run(function()
+--       ttymap.notify("Starting tour")
+--       director.fly(139.69, 35.69, 10)         -- yields until arrival
+--       director.wait(120)                        -- yields 120 frames
+--       for _, stop in ipairs(stops) do
+--           director.fly(stop.lon, stop.lat, stop.zoom)
+--           ttymap.notify(stop.note)
+--           director.wait(120)
+--       end
+--   end, {
+--       on_cancel = function() ttymap.notify("Cancelled") end,
+--   })
+--
+-- Multiple scripts run in parallel — each call to `run` registers
+-- a new coroutine. They're all driven by a single on_tick
+-- subscription that advances waits, ticks tweens, and prunes dead
+-- records.
+--
+-- Cancellation:
+--   * `handle:cancel()` cancels one script. Pass `{ silent = true }`
+--     to skip the on_cancel callback (use when the caller already
+--     knows about the cancel and doesn't want a duplicate signal —
+--     e.g. an explicit "stop tour" UI action).
+--   * `director.cancel_all()` cancels every active script.
+--   * The animation lib's tolerance check during a `director.fly`
+--     (manual user pan / zoom) cancels the script via the lib's own
+--     on_cancel — and fires the script's on_cancel.
+-- Natural completion (the function returns) does NOT fire
+-- on_cancel — it's reserved for "interrupted before finishing".
+--
+-- Primitives:
+--   director.fly(lon, lat, zoom, opts?)   -- yields until arrival
+--   director.wait(frames)                  -- yields N frames
+--   director.tween(setter, frames)         -- yields, calls
+--                                             setter(t in [0,1])
+--                                             every frame for
+--                                             `frames` frames
+--   ttymap.notify(...)                     -- not a director
+--                                             primitive — synchronous,
+--                                             call directly
+--
+-- This is the kernel of "scriptable scenes" in ttymap. The travel
+-- plugin's pre/stop/post tour, ping_simulation's per-ping loops,
+-- a future demo plugin's auto-pan-zoom — all collapse to
+-- procedural code.
+
+local anim = require "ttymap.animation"
+
+local M = {}
+local actives = {}
+
+-- ── Handle / cancellation ───────────────────────────────────────
+local Handle = {}
+Handle.__index = Handle
+
+local function cancel_rec(rec, silent)
+    if rec.dead then return end
+    rec.dead = true
+    rec.cancelled = true
+    if not silent and rec.on_cancel then
+        local ok, err = pcall(rec.on_cancel)
+        if not ok then
+            ttymap.log:warn("director: on_cancel raised: " .. tostring(err))
+        end
+    end
+end
+
+function Handle:cancel(opts)
+    cancel_rec(self, opts and opts.silent)
+end
+
+function M.cancel_all()
+    for _, rec in ipairs(actives) do
+        cancel_rec(rec)
+    end
+end
+
+-- ── Step + dispatch ─────────────────────────────────────────────
+-- Resume rec's coroutine and act on whatever directive it yields.
+-- Marks rec.dead if the script finished naturally or errored out.
+local function step(rec)
+    if rec.dead then return end
+    local ok, directive = coroutine.resume(rec.co)
+    if not ok then
+        ttymap.log:warn("director: coroutine error: " .. tostring(directive))
+        rec.dead = true
+        return
+    end
+    if coroutine.status(rec.co) == "dead" then
+        -- Natural completion. No on_cancel — rec.cancelled stays false.
+        rec.dead = true
+        return
+    end
+    rec.directive = directive
+    if directive.kind == "fly" then
+        local opts = directive.opts or {}
+        anim.fly_to(directive.lon, directive.lat, directive.zoom, {
+            frames    = opts.frames,
+            on_done   = function()
+                if not rec.dead then
+                    rec.directive = nil
+                    step(rec)
+                end
+            end,
+            on_cancel = function() cancel_rec(rec) end,
+        })
+    elseif directive.kind == "wait" then
+        rec.wait_left = directive.frames
+    elseif directive.kind == "tween" then
+        rec.tween_elapsed = 0
+    end
+end
+
+-- ── Public ──────────────────────────────────────────────────────
+function M.run(fn, opts)
+    local rec = setmetatable({
+        co        = coroutine.create(fn),
+        dead      = false,
+        cancelled = false,
+        on_cancel = opts and opts.on_cancel,
+    }, Handle)
+    step(rec)
+    if not rec.dead then
+        table.insert(actives, rec)
+    end
+    return rec
+end
+
+function M.fly(lon, lat, zoom, opts)
+    return coroutine.yield({
+        kind = "fly",
+        lon  = lon, lat = lat, zoom = zoom,
+        opts = opts,
+    })
+end
+
+function M.wait(frames)
+    return coroutine.yield({ kind = "wait", frames = frames })
+end
+
+function M.tween(setter, frames)
+    return coroutine.yield({
+        kind   = "tween",
+        setter = setter,
+        frames = frames,
+    })
+end
+
+-- ── Driver ──────────────────────────────────────────────────────
+-- Per-tick: prune dead records, decrement wait timers, advance
+-- tween setters. "fly" directives don't need per-tick attention —
+-- they advance via the animation lib's on_done callback wired up
+-- in step().
+ttymap.api.frame.on_tick(function()
+    local i = 1
+    while i <= #actives do
+        local rec = actives[i]
+        if rec.dead then
+            table.remove(actives, i)
+        else
+            local d = rec.directive
+            local advance = false
+            if d then
+                if d.kind == "wait" then
+                    rec.wait_left = rec.wait_left - 1
+                    if rec.wait_left <= 0 then advance = true end
+                elseif d.kind == "tween" then
+                    rec.tween_elapsed = rec.tween_elapsed + 1
+                    local t = math.min(rec.tween_elapsed / d.frames, 1)
+                    local ok, err = pcall(d.setter, t)
+                    if not ok then
+                        ttymap.log:warn("director: tween setter error: " .. tostring(err))
+                        cancel_rec(rec)
+                    elseif t >= 1 then
+                        advance = true
+                    end
+                end
+                -- "fly": waits on anim's on_done — no per-tick work.
+            end
+            if advance then
+                rec.directive = nil
+                step(rec)
+                if rec.dead then
+                    table.remove(actives, i)
+                else
+                    i = i + 1
+                end
+            else
+                i = i + 1
+            end
+        end
+    end
+end)
+
+return M

--- a/ttymap-tui/runtime/lua/ttymap/director.lua
+++ b/ttymap-tui/runtime/lua/ttymap/director.lua
@@ -55,6 +55,14 @@ local anim = require "ttymap.animation"
 local M = {}
 local actives = {}
 
+-- Tolerances for "did the user touch the map during a wait"
+-- detection. Same values the animation lib uses for its own
+-- pre-emption check — loose enough to absorb the float round-trip
+-- through `geo::normalize` + Mercator clamps, tight enough that a
+-- single-cell keyboard pan trips them.
+local TOL_LL   = 0.0005
+local TOL_ZOOM = 0.001
+
 -- ── Handle / cancellation ───────────────────────────────────────
 local Handle = {}
 Handle.__index = Handle
@@ -112,6 +120,13 @@ local function step(rec)
         })
     elseif directive.kind == "wait" then
         rec.wait_left = directive.frames
+        -- Captured on the first wait tick (deferred). The just-
+        -- completed fly's on_done runs *inside* the animation
+        -- on_tick, which means drain_ops hasn't yet applied its
+        -- final FlyTo to MapState — reading `:center()` here would
+        -- snapshot the pre-fly value and the next tick would falsely
+        -- diverge. One-frame defer lets MapState settle.
+        rec.wait_check = nil
     elseif directive.kind == "tween" then
         rec.tween_elapsed = 0
     end
@@ -145,6 +160,11 @@ function M.wait(frames)
 end
 
 function M.tween(setter, frames)
+    -- Guard frames=0 (would divide-by-zero in the per-tick driver
+    -- at `tween_elapsed / d.frames`) and negatives. Clamp to 1 so
+    -- the setter still fires with a final value rather than
+    -- silently dropping the call.
+    if frames < 1 then frames = 1 end
     return coroutine.yield({
         kind   = "tween",
         setter = setter,
@@ -166,10 +186,34 @@ ttymap.api.frame.on_tick(function()
         else
             local d = rec.directive
             local advance = false
+            local cancelled_in_tick = false
             if d then
                 if d.kind == "wait" then
-                    rec.wait_left = rec.wait_left - 1
-                    if rec.wait_left <= 0 then advance = true end
+                    -- Detect manual user input during wait: any
+                    -- divergence between the captured map state and
+                    -- the live one means the user (or another
+                    -- caller) moved the camera; bail the script.
+                    -- First tick captures, subsequent ticks compare.
+                    if not rec.wait_check then
+                        local lon, lat = ttymap.map:center()
+                        rec.wait_check = {
+                            lon = lon, lat = lat,
+                            zoom = ttymap.map:zoom(),
+                        }
+                    else
+                        local lon, lat = ttymap.map:center()
+                        local zoom = ttymap.map:zoom()
+                        if math.abs(lon - rec.wait_check.lon) > TOL_LL
+                            or math.abs(lat - rec.wait_check.lat) > TOL_LL
+                            or math.abs(zoom - rec.wait_check.zoom) > TOL_ZOOM then
+                            cancel_rec(rec)
+                            cancelled_in_tick = true
+                        end
+                    end
+                    if not cancelled_in_tick then
+                        rec.wait_left = rec.wait_left - 1
+                        if rec.wait_left <= 0 then advance = true end
+                    end
                 elseif d.kind == "tween" then
                     rec.tween_elapsed = rec.tween_elapsed + 1
                     local t = math.min(rec.tween_elapsed / d.frames, 1)
@@ -183,7 +227,9 @@ ttymap.api.frame.on_tick(function()
                 end
                 -- "fly": waits on anim's on_done — no per-tick work.
             end
-            if advance then
+            if cancelled_in_tick or rec.dead then
+                table.remove(actives, i)
+            elseif advance then
                 rec.directive = nil
                 step(rec)
                 if rec.dead then

--- a/ttymap-tui/runtime/plugin/travel/init.lua
+++ b/ttymap-tui/runtime/plugin/travel/init.lua
@@ -10,16 +10,17 @@
 --      whole polyline + all markers so the geographic shape of the
 --      trip is visible at a glance. Enter starts the tour, Esc /
 --      Backspace returns to list.
---   3. **tour**: three sub-phases drive the camera. **pre** flies
---      to a bounding-box overview so the user sees the whole trip
---      laid out before plunging in (no jarring teleport-to-Tokyo);
---      **stop** loops through each `route.stops` entry, firing a
---      `ttymap.notify` per arrival; **post** returns to overview
---      for a final wrap-up beat. Manual pan / zoom (or palette
---      re-toggle) cancels at any phase. No polyline during tour
---      (Braille pixel-snapping ripples a static line as the camera
---      glides) — markers carry the journey on their own; future
---      stops show muted, current accent, past accent_alt.
+--   3. **tour**: the camera flies through three phases (pre overview
+--      → stop loop → post overview) driven by `ttymap.director` —
+--      the whole choreography is a single procedural Lua script.
+--      `state.tour.phase` is set inline as the script runs so the
+--      sidebar / on_tick paint can tell where we are. Manual pan /
+--      zoom (or palette re-toggle) cancels at any point via the
+--      animation lib's tolerance check → director.on_cancel.
+--      No polyline during fly motion (Braille pixel-snapping
+--      ripples a static line as the camera glides) — markers carry
+--      the journey on their own; the line surfaces only during
+--      the pre/post overview *dwells* where the camera is parked.
 --
 -- Activation: `:` palette → "Travel". Re-invoking always exits
 -- completely (cancels any tour, closes the panel).
@@ -27,7 +28,7 @@
 -- Adding a country: see `travel/routes/init.lua`.
 
 local sidebar   = require("ttymap.sidebar")
-local anim      = require("ttymap.animation")
+local director  = require("ttymap.director")
 local countries = require("travel.routes")
 
 -- Flatten the per-country tables into a single list of routes,
@@ -49,9 +50,7 @@ end
 -- on_tick doesn't surface dt). Tight 2-second beats keep momentum:
 -- long enough to read the notify popup and absorb the view, short
 -- enough that a 5-stop tour finishes in ~15s.
-local PRE_DWELL_FRAMES  = 120   -- ~2s overview before the journey starts
-local DWELL_FRAMES      = 120   -- ~2s parked at each stop
-local POST_DWELL_FRAMES = 120   -- ~2s overview after final stop
+local DWELL_FRAMES = 120
 
 -- Compute a (centre, zoom) that fits all stops with margin. Logarithmic
 -- zoom heuristic: span doubles → zoom drops by 1. Clamped to a sensible
@@ -69,11 +68,6 @@ local function overview_view(route)
     local center_lon = (min_lon + max_lon) / 2
     local center_lat = (min_lat + max_lat) / 2
     local span = math.max(max_lon - min_lon, max_lat - min_lat, 0.1)
-    -- 8.5 - log2(span) clamped to [3, 11]:
-    --   span ≥ 11°  → zoom 5    (continent / large country)
-    --   span ≈  3°  → zoom 7    (Italian classic, Snow Monkey + Alps)
-    --   span ≈  1°  → zoom 8-9  (Hokkaido, Sicily)
-    --   span ≈ 0.5° → zoom 9-10 (Amalfi)
     local zoom = math.floor(8.5 - math.log(span) / math.log(2))
     if zoom < 3 then zoom = 3 elseif zoom > 11 then zoom = 11 end
     return center_lon, center_lat, zoom
@@ -83,9 +77,8 @@ local state = {
     selected = 1,    -- 1-based index into routes (list mode)
     w        = nil,  -- sidebar card handle while open
     detail   = nil,  -- nil = list mode; a route table = detail mode
-    tour     = nil,  -- nil when not playing; else a tour table
-    --                  { route, phase = "pre"|"stop"|"post",
-    --                    stop_idx, dwell_left }
+    tour     = nil,  -- nil when not playing; else { route, phase, stop_idx }
+    handle   = nil,  -- director handle for the active tour
 }
 
 local function close_panel()
@@ -95,95 +88,61 @@ local function close_panel()
     end
 end
 
-local advance_tour  -- forward decl
+local function start_tour(route)
+    local lon, lat, z = overview_view(route)
+    state.tour = { route = route, phase = "pre_fly", stop_idx = 0 }
+    state.handle = director.run(function()
+        ttymap.notify(string.format("Starting: %s · %s",
+            route.country, route.name))
+        director.fly(lon, lat, z)
 
-local function finish_tour(message)
-    state.tour = nil
-    if message then
-        ttymap.notify(message)
-    end
-end
+        state.tour.phase = "pre_dwell"
+        director.wait(DWELL_FRAMES)
 
--- Generic on_cancel handler — every fly_to in the state machine bails
--- the whole tour the same way.
-local function on_cancel_bail()
-    finish_tour("Tour cancelled")
-end
+        for i, stop in ipairs(route.stops) do
+            state.tour.phase = "stop_fly"
+            state.tour.stop_idx = i
+            director.fly(stop.lon, stop.lat, stop.zoom)
 
--- Schedule a fly_to whose `on_done` parks the camera for `dwell_frames`
--- before the next state-machine transition.
-local function fly_then_dwell(lon, lat, zoom, dwell_frames)
-    anim.fly_to(lon, lat, zoom, {
-        on_done = function()
-            if state.tour then
-                state.tour.dwell_left = dwell_frames
-            end
+            state.tour.phase = "stop_dwell"
+            ttymap.notify(stop.note)
+            director.wait(DWELL_FRAMES)
+        end
+
+        state.tour.phase = "post_fly"
+        ttymap.notify(string.format("Tour complete: %s · %s",
+            route.country, route.name))
+        director.fly(lon, lat, z)
+
+        state.tour.phase = "post_dwell"
+        director.wait(DWELL_FRAMES)
+
+        state.tour   = nil
+        state.handle = nil
+    end, {
+        on_cancel = function()
+            state.tour   = nil
+            state.handle = nil
+            ttymap.notify("Tour cancelled")
         end,
-        on_cancel = on_cancel_bail,
     })
 end
 
-advance_tour = function()
-    local t = state.tour
-    if not t then return end
-
-    if t.phase == "pre" then
-        -- Pre-overview done. Enter stop loop at index 1.
-        t.phase = "stop"
-        t.stop_idx = 1
-        local stop = t.route.stops[1]
-        if not stop then
-            finish_tour("Tour: empty route")
-            return
-        end
-        ttymap.notify(stop.note)
-        fly_then_dwell(stop.lon, stop.lat, stop.zoom, DWELL_FRAMES)
-        return
+local function cancel_tour_silent()
+    if state.handle then
+        state.handle:cancel({ silent = true })
+        state.handle = nil
     end
-
-    if t.phase == "stop" then
-        t.stop_idx = t.stop_idx + 1
-        local stop = t.route.stops[t.stop_idx]
-        if stop then
-            ttymap.notify(stop.note)
-            fly_then_dwell(stop.lon, stop.lat, stop.zoom, DWELL_FRAMES)
-            return
-        end
-        -- All stops visited. Enter post-overview wrap-up.
-        t.phase = "post"
-        ttymap.notify(string.format("Tour complete: %s · %s",
-            t.route.country, t.route.name))
-        local lon, lat, z = overview_view(t.route)
-        fly_then_dwell(lon, lat, z, POST_DWELL_FRAMES)
-        return
-    end
-
-    -- Post-overview dwell expired — tour is done.
-    finish_tour(nil)
-end
-
-local function start_tour(route)
-    state.tour = {
-        route      = route,
-        phase      = "pre",
-        stop_idx   = 0,
-        dwell_left = 0,
-    }
-    ttymap.notify(string.format("Starting: %s · %s",
-        route.country, route.name))
-    local lon, lat, z = overview_view(route)
-    fly_then_dwell(lon, lat, z, PRE_DWELL_FRAMES)
+    state.tour = nil
 end
 
 -- Per-frame map paint. Three cases, in priority order:
 --
 --   * **tour active**: paint markers for every stop, coloured by
 --     phase + position (current accent, past accent_alt, future
---     muted). Future stops let the user see what's coming. No
---     polyline (Braille pixel-snapping ripples a static line as
---     the camera glides). Tour state advances via `advance_tour`
---     from the dwell countdown here and from the `on_done` callback
---     in `fly_then_dwell`.
+--     muted). The polyline surfaces only during pre/post overview
+--     dwells (camera parked = stable line). Phase is set inline by
+--     the director script in `start_tour`.
 --   * **detail mode**: no tour, but a route is selected — paint the
 --     whole polyline + all markers as a preview. Camera is static
 --     here (the user hasn't started flying), so the line is stable.
@@ -192,16 +151,10 @@ ttymap.api.frame.on_tick(function(map)
     local t = state.tour
     if t then
         local route = t.route
-        local current_idx = (t.phase == "stop") and t.stop_idx or 0
+        local current_idx = (t.phase == "stop_fly" or t.phase == "stop_dwell")
+            and t.stop_idx or 0
 
-        -- Route polyline: visible only during the pre/post overview
-        -- *dwells* (camera parked at the bbox view = stable line).
-        -- The pre dwell is the "here is the whole journey" moment
-        -- before the stop-by-stop flight; the post dwell mirrors it
-        -- as a wrap-up. Hidden during all camera motion (pre fly,
-        -- stop fly, post fly) because Braille pixel-snapping ripples
-        -- a static line as the camera glides.
-        if (t.phase == "pre" or t.phase == "post") and t.dwell_left > 0 then
+        if t.phase == "pre_dwell" or t.phase == "post_dwell" then
             local coords = {}
             for _, s in ipairs(route.stops) do
                 table.insert(coords, { s.lon, s.lat })
@@ -213,19 +166,14 @@ ttymap.api.frame.on_tick(function(map)
             local color
             if i == current_idx then
                 color = "accent"
-            elseif t.phase == "post" or i < current_idx then
+            elseif t.phase == "post_fly" or t.phase == "post_dwell"
+                or i < current_idx then
                 color = "accent_alt"
             else
                 color = "muted"
             end
             map:point(s.lon, s.lat, "●", color)
             map:label(s.lon, s.lat, s.name, color)
-        end
-        if t.dwell_left > 0 then
-            t.dwell_left = t.dwell_left - 1
-            if t.dwell_left == 0 then
-                advance_tour()
-            end
         end
         return
     end
@@ -244,6 +192,17 @@ ttymap.api.frame.on_tick(function(map)
 end)
 
 -- ── Detail-mode rendering ─────────────────────────────────────────
+local function phase_label_for(tour)
+    local p = tour.phase
+    if p == "pre_fly" or p == "pre_dwell" then
+        return "Overview — orienting…"
+    elseif p == "post_fly" or p == "post_dwell" then
+        return "Wrap-up — overview…"
+    else
+        return "Tour playing — pan / zoom to cancel."
+    end
+end
+
 local function render_detail(route)
     local lines = {
         { { text = route.country, style = "muted" },
@@ -259,7 +218,8 @@ local function render_detail(route)
     -- overview phases don't single out a row — they're whole-route
     -- moments.
     local current_idx = 0
-    if state.tour and state.tour.route == route and state.tour.phase == "stop" then
+    if state.tour and state.tour.route == route
+        and (state.tour.phase == "stop_fly" or state.tour.phase == "stop_dwell") then
         current_idx = state.tour.stop_idx
     end
     for i, s in ipairs(route.stops) do
@@ -267,7 +227,8 @@ local function render_detail(route)
         if i == current_idx then
             marker, name_style = "▶ ", "accent"
         elseif state.tour and state.tour.route == route
-            and (state.tour.phase == "post" or i < current_idx) then
+            and (state.tour.phase == "post_fly" or state.tour.phase == "post_dwell"
+                 or i < current_idx) then
             marker, name_style = "✓ ", "accent_alt"
         else
             marker, name_style = "  ", "accent_alt"
@@ -282,15 +243,7 @@ local function render_detail(route)
     end
     table.insert(lines, { { text = "" } })
     if state.tour and state.tour.route == route then
-        local phase_label
-        if state.tour.phase == "pre" then
-            phase_label = "Overview — orienting…"
-        elseif state.tour.phase == "post" then
-            phase_label = "Wrap-up — overview…"
-        else
-            phase_label = "Tour playing — pan / zoom to cancel."
-        end
-        table.insert(lines, { { text = phase_label, style = "muted" } })
+        table.insert(lines, { { text = phase_label_for(state.tour), style = "muted" } })
     else
         table.insert(lines, { { text = "Enter: play tour",          style = "muted" } })
         table.insert(lines, { { text = "q / Esc / Backspace: back", style = "muted" } })
@@ -344,12 +297,13 @@ local function open_panel()
         handle_key = function(key)
             -- Tour active: any cancellation key drops back to detail
             -- mode. Manual pan / zoom is handled by the animation
-            -- lib (its tolerance check fires on_cancel which clears
-            -- state.tour); we only catch keys that don't reach the
-            -- map (Esc, etc.).
+            -- lib (its tolerance check fires director.on_cancel
+            -- which clears state.tour); we only catch keys that
+            -- don't reach the map (Esc, etc.).
             if state.tour then
                 if sidebar.is_close_key(key) or key.code == "Backspace" then
-                    finish_tour("Tour cancelled")
+                    cancel_tour_silent()
+                    ttymap.notify("Tour cancelled")
                     return nil
                 end
                 return { ignore = true }
@@ -395,9 +349,7 @@ local function toggle()
     -- cancel any tour, drop detail, close panel. One keypress to
     -- dismiss everything regardless of which sub-state we're in.
     if state.tour or state.detail or state.w then
-        if state.tour then
-            finish_tour(nil)
-        end
+        cancel_tour_silent()
         state.detail = nil
         close_panel()
         return


### PR DESCRIPTION
## Summary

A `require`-only Lua library that lets plugins write async choreography as procedural code. Wraps `ttymap.animation.fly_to` and a frame timer behind three yielding primitives, driven by a single `on_tick` subscription.

The travel plugin is the first user — `advance_tour` (a 30-line phase state machine) + `fly_then_dwell` helper + `on_cancel_bail` collapse to one procedural `director.run(function() ... end)` block.

## API

```lua
local director = require \"ttymap.director\"

director.run(function()
    ttymap.notify(\"Starting tour\")
    director.fly(139.69, 35.69, 10)         -- yields until arrival
    director.wait(120)                        -- yields 120 frames
    for _, stop in ipairs(stops) do
        director.fly(stop.lon, stop.lat, stop.zoom)
        ttymap.notify(stop.note)
        director.wait(120)
    end
end, {
    on_cancel = function() ttymap.notify(\"Cancelled\") end,
})
```

Primitives:

| Function                                       | Behavior                                                                          |
| ---------------------------------------------- | --------------------------------------------------------------------------------- |
| `director.fly(lon, lat, zoom, opts?)`          | Yields until the camera arrives. Uses `ttymap.animation.fly_to` internally.       |
| `director.wait(frames)`                        | Yields N frames.                                                                  |
| `director.tween(setter, frames)`               | Yields, calls `setter(t in [0,1])` every frame for `frames` frames. General-purpose tween for any Lua value (marker scale, opacity, anything). |
| `director.run(fn, opts?)` → `handle`           | Registers a script. Multiple calls run in parallel.                               |
| `handle:cancel({ silent = true }?)`            | Cancels one script. `silent` skips `on_cancel`.                                   |
| `director.cancel_all()`                        | Cancels every active script.                                                      |

## Cancellation semantics

- **Manual user input** during a `director.fly`: the animation lib's tolerance check fires its own `on_cancel`, which propagates to the script's `on_cancel`. The pre-emption is observable.
- **Explicit `handle:cancel()`**: fires `on_cancel`. Pass `{ silent = true }` when the caller is the explicit canceller and doesn't want a duplicate signal (e.g. a UI \"stop tour\" action that already shows its own toast).
- **Natural completion** (the function returns) does **not** fire `on_cancel`. It's reserved for \"interrupted before finishing\".

## Travel plugin migration

Before — a hand-written state machine with `advance_tour`, `fly_then_dwell`, and a `on_cancel_bail` helper, plus a `dwell_left` countdown threaded through the per-tick driver. The `phase` enum had three coarse values (`pre`, `stop`, `post`) that hid the fly-vs-dwell distinction.

After — one procedural script, six fine-grained phase strings (`pre_fly`, `pre_dwell`, `stop_fly`, `stop_dwell`, `post_fly`, `post_dwell`) set inline as the script runs:

```lua
state.handle = director.run(function()
    ttymap.notify(\"Starting: \" .. route.country .. \" · \" .. route.name)
    director.fly(lon, lat, z)

    state.tour.phase = \"pre_dwell\"
    director.wait(DWELL_FRAMES)

    for i, stop in ipairs(route.stops) do
        state.tour.phase = \"stop_fly\"
        state.tour.stop_idx = i
        director.fly(stop.lon, stop.lat, stop.zoom)

        state.tour.phase = \"stop_dwell\"
        ttymap.notify(stop.note)
        director.wait(DWELL_FRAMES)
    end

    state.tour.phase = \"post_fly\"
    ttymap.notify(\"Tour complete: ...\")
    director.fly(lon, lat, z)

    state.tour.phase = \"post_dwell\"
    director.wait(DWELL_FRAMES)

    state.tour, state.handle = nil, nil
end, { on_cancel = function() state.tour, state.handle = nil, nil; ttymap.notify(\"Tour cancelled\") end })
```

The on_tick paint logic gets simpler too — it just reads the phase string (\"polyline visible during pre_dwell / post_dwell, current stop accent during stop_*\") instead of decrementing dwell timers and dispatching transitions.

## Why now

This is the kernel of the \"scriptable scenes\" / game-engine-ish direction discussed in the previous travel-plugin thread. A future demo plugin's auto-pan tour, a `ping_simulation` rewrite, anything with timeline + concurrency can lean on this primitive instead of hand-rolling another state machine.

## Docs

- `docs/lua-architecture.md` gets a new **Shared libraries** table covering `ttymap.fmt` / `.sidebar` / `.animation` / `.director` (previously only `.fmt` was mentioned in passing).
- Bundled plugin count bumped 14 → 15 with `travel/` added to the listing (was missed in the previous travel PR).

## Test plan

- [x] `:` palette → `Travel` works exactly as before — list / detail / tour transitions, pre overview dwell with line, stop loop with notify popups, post overview dwell, panel-stays-open-during-tour with `▶`/`✓` progress
- [x] Manual `h`/`j`/`k`/`l` pan during any phase cancels via `on_cancel` (`Tour cancelled` toast)
- [x] `:` palette → `Travel` re-toggle exits silently (no duplicate `Tour cancelled` toast)
- [x] `Esc`/`Backspace` from tour shows `Tour cancelled` once and returns to detail
- [x] All 180 tests pass; clippy clean; fmt clean (verified via pre-commit hook)