### PR TITLE
feat(engine): runtime toggle for tile text labels (+ geo_quiz hard mode)

### DIFF
--- a/ttymap-engine/src/map/mod.rs
+++ b/ttymap-engine/src/map/mod.rs
@@ -94,6 +94,13 @@ impl MapHandle {
         self.render_client.set_styler(styler);
     }
 
+    /// Toggle tile-rendered text labels on the render thread.
+    /// Caller is responsible for the follow-up [`Self::request_redraw`]
+    /// — flipping the flag alone won't redraw the visible frame.
+    pub fn set_labels_visible(&self, visible: bool) {
+        self.render_client.set_labels_visible(visible);
+    }
+
     /// Queue a fresh `RenderTask::Draw` against the current
     /// viewport, carrying any per-frame overlays the caller has
     /// collected (e.g. Lua-pushed polylines drained from

--- a/ttymap-engine/src/map/render/pipeline.rs
+++ b/ttymap-engine/src/map/render/pipeline.rs
@@ -157,6 +157,13 @@ impl RenderPipeline {
         self.renderer.set_styler(styler);
     }
 
+    /// Show / hide tile text labels. Forwards to the underlying
+    /// `Renderer`. No tile cache flush — the styler still classifies
+    /// features the same; only the second-pass symbol draw is gated.
+    pub fn set_labels_visible(&mut self, visible: bool) {
+        self.renderer.set_labels_visible(visible);
+    }
+
     // ── Private ──────────────────────────────────────────────────────────
 
     /// Compute the set of visible tiles for a viewport against the

--- a/ttymap-engine/src/map/render/renderer.rs
+++ b/ttymap-engine/src/map/render/renderer.rs
@@ -83,6 +83,12 @@ pub struct Renderer {
     width: usize,
     height: usize,
     scratches: Scratches,
+    /// Toggle for tile-rendered text labels (place names, road
+    /// names, etc.). When false the `draw` symbol pass is
+    /// suppressed; geometry features keep rendering. Plugins flip
+    /// it through `RenderHandle::set_labels_visible`. Default
+    /// `true`.
+    labels_visible: bool,
 }
 
 /// A symbol feature that survived the first pass. Holds the resolved
@@ -105,6 +111,7 @@ impl Renderer {
             width,
             height,
             scratches: Scratches::new(),
+            labels_visible: true,
         }
     }
 
@@ -119,6 +126,15 @@ impl Renderer {
     /// (they don't consult the styler).
     pub fn set_styler(&mut self, styler: Arc<Styler>) {
         self.styler = styler;
+    }
+
+    /// Show / hide tile-rendered text labels (place names, road
+    /// names, …). Geometry features (roads, water, fills) are
+    /// unaffected. Drives the `ttymap.map:set_labels_visible(b)`
+    /// Lua API — used e.g. by the `geo_quiz` plugin's hard mode
+    /// to suppress city-name hints.
+    pub fn set_labels_visible(&mut self, visible: bool) {
+        self.labels_visible = visible;
     }
 
     pub fn width(&self) -> usize {
@@ -193,13 +209,18 @@ impl Renderer {
                     }
 
                     if rule.style_type == StyleType::Symbol {
-                        symbols.push(ResolvedSymbol {
-                            vis: &td.vis,
-                            feature,
-                            color: rule.color,
-                            sort: extract_sort(&feature.properties),
-                            extent,
-                        });
+                        // Skip the entire symbol pass when labels
+                        // are hidden — the Vec stays empty so the
+                        // second-pass draw loop is a no-op.
+                        if self.labels_visible {
+                            symbols.push(ResolvedSymbol {
+                                vis: &td.vis,
+                                feature,
+                                color: rule.color,
+                                sort: extract_sort(&feature.properties),
+                                extent,
+                            });
+                        }
                     } else {
                         let mut ctx = DrawCtx {
                             canvas: &mut self.canvas,

--- a/ttymap-engine/src/map/render/thread.rs
+++ b/ttymap-engine/src/map/render/thread.rs
@@ -37,6 +37,11 @@ pub enum RenderTask {
         height: usize,
     },
     SetStyler(Arc<Styler>),
+    /// Toggle tile text labels on / off. The render thread flips
+    /// the renderer's flag in order with other tasks, so a
+    /// `SetLabelsVisible` issued *between* two Draws will only
+    /// affect the second.
+    SetLabelsVisible(bool),
     Shutdown,
 }
 
@@ -81,6 +86,19 @@ impl RenderClient {
     pub fn set_styler(&self, styler: Arc<Styler>) {
         if self.task_tx.send(RenderTask::SetStyler(styler)).is_err() {
             log::warn!("render thread channel closed on set_styler");
+        }
+    }
+
+    /// Toggle tile text labels on the render thread. Caller must
+    /// follow up with a `request_draw` to see the change — this
+    /// command alone only flips the flag.
+    pub fn set_labels_visible(&self, visible: bool) {
+        if self
+            .task_tx
+            .send(RenderTask::SetLabelsVisible(visible))
+            .is_err()
+        {
+            log::warn!("render thread channel closed on set_labels_visible");
         }
     }
 }
@@ -189,6 +207,10 @@ fn apply_task(task: RenderTask, pipeline: &mut RenderPipeline) -> TaskOutcome {
         }
         RenderTask::SetStyler(styler) => {
             pipeline.set_styler(styler);
+            TaskOutcome::Continue
+        }
+        RenderTask::SetLabelsVisible(visible) => {
+            pipeline.set_labels_visible(visible);
             TaskOutcome::Continue
         }
         RenderTask::Shutdown => TaskOutcome::Shutdown,

--- a/ttymap-tui/runtime/plugin/geo_quiz.lua
+++ b/ttymap-tui/runtime/plugin/geo_quiz.lua
@@ -157,6 +157,10 @@ local function close_card()
         state.w:close()
         state.w = nil
     end
+    -- Restore tile labels in case hard mode hid them. Idempotent —
+    -- showing labels when they're already on is a no-op on the
+    -- render thread.
+    ttymap.map:set_labels_visible(true)
 end
 
 local function submit()
@@ -305,6 +309,11 @@ local function start_session(difficulty)
     state.difficulty = difficulty
     state.total_km   = 0
     state.rounds     = 0
+    -- Hard mode hides tile-rendered text labels for the whole
+    -- session — without that the country / city names baked into
+    -- the map make every guess trivial. close_card() restores them
+    -- on quit.
+    ttymap.map:set_labels_visible(difficulty ~= "hard")
     start_round()
     open_card()
 end

--- a/ttymap-tui/src/app/dispatcher.rs
+++ b/ttymap-tui/src/app/dispatcher.rs
@@ -213,6 +213,10 @@ impl Dispatcher {
             }
             UserCommand::Resize(cols, rows) => self.handle_resize(cols, rows),
             UserCommand::ToggleSidebar => self.toggle_sidebar(),
+            UserCommand::SetLabelsVisible(visible) => {
+                self.map.set_labels_visible(visible);
+                self.request_map_redraw();
+            }
         }
         self.notify_post_command(&snapshot);
     }

--- a/ttymap-tui/src/command.rs
+++ b/ttymap-tui/src/command.rs
@@ -83,6 +83,11 @@ pub enum UserCommand {
     /// canvas dimensions so the render pipeline allocates the right
     /// buffer size for the visible map area.
     ToggleSidebar,
+    /// Toggle tile-rendered text labels (place names, road names,
+    /// …) on the render thread. Geometry features keep rendering.
+    /// Plugin-driven — `ttymap.map:set_labels_visible(b)` is the
+    /// canonical caller (e.g. geo_quiz hard mode hides hints).
+    SetLabelsVisible(bool),
 }
 
 impl UserCommand {

--- a/ttymap-tui/src/lua/api/map.rs
+++ b/ttymap-tui/src/lua/api/map.rs
@@ -116,6 +116,21 @@ impl UserData for HostMap {
             let ll = *this.center.lock().expect("center mutex poisoned");
             Ok((ll.lon, ll.lat))
         });
+
+        // `ttymap.map:set_labels_visible(b)` — show / hide every
+        // tile-rendered text label (place names, road names …).
+        // Geometry features (roads, water, fills) keep rendering.
+        // Used by `geo_quiz` hard mode to suppress city-name hints;
+        // any plugin can flip it for screenshot-style clean views.
+        // The flag flips on the render thread and a redraw fires
+        // automatically (the dispatcher pairs it with
+        // `request_map_redraw`).
+        methods.add_method("set_labels_visible", |_, this, visible: bool| {
+            this.ops
+                .borrow_mut()
+                .push(Op::Command(UserCommand::SetLabelsVisible(visible)));
+            Ok(())
+        });
     }
 }
 


### PR DESCRIPTION
Adds a render-thread toggle for tile-rendered text labels so plugins can hide place / road names without touching the styler. Geometry features (roads, water, fills) keep rendering — only the second-pass symbol draw is gated.

Hard mode of \`geo_quiz\` now actually lives up to its name: with map labels suppressed, the player has nothing but coastlines and roads to navigate by. Easy mode unchanged.

## Plumbing

| Layer                 | Change                                                                                        |
| --------------------- | --------------------------------------------------------------------------------------------- |
| Renderer              | New \`labels_visible: bool\` field (default true). First pass skips \`symbols.push(…)\` when false; second-pass sort + draw becomes a no-op on an empty Vec. |
| RenderPipeline        | \`set_labels_visible\` proxy.                                                                   |
| RenderTask            | New \`SetLabelsVisible(bool)\` variant — joins \`Draw\` / \`Resize\` / \`SetStyler\` on the render-thread message channel. |
| RenderClient          | \`set_labels_visible\` sender.                                                                  |
| MapHandle             | \`set_labels_visible\` exposes it to the App.                                                   |
| UserCommand           | New \`SetLabelsVisible(bool)\` variant — joins \`SetTheme\` as a top-level non-\`MapAction\` render command. |
| App dispatcher        | New arm: calls \`self.map.set_labels_visible(b)\` followed by \`self.request_map_redraw()\`.    |
| \`ttymap.map\` Lua API | \`:set_labels_visible(b)\` enqueues \`Op::Command(UserCommand::SetLabelsVisible(b))\`.          |

Processing happens in order with other render tasks, so a toggle issued between two Draws applies to the second.

## geo_quiz integration

\`start_session(\"hard\")\` flips labels off; \`close_card\` restores them unconditionally. Idempotent — turning labels on when they're already on is a render-thread no-op. Labels stay off across rounds within a hard session and only flip back when the player quits.

## Out of scope

- The toggle is a single global flag — no per-feature-type filtering (e.g. \"hide city names but keep road names\"). If that's wanted later it's a styler change, not a renderer change.
- No persistence — \`ttymap.opt.runtime.labels_visible\` could come later if users want a startup default.
- Existing tile cache stays valid through the toggle (the cache stores decoded MVT, not rendered output — only the renderer-side symbol pass changes).

## Test plan

- [ ] \`:\` palette → \"Geo quiz · easy\" — tile labels visible, country line shown in card
- [ ] \`:\` palette → \"Geo quiz · hard\" — tile labels gone, only city name shown in card
- [ ] Quit hard session — tile labels restored
- [ ] Multi-round hard session — labels stay off across rounds, restore on Esc
- [ ] All 189 tests pass; clippy / fmt clean