### PR TITLE
fix(director): skip first wait tick to let drain_ops settle

### DIFF
--- a/ttymap-tui/runtime/lua/ttymap/director.lua
+++ b/ttymap-tui/runtime/lua/ttymap/director.lua
@@ -120,13 +120,19 @@ local function step(rec)
         })
     elseif directive.kind == "wait" then
         rec.wait_left = directive.frames
-        -- Captured on the first wait tick (deferred). The just-
-        -- completed fly's on_done runs *inside* the animation
-        -- on_tick, which means drain_ops hasn't yet applied its
-        -- final FlyTo to MapState — reading `:center()` here would
-        -- snapshot the pre-fly value and the next tick would falsely
-        -- diverge. One-frame defer lets MapState settle.
         rec.wait_check = nil
+        -- Skip one driver tick before capturing the baseline. step()
+        -- is reachable from inside the *previous* directive's
+        -- callback — most importantly anim's `on_done`, which fires
+        -- during anim's own on_tick, *before* drain_ops applies the
+        -- final FlyTo to MapState. The director's on_tick runs
+        -- right after anim's (same `lua.tick()` pass) and would
+        -- otherwise capture `:center()` at the pre-fly position —
+        -- next tick reads post-fly and false-cancels the script
+        -- the moment the tour starts. Skipping one full driver tick
+        -- lets the App finish its drain_ops between iterations and
+        -- the second wait tick gets a clean post-settle baseline.
+        rec.wait_settle_left = 1
     elseif directive.kind == "tween" then
         rec.tween_elapsed = 0
     end
@@ -190,11 +196,22 @@ ttymap.api.frame.on_tick(function()
             if d then
                 if d.kind == "wait" then
                     -- Detect manual user input during wait: any
-                    -- divergence between the captured map state and
-                    -- the live one means the user (or another
+                    -- divergence between the captured baseline and
+                    -- the live map state means the user (or another
                     -- caller) moved the camera; bail the script.
-                    -- First tick captures, subsequent ticks compare.
-                    if not rec.wait_check then
+                    --
+                    -- Sequence per wait:
+                    --   tick 1 — settle: skip everything except the
+                    --     wait-timer decrement so the App's
+                    --     drain_ops can apply the just-finished
+                    --     fly's final dispatch.
+                    --   tick 2 — capture: snapshot `:center()` /
+                    --     `:zoom()` as the baseline.
+                    --   tick 3+ — compare vs baseline; cancel on
+                    --     divergence.
+                    if rec.wait_settle_left and rec.wait_settle_left > 0 then
+                        rec.wait_settle_left = rec.wait_settle_left - 1
+                    elseif not rec.wait_check then
                         local lon, lat = ttymap.map:center()
                         rec.wait_check = {
                             lon = lon, lat = lat,


### PR DESCRIPTION
## Symptom

Travel plugin (and any director script that does \`fly → wait\`) cancels itself the moment the tour starts. Repro:

1. \`:\` palette → \"Travel\" → pick a route → Enter to play.
2. \"Starting: …\" toast appears, camera begins gliding to the overview, and instantly fires \"Tour cancelled\". The pre-overview fly never completes.

## Cause

One-frame timing skew between when the wait directive is set up and when the App applies the fly's final FlyTo.

\`step()\` runs from inside anim's \`on_done\`, which fires from *inside* anim's own \`on_tick\` — same \`lua.tick()\` pass. The director's \`on_tick\` runs right after, sees the new wait directive, and captures \`:center()\` / \`:zoom()\` as the baseline. But the App's \`drain_ops\` (which actually applies the dispatched FlyTo to MapState) only runs *between* loop iterations, so the captured baseline is the **pre-fly** position. Next tick reads the now-applied **post-fly** value, sees a divergence, and cancels.

## Fix

Introduce a one-tick settle skip on every wait setup. The driver now sequences each wait as:

| Tick | Action |
| ---- | ------ |
| 1    | settle: decrement \`wait_left\` only |
| 2    | capture: snapshot \`:center()\` / \`:zoom()\` as baseline (drain_ops has run between iterations 1 and 2, so the snapshot reflects post-fly state) |
| 3+   | compare vs baseline, cancel on divergence |

The 1-frame extra wait is invisible — every existing director caller uses 60+ frame waits. Standalone \`wait()\` calls (no preceding fly) pay the same 1-frame skip; harmless.

Animation-side equivalents already work because anim's \`expected\` is set from the dispatched value (not from \`:center()\` read-back), so it doesn't need a settle skip.

## Test plan

- [ ] \`:\` → \"Travel\" → pick a route → Enter — tour now plays through pre-overview, all stops, and post-overview without false cancellation
- [ ] Manual pan / zoom during a stop dwell still cancels the tour (\"Tour cancelled\" toast) — wait-divergence detection from the previous PR still works after the settle window
- [ ] All 184 tests pass; clippy + fmt clean