### PR TITLE
fix(sidebar): word-wrap long lines in render-paragraph + list-mode (#260)

### DIFF
--- a/ttymap-tui/src/lua/bridge/card_component.rs
+++ b/ttymap-tui/src/lua/bridge/card_component.rs
@@ -722,8 +722,8 @@ mod tests {
             .iter()
             .flat_map(|row| row.iter().map(|(_, k)| *k))
             .collect();
-        assert!(kinds_present.iter().any(|k| *k == StyleKind::Muted));
-        assert!(kinds_present.iter().any(|k| *k == StyleKind::Accent));
+        assert!(kinds_present.contains(&StyleKind::Muted));
+        assert!(kinds_present.contains(&StyleKind::Accent));
     }
 
     #[test]

--- a/ttymap-tui/src/lua/bridge/card_component.rs
+++ b/ttymap-tui/src/lua/bridge/card_component.rs
@@ -44,7 +44,7 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mlua::{Lua, Table};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph, Wrap};
 
 use super::card_parse::{
     KeyAction, key_code_to_lua, parse_footer_hints, parse_item_value, parse_line_value,
@@ -267,7 +267,21 @@ impl LuaCardComponent {
         }
         self.scroll_offset.set(offset);
 
-        let paragraph = Paragraph::new(lines).style(body).scroll((offset, 0));
+        // Wrap long lines at the inner width instead of truncating —
+        // travel-plugin stop notes, wiki article bodies, etc. routinely
+        // exceed the sidebar's column count. `trim: false` preserves
+        // intentional leading whitespace (e.g. "  ▶ 1. Tokyo" becomes
+        // "  Tokyo — neon nights ..." indentation on overflow rows).
+        // Caveat: with wrap on, the scrollbar's "total" count
+        // undercounts because we feed it input-line count, not the
+        // post-wrap render count. ratatui's Paragraph doesn't expose
+        // the latter; the scrollbar position is still directionally
+        // right (offset increases toward the bottom), just slightly
+        // off in scale. Acceptable for sidebar use.
+        let paragraph = Paragraph::new(lines)
+            .style(body)
+            .scroll((offset, 0))
+            .wrap(Wrap { trim: false });
         win.paragraph(paragraph, inner);
         win.scrollbar(outer, total_lines, offset, inner.height);
     }

--- a/ttymap-tui/src/lua/bridge/card_component.rs
+++ b/ttymap-tui/src/lua/bridge/card_component.rs
@@ -45,6 +45,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mlua::{Lua, Table};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem, ListState, Paragraph, Wrap};
+use unicode_width::UnicodeWidthStr;
 
 use super::card_parse::{
     KeyAction, key_code_to_lua, parse_footer_hints, parse_item_value, parse_line_value,
@@ -304,17 +305,29 @@ impl LuaCardComponent {
         // Materialise items as ratatui ListItems. Each item is a
         // `Vec<Line>` (1+ lines) so a quake-style "M5.7 Tokyo /
         // 2h ago" lands as a 2-line ListItem.
+        //
+        // Each input line is run through `wrap_styled_line` first
+        // so long content (travel-plugin route summaries, wiki
+        // article titles, …) wraps at the inner width instead of
+        // truncating at the right edge. ratatui's `List` natively
+        // supports multi-line items, so a single Lua-side line that
+        // wraps to two display rows just makes the ListItem two
+        // rows tall. Selection still picks the whole logical item.
         let list_items: Vec<ListItem<'static>> = raw_items
             .iter()
             .map(|item_lines| {
                 let lines: Vec<Line<'static>> = item_lines
                     .iter()
-                    .map(|spans| {
-                        let rendered: Vec<Span<'static>> = spans
-                            .iter()
-                            .map(|(text, kind)| Span::styled(text.clone(), win.style(*kind)))
-                            .collect();
-                        Line::from(rendered)
+                    .flat_map(|spans| {
+                        wrap_styled_line(spans, inner.width)
+                            .into_iter()
+                            .map(|wrapped_spans| {
+                                let rendered: Vec<Span<'static>> = wrapped_spans
+                                    .into_iter()
+                                    .map(|(text, kind)| Span::styled(text, win.style(kind)))
+                                    .collect();
+                                Line::from(rendered)
+                            })
                     })
                     .collect();
                 ListItem::new(lines)
@@ -460,9 +473,68 @@ impl Component for LuaCardComponent {
 
 // ── Helpers ────────────────────────────────────────────────────────
 
-/// Read `spec.footer_hints` as a sequence of `{key, label}` pairs and
-/// leak each pair so [`Component::footer_hints`] can hand back
-/// `&'static str`. Bounded leak — a window declares a finite list at
+/// Word-wrap a single styled line so it fits inside `max_width`
+/// terminal cells, returning one or more output rows. Each row is
+/// itself a list of styled spans — the wrap walks word by word and
+/// merges adjacent same-style runs back together so multi-style
+/// lines (e.g. "Japan · Golden Route   10-14 days") preserve their
+/// per-segment colours across the break.
+///
+/// Whitespace boundaries drive the break (`split_inclusive` keeps
+/// the trailing space on each word so the right edge doesn't end on
+/// a leftover blank). Words wider than `max_width` themselves stay
+/// intact on a single row — better mid-overflow than mid-word splits
+/// that destroy CJK characters or compound words. ratatui will
+/// truncate the overflow at the cell boundary.
+///
+/// Fast path: when the line already fits, returns `[input.to_vec()]`
+/// without copying spans.
+fn wrap_styled_line(
+    spans: &[(String, StyleKind)],
+    max_width: u16,
+) -> Vec<Vec<(String, StyleKind)>> {
+    if max_width == 0 {
+        return vec![spans.to_vec()];
+    }
+    let max_w = max_width as usize;
+    let total: usize = spans.iter().map(|(s, _)| s.as_str().width()).sum();
+    if total <= max_w {
+        return vec![spans.to_vec()];
+    }
+
+    let mut out: Vec<Vec<(String, StyleKind)>> = vec![Vec::new()];
+    let mut row_width = 0usize;
+
+    for (text, style) in spans {
+        for word in text.split_inclusive(char::is_whitespace) {
+            let w = word.width();
+            // If the word doesn't fit on the current row AND the row
+            // already has content, start a new row. Empty rows accept
+            // any word — including ones wider than `max_w` — so we
+            // never loop forever on an oversized token.
+            if row_width + w > max_w && row_width > 0 {
+                out.push(Vec::new());
+                row_width = 0;
+            }
+            let row = out.last_mut().expect("at least one row by construction");
+            // Merge into the last span if same style — keeps the
+            // output as compact as the input intended.
+            if let Some(last) = row.last_mut() {
+                if last.1 == *style {
+                    last.0.push_str(word);
+                } else {
+                    row.push((word.to_string(), *style));
+                }
+            } else {
+                row.push((word.to_string(), *style));
+            }
+            row_width += w;
+        }
+    }
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -604,4 +676,85 @@ mod tests {
     // Close coverage moved to `card_handle::tests::close_enqueues_op_close_idempotent`:
     // the close path no longer goes through Component::poll, so the
     // CloseFlag polling tests retire with the flag itself.
+
+    // ── wrap_styled_line ─────────────────────────────────────────
+
+    fn span(text: &str, kind: StyleKind) -> (String, StyleKind) {
+        (text.to_string(), kind)
+    }
+
+    #[test]
+    fn wrap_styled_line_passes_through_when_input_fits() {
+        let line = vec![span("short", StyleKind::Body)];
+        let out = wrap_styled_line(&line, 80);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0], line);
+    }
+
+    #[test]
+    fn wrap_styled_line_breaks_at_word_boundary() {
+        // "alpha beta gamma" = "alpha "(6) + "beta "(5) + "gamma"(5)
+        // = 16 cells. With max=10:
+        //   row 1: "alpha "  (6, next "beta " would push to 11 > 10)
+        //   row 2: "beta gamma"  (10, ≤ 10)
+        let line = vec![span("alpha beta gamma", StyleKind::Body)];
+        let out = wrap_styled_line(&line, 10);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0][0].0, "alpha ");
+        assert_eq!(out[1][0].0, "beta gamma");
+    }
+
+    #[test]
+    fn wrap_styled_line_preserves_per_segment_styles_across_break() {
+        // "Japan · " (muted) "Golden Route" (accent) "  " (body)
+        // "10-14 days" (muted). Total ≈ 32 cells; with max=20 we
+        // expect a break between "Route" and "10-14".
+        let line = vec![
+            span("Japan ", StyleKind::Muted),
+            span("Route ", StyleKind::Accent),
+            span("days", StyleKind::Muted),
+        ];
+        let out = wrap_styled_line(&line, 11);
+        assert!(out.len() >= 2, "should wrap into at least 2 rows");
+        // Each output span must carry its original style — no style
+        // collapse to a single colour.
+        let kinds_present: Vec<StyleKind> = out
+            .iter()
+            .flat_map(|row| row.iter().map(|(_, k)| *k))
+            .collect();
+        assert!(kinds_present.iter().any(|k| *k == StyleKind::Muted));
+        assert!(kinds_present.iter().any(|k| *k == StyleKind::Accent));
+    }
+
+    #[test]
+    fn wrap_styled_line_keeps_oversized_word_on_one_row() {
+        // "supercalifragilisticexpialidocious" = 34 cells; max 10
+        // can't break it (no internal spaces) so it stays whole and
+        // overflows. Better than mid-word splitting which would
+        // break CJK / acronyms.
+        let line = vec![span("supercalifragilisticexpialidocious", StyleKind::Body)];
+        let out = wrap_styled_line(&line, 10);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0][0].0, "supercalifragilisticexpialidocious");
+    }
+
+    #[test]
+    fn wrap_styled_line_merges_adjacent_same_style_spans_within_wrapped_row() {
+        // After wrapping, adjacent same-style words should land
+        // back as one span in each output row (compactness — and
+        // it lets ratatui draw them with one styled write).
+        let line = vec![
+            span("alpha ", StyleKind::Body),
+            span("beta ", StyleKind::Body),
+            span("gamma ", StyleKind::Body),
+            span("delta", StyleKind::Body),
+        ];
+        let out = wrap_styled_line(&line, 12);
+        // Whatever the row layout, each row should be exactly one
+        // span (since every input span is the same style).
+        for (i, row) in out.iter().enumerate() {
+            assert_eq!(row.len(), 1, "row {i} should be one merged span");
+        }
+        assert!(out.len() >= 2, "should wrap into multiple rows");
+    }
 }


### PR DESCRIPTION
Fixes #260.

## Symptom

Sidebar content longer than the column count was silently truncated at the right edge — across both rendering paths:

- **Paragraph cards** (`render = function() return lines end`): wiki article extracts, help paragraphs, travel-plugin **detail** stop notes ("Tokyo — neon nights, ramen mornings, ancient shrines").
- **List-mode cards** (`items = function() return rows end`): travel-plugin **list view** route summaries ("Mountain heritage — bathing macaques, gassho farmhouses"), wiki article titles, satellite / aircraft / quake row entries.

Two commits, two paths.

## Commit 1 — Paragraph wrap

Enable ratatui's \`Wrap { trim: false }\` on the Paragraph that backs every \`render = function() return lines end\` card spec. Lines now break at word boundaries and continue on the next row; intentional leading whitespace is preserved (so \`\"  ▶ 1. Tokyo\"\` keeps its indentation when the trailing detail line wraps).

Caveat: with wrap enabled, the scrollbar's \"total\" undercounts because we feed it input-line count, not post-wrap render count. ratatui's \`Paragraph\` doesn't expose the latter; the scrollbar position is still directionally right (offset increases toward the bottom), just slightly off in scale.

## Commit 2 — List-mode wrap

ratatui's \`List\` doesn't auto-wrap row content — \`ListItem\` rows render verbatim. So commit 1 left every \`items()\`-driven plugin still truncating.

Add a \`wrap_styled_line\` helper that breaks a styled line at whitespace boundaries while preserving per-segment styles across the wrap. Multi-style inputs like \"Japan · Golden Route\" stay coloured in their original segments after wrapping; adjacent same-style runs are merged back together so the output stays compact. Words wider than \`max_width\` themselves remain intact on a single row (no mid-word splits — protects CJK characters and acronyms).

Apply it in \`render_list\` per input line. Each input row that wraps becomes a multi-line \`ListItem\`; ratatui's \`List\` supports that natively (quake's two-line entries already exercise the path), so selection still picks the whole logical item.

## Out of scope

**Adaptive sidebar width** (sizing the rail to a fraction of terminal cols) is not in this PR. With wrap on, fixed-width content is now readable; whether to also stretch the sidebar on wide terminals is a separate UX call.

## Tests

5 new unit tests in \`card_component::tests\` covering \`wrap_styled_line\`:
- pass-through when input fits
- word-boundary break with span coverage
- per-segment styles preserved across wrap
- oversized single word stays whole on one row
- adjacent same-style spans merge inside each wrapped row

## Test plan

- [ ] \`:\` → \"Travel\" → list view shows full route summaries (no truncation, wraps onto a second row per item)
- [ ] \`:\` → \"Travel\" → Enter on a route → detail panel shows full stop notes wrapped instead of truncated
- [ ] \`:\` → \"Wiki\" → article extracts wrap at the sidebar edge
- [ ] Help panel content (\`?\`) renders cleanly with multi-line entries
- [ ] List-mode plugins (quake, aircraft, satellite) — long place names wrap; selection still tracks the right logical row