### PR TITLE
demo: VHS tapes for ping_simulation + travel plugins

### DIFF
--- a/vhs/ping_simulation.tape
+++ b/vhs/ping_simulation.tape
@@ -1,0 +1,39 @@
+# ttymap ping_simulation demo —
+#   world view → palette → toggle "ping simulation" → watch animated arcs.
+# Run from repo root: `vhs vhs/ping_simulation.tape` → assets/ping_simulation.mp4
+
+Output assets/ping_simulation.mp4
+
+Set FontSize 16
+Set Width 1920
+Set Height 1080
+Set Framerate 24
+Set Theme "TokyoNight"
+Set TypingSpeed 50ms
+Set PlaybackSpeed 1.0
+
+Type "ttymap"
+Enter
+Sleep 2s
+
+# `gg` jumps to the world view so all five ping arcs fit on screen.
+Type "gg"
+Sleep 1500ms
+
+# `:` opens the palette; "ping" filters to "Toggle ping simulation";
+# Enter invokes it.
+Type ":"
+Sleep 400ms
+Type "ping"
+Sleep 500ms
+Enter
+Sleep 500ms
+
+# Each ping cycle is out(45) + return(45) + pause(20) ≈ 110 frames;
+# the five pings are staggered (offset 0/18/36/54/72), so the visual
+# rhythm fully settles after the first ~1.5 s. ~12 s captures several
+# full cycles across all five arcs.
+Sleep 12s
+
+Type "q"
+Sleep 200ms

--- a/vhs/travel.tape
+++ b/vhs/travel.tape
@@ -1,0 +1,59 @@
+# ttymap travel demo —
+#   palette → "Travel" → list → ↓×4 (Hiroshima + Setouchi, 5th)
+#   → Enter (detail, pulled-back polyline preview)
+#   → Enter (animated tour) → linger on post-tour overview.
+# Run from repo root: `vhs vhs/travel.tape` → assets/travel.mp4
+
+Output assets/travel.mp4
+
+Set FontSize 16
+Set Width 1920
+Set Height 1080
+Set Framerate 24
+Set Theme "TokyoNight"
+Set TypingSpeed 50ms
+Set PlaybackSpeed 1.0
+
+Type "ttymap"
+Enter
+Sleep 2s
+
+# `:` opens the palette; "travel" filters to the Travel command.
+Type ":"
+Sleep 400ms
+Type "travel"
+Sleep 500ms
+Enter
+Sleep 1500ms
+
+# List opens at row 1 (Japan · Golden Route). Navigate down to the
+# 5th entry — Japan · Hiroshima + Setouchi.
+Down
+Sleep 250ms
+Down
+Sleep 250ms
+Down
+Sleep 250ms
+Down
+Sleep 800ms
+
+# Enter opens detail — sidebar shows itinerary, map paints the whole
+# polyline + all markers as a static pulled-back preview. Linger so
+# the route shape reads.
+Enter
+Sleep 5s
+
+# Enter again starts the tour: pre-fly → pre-dwell → 5 × (fly + 2 s
+# dwell) → post-fly → post-dwell ≈ 30 s end-to-end. Extra trailing
+# sleep keeps the post-overview (camera parked, full polyline +
+# markers shown) on screen for a beat after the script ends.
+Enter
+Sleep 38s
+
+# Back out: detail → list → close sidebar → quit ttymap.
+Escape
+Sleep 400ms
+Escape
+Sleep 400ms
+Type "q"
+Sleep 200ms


### PR DESCRIPTION
## Summary
- Adds `vhs/ping_simulation.tape` and `vhs/travel.tape`, mirroring `nav.tape`'s settings (1920×1080, FontSize 16, TokyoNight, 24 fps).
- **ping_simulation** (~17 s): launch → `gg` world view → `:ping` Enter → ~12 s of staggered Tokyo→NY / London→São Paulo / Beijing→Sydney / Moscow→Cape Town / Mumbai→LA arcs.
- **travel** (~50 s): launch → `:travel` Enter → ↓×4 to Japan · Hiroshima + Setouchi → Enter (detail polyline preview, ~5 s linger) → Enter (tour through Osaka / Himeji / Hiroshima / Miyajima / Iwakuni) → linger on post-overview.

The mp4 outputs stay gitignored — tapes are the source. To embed in README, regenerate locally and drag-drop the file onto a PR / issue; GitHub returns a `user-attachments/...` URL that plays inline in markdown.

## Test plan
- [ ] `vhs vhs/ping_simulation.tape` renders `assets/ping_simulation.mp4` end-to-end
- [ ] `vhs vhs/travel.tape` renders `assets/travel.mp4` end-to-end
- [ ] Visual: arcs settle into staggered rhythm in ping_simulation
- [ ] Visual: travel selects Hiroshima + Setouchi, shows pulled-back polyline in detail mode, tour runs to completion, post-overview lingers