### PR TITLE
fix(overlay): clearing redraw when sink goes empty (#259)

### DIFF
--- a/ttymap-tui/src/app/overlay.rs
+++ b/ttymap-tui/src/app/overlay.rs
@@ -9,6 +9,16 @@
 //! keeping animation visually smooth. User-event-driven redraws
 //! (pan, zoom, resize, theme change) bypass the throttle and fire
 //! immediately through `App::request_map_redraw`.
+//!
+//! When a plugin stops pushing overlays (e.g. user toggles
+//! `ping_simulation` off), the sink goes empty but the previously-
+//! rendered MapFrame still has the lines baked in — the render
+//! thread won't repaint until something invalidates the frame. We
+//! catch this with a `had_overlays` flag: on the empty-sink tick
+//! immediately after a non-empty one, we trigger one final
+//! "clearing" redraw (with empty overlays) so the stale ghosts
+//! disappear. Without this, ghosts persist until the next pan /
+//! zoom forces a redraw — the [#259] symptom.
 
 use std::time::{Duration, Instant};
 
@@ -18,6 +28,10 @@ pub(super) struct OverlayThrottle {
     sink: Vec<UserPolyline>,
     last_redraw: Instant,
     interval: Duration,
+    /// True when the most recent `should_redraw → true` cycle drained
+    /// non-empty overlays. Cleared by the empty-sink "clearing"
+    /// redraw so the transition only fires once per cycle.
+    had_overlays: bool,
 }
 
 impl OverlayThrottle {
@@ -26,6 +40,7 @@ impl OverlayThrottle {
             sink: Vec::new(),
             last_redraw: Instant::now(),
             interval,
+            had_overlays: false,
         }
     }
 
@@ -42,19 +57,101 @@ impl OverlayThrottle {
         std::mem::take(&mut self.sink)
     }
 
-    /// Returns `true` when the sink is non-empty AND the throttle
-    /// interval has elapsed since the last overlay-driven redraw.
-    /// On a `true` return, the throttle's `last_redraw` is advanced
-    /// — callers don't have to track it.
+    /// Returns `true` when:
+    ///   * the sink is non-empty AND the throttle interval has
+    ///     elapsed since the last overlay-driven redraw — the
+    ///     normal animation path; OR
+    ///   * the sink is empty BUT the previous redraw cycle had
+    ///     overlays — the one-shot "clearing" redraw that wipes
+    ///     stale ghosts left by a plugin that stopped pushing.
+    ///
+    /// On a `true` return, internal state advances so subsequent
+    /// idle frames return `false` until a new push or transition.
     pub(super) fn should_redraw(&mut self) -> bool {
         if self.sink.is_empty() {
+            // Just transitioned from "had overlays" to "now empty"
+            // — fire one clearing redraw so the render thread
+            // produces a MapFrame without the stale overlay layer.
+            if self.had_overlays {
+                self.had_overlays = false;
+                return true;
+            }
             return false;
         }
         let now = Instant::now();
         if now.duration_since(self.last_redraw) >= self.interval {
             self.last_redraw = now;
+            self.had_overlays = true;
             return true;
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn poly() -> UserPolyline {
+        UserPolyline {
+            coords: vec![],
+            color: 0,
+        }
+    }
+
+    #[test]
+    fn empty_sink_no_history_returns_false() {
+        let mut throttle = OverlayThrottle::new(Duration::ZERO);
+        assert!(!throttle.should_redraw());
+    }
+
+    #[test]
+    fn non_empty_sink_with_zero_interval_redraws() {
+        let mut throttle = OverlayThrottle::new(Duration::ZERO);
+        throttle.sink_mut().push(poly());
+        assert!(throttle.should_redraw());
+    }
+
+    #[test]
+    fn empty_sink_after_non_empty_fires_one_clearing_redraw() {
+        // Reproduces #259: a plugin pushes an overlay, then stops.
+        // The empty tick immediately after must trigger a redraw so
+        // the render thread clears the stale overlay layer.
+        let mut throttle = OverlayThrottle::new(Duration::ZERO);
+        throttle.sink_mut().push(poly());
+        assert!(throttle.should_redraw(), "non-empty + interval elapsed");
+        throttle.drain();
+
+        // Empty sink (plugin stopped pushing) — still need one
+        // redraw to clear what we just sent.
+        assert!(throttle.should_redraw(), "first empty tick after overlays");
+
+        // Subsequent empty ticks must NOT keep firing — that's a
+        // wasteful idle-redraw loop.
+        assert!(
+            !throttle.should_redraw(),
+            "second empty tick must not redraw"
+        );
+        assert!(
+            !throttle.should_redraw(),
+            "third empty tick must not redraw"
+        );
+    }
+
+    #[test]
+    fn interval_throttles_back_to_back_pushes() {
+        // Zero interval lets the first push fire, then we extend
+        // the throttle so the second push has to wait. Models the
+        // steady-state animation case.
+        let mut throttle = OverlayThrottle::new(Duration::ZERO);
+        throttle.sink_mut().push(poly());
+        assert!(throttle.should_redraw(), "first push always wins");
+        throttle.drain();
+
+        // Pretend we just installed a long interval.
+        throttle.interval = Duration::from_secs(60);
+
+        throttle.sink_mut().push(poly());
+        assert!(!throttle.should_redraw(), "second push within interval");
     }
 }


### PR DESCRIPTION
Fixes #259.

## Symptom

Toggle a polyline-pushing plugin (`ping_simulation`, the travel
plugin's tour, ...) off → the last drawn lines stay on screen. A
pan or zoom forces a redraw and they vanish.

## Cause

\`map:polyline\` enqueues into the overlay sink, drained every
\`runtime.overlay_redraw_ms\` into a \`RenderTask::Draw\` so the
render thread bakes the line into the next \`MapFrame\`. When the
plugin stops pushing the sink goes empty, but \`should_redraw\`
returned \`false\` for an empty sink — so no \`Draw\` fired, and
the cached \`MapFrame\` still had the lines burned in.

## Fix

\`OverlayThrottle\` now tracks \`had_overlays\`. The first empty
tick after a non-empty drain returns \`true\` once — a one-shot
\"clearing\" redraw with an empty overlay batch. The render thread
regenerates the \`MapFrame\` without the stale layer, and the
ghosts disappear.

Subsequent idle ticks (sink empty, \`had_overlays\` already cleared)
return \`false\`. No idle-redraw loop on plugins that genuinely
have nothing to paint.

## Tests

Four new unit tests in \`app::overlay::tests\` covering:
- empty sink + no history → false
- non-empty + zero interval → true
- empty after non-empty → exactly one redraw, then idle (the
  regression test for #259)
- back-to-back pushes within interval → throttled

## Test plan

- [ ] \`:\` → \"Toggle ping simulation\" → toggle off → ghosts disappear within one frame (no pan needed)
- [ ] \`:\` → \"Travel\" → run a tour → pan to cancel mid-fly → no leftover line/markers stuck on screen
- [ ] \`:\` → \"Toggle ping simulation\" off, then no further interaction → CPU stays quiet (no redraw loop)