### PR TITLE
refactor(lua): rename PluginRegistry → LuaRegistry

### DIFF
--- a/ttymap-tui/src/app/mod.rs
+++ b/ttymap-tui/src/app/mod.rs
@@ -87,7 +87,7 @@ impl App {
 
         // Compositor bootstraps with the BaseLayer (keymap +
         // activation dispatch) at index 0. Every subsequent modal is
-        // pushed on top. BaseLayer borrows the live `PluginRegistry`
+        // pushed on top. BaseLayer borrows the live `LuaRegistry`
         // so plugin `KeybindHandle:remove()` updates are visible on
         // the next keypress; built-in activations (today: just `:`
         // for the palette) are kept in their own Vec so plugins

--- a/ttymap-tui/src/compositor/base.rs
+++ b/ttymap-tui/src/compositor/base.rs
@@ -31,7 +31,7 @@ use super::window::{RenderWindow, Window};
 use super::{Activation, Component, SpawnComponent};
 use crate::UserCommand;
 use crate::input::keymap::KeyMap;
-use crate::lua::PluginRegistryHandle;
+use crate::lua::LuaRegistryHandle;
 use ttymap_engine::map::MapAction;
 
 pub struct BaseLayer {
@@ -41,14 +41,14 @@ pub struct BaseLayer {
     /// pushed by [`crate::palette::install`]. Walked first on
     /// keypress, so a plugin can't accidentally shadow `:`.
     builtin_activations: Vec<Activation>,
-    /// Live registry of plugin-declared activations. Cloned from
+    /// Live registry of Lua-registered activations. Cloned from
     /// `LuaSubsystem` at startup. Keypress dispatch borrows it
-    /// per-event; plugin `:remove()` mutably borrows it from a
+    /// per-event; Lua `:remove()` mutably borrows it from a
     /// `KeybindHandle` to drop the matching entry.
-    registry: PluginRegistryHandle,
-    /// Plugin-supplied footer hints harvested at startup. Static
-    /// for the program lifetime — adding / removing entries does
-    /// not refresh this list.
+    registry: LuaRegistryHandle,
+    /// Lua-supplied footer hints harvested at startup. Static for
+    /// the program lifetime — adding / removing entries does not
+    /// refresh this list.
     footer_hints: Vec<(&'static str, &'static str)>,
     /// First-`g` flag of the `gg` sequence. Lives here (not in
     /// `KeyMap`) because multi-key sequencing is a base-layer
@@ -60,7 +60,7 @@ impl BaseLayer {
     pub fn new(
         keymap: KeyMap,
         builtin_activations: Vec<Activation>,
-        registry: PluginRegistryHandle,
+        registry: LuaRegistryHandle,
         footer_hints: Vec<(&'static str, &'static str)>,
     ) -> Self {
         Self {
@@ -183,7 +183,7 @@ mod tests {
         BaseLayer::new(
             KeyMap::default(),
             Vec::new(),
-            crate::lua::new_plugin_registry(),
+            crate::lua::new_lua_registry(),
             Vec::new(),
         )
     }
@@ -236,7 +236,7 @@ mod tests {
         use std::cell::Cell;
         use std::rc::Rc;
 
-        let registry = crate::lua::new_plugin_registry();
+        let registry = crate::lua::new_lua_registry();
         let fired = Rc::new(Cell::new(0_u32));
 
         struct DummyComponent;

--- a/ttymap-tui/src/lua/api/mod.rs
+++ b/ttymap-tui/src/lua/api/mod.rs
@@ -140,7 +140,7 @@ pub fn install(
     shared: Arc<LuaHostShared>,
     ops: crate::compositor::op::OpsBuffer,
     bus: std::rc::Rc<crate::event::EventBus>,
-    registry: crate::lua::registrar::PluginRegistryHandle,
+    registry: crate::lua::registrar::LuaRegistryHandle,
 ) -> mlua::Result<LuaHostHandles> {
     // Fire-and-forget Lua intents (`map:jump`, `:zoom`, `:fly_to`,
     // `frame.export`) enqueue `Op::Command(UserCommand::...)` onto
@@ -183,7 +183,7 @@ pub fn install(
 
     // Activation surfaces (`register_palette_command` /
     // `register_keybind` / `on_event`) — every call pushes directly
-    // into the live `PluginRegistry` (or, for `on_event`, subscribes
+    // into the live `LuaRegistry` (or, for `on_event`, subscribes
     // directly against the bus) and returns a Lua-facing handle.
     // No deferred capture, no per-script slot.
     register::install(lua, &ttymap, bus.clone(), registry, shared.clone())?;
@@ -250,7 +250,7 @@ mod tests {
         let lua = mlua::Lua::new();
         let ops = crate::compositor::op::new_ops_buffer();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
-        let registry = crate::lua::new_plugin_registry();
+        let registry = crate::lua::new_lua_registry();
         let handles = install(&lua, LuaHostShared::empty(), ops.clone(), bus, registry)
             .expect("install ttymap table");
         (lua, handles, ops)
@@ -384,7 +384,7 @@ mod tests {
             shared.clone(),
             crate::compositor::op::new_ops_buffer(),
             bus,
-            crate::lua::new_plugin_registry(),
+            crate::lua::new_lua_registry(),
         )
         .expect("install ttymap table");
 
@@ -419,7 +419,7 @@ mod tests {
             LuaHostShared::empty(),
             crate::compositor::op::new_ops_buffer(),
             bus.clone(),
-            crate::lua::new_plugin_registry(),
+            crate::lua::new_lua_registry(),
         )
         .expect("install ttymap table");
         lua.load(
@@ -449,7 +449,7 @@ mod tests {
             LuaHostShared::empty(),
             crate::compositor::op::new_ops_buffer(),
             bus.clone(),
-            crate::lua::new_plugin_registry(),
+            crate::lua::new_lua_registry(),
         )
         .expect("install ttymap table");
         lua.load(
@@ -477,7 +477,7 @@ mod tests {
             LuaHostShared::empty(),
             crate::compositor::op::new_ops_buffer(),
             bus.clone(),
-            crate::lua::new_plugin_registry(),
+            crate::lua::new_lua_registry(),
         )
         .expect("install ttymap table");
         lua.load(
@@ -510,7 +510,7 @@ mod tests {
             LuaHostShared::empty(),
             crate::compositor::op::new_ops_buffer(),
             bus,
-            crate::lua::new_plugin_registry(),
+            crate::lua::new_lua_registry(),
         )
         .expect("install ttymap table");
         let result: mlua::Result<()> = lua.load(r#"ttymap.on_event("", function() end)"#).exec();

--- a/ttymap-tui/src/lua/api/register.rs
+++ b/ttymap-tui/src/lua/api/register.rs
@@ -3,7 +3,7 @@
 //! subscriptions.
 //!
 //! `register_palette_command` / `register_keybind` push entries
-//! **directly** into the [`PluginRegistry`] (no deferred capture, no
+//! **directly** into the [`LuaRegistry`] (no deferred capture, no
 //! per-script slot). The host doesn't track which script registered
 //! what; "plugin" is purely a Lua-side organisational unit (one .lua
 //! file's worth of `register_*` calls). Each call returns a handle
@@ -27,13 +27,13 @@ use crate::lua::bridge::registrar_handle::{
     KeybindHandle, PaletteCommandHandle, allocate_handle_id,
 };
 use crate::lua::host::{HelpEntry, LuaHostShared};
-use crate::lua::registrar::PluginRegistryHandle;
+use crate::lua::registrar::LuaRegistryHandle;
 
 pub(super) fn install(
     lua: &Lua,
     ttymap: &Table,
     bus: Rc<EventBus>,
-    registry: PluginRegistryHandle,
+    registry: LuaRegistryHandle,
     shared: Arc<LuaHostShared>,
 ) -> mlua::Result<()> {
     install_register_palette_command(lua, ttymap, registry.clone(), shared)?;
@@ -45,7 +45,7 @@ pub(super) fn install(
 fn install_register_palette_command(
     lua: &Lua,
     ttymap: &Table,
-    registry: PluginRegistryHandle,
+    registry: LuaRegistryHandle,
     shared: Arc<LuaHostShared>,
 ) -> mlua::Result<()> {
     ttymap.set(
@@ -112,7 +112,7 @@ fn install_register_palette_command(
 fn install_register_keybind(
     lua: &Lua,
     ttymap: &Table,
-    registry: PluginRegistryHandle,
+    registry: LuaRegistryHandle,
 ) -> mlua::Result<()> {
     ttymap.set(
         "register_keybind",

--- a/ttymap-tui/src/lua/bridge/palette_provider.rs
+++ b/ttymap-tui/src/lua/bridge/palette_provider.rs
@@ -247,7 +247,7 @@ mod tests {
             LuaHostShared::empty(),
             crate::compositor::op::new_ops_buffer(),
             bus,
-            crate::lua::new_plugin_registry(),
+            crate::lua::new_lua_registry(),
         )
         .expect("install ttymap");
         let spec: Table = lua.load(script).eval().expect("eval spec");

--- a/ttymap-tui/src/lua/bridge/registrar_handle.rs
+++ b/ttymap-tui/src/lua/bridge/registrar_handle.rs
@@ -5,21 +5,21 @@
 //!
 //! Both handles expose a single `:remove()` method that drops the
 //! matching entry from the live
-//! [`PluginRegistry`](crate::lua::registrar::PluginRegistry). The
+//! [`LuaRegistry`](crate::lua::registrar::LuaRegistry). The
 //! verb matches [`super::event_handle::EventHandle::remove`] so a
 //! plugin author can dispose any registration uniformly. Idempotent
 //! — `:remove()` on an already-removed handle is a no-op.
 //!
 //! Each handle carries an `id: u64` allocated at registration call
 //! site (the same id stored alongside the entry in the registry),
-//! plus a clone of the `Rc<RefCell<PluginRegistry>>` so `:remove()`
+//! plus a clone of the `Rc<RefCell<LuaRegistry>>` so `:remove()`
 //! can mutably borrow and find the entry by ID.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use mlua::UserData;
 
-use crate::lua::registrar::PluginRegistryHandle;
+use crate::lua::registrar::LuaRegistryHandle;
 
 /// Process-global counter for registrar handle IDs. Bumped once per
 /// `register_palette_command` or `register_keybind` call. Unique
@@ -37,18 +37,18 @@ pub fn allocate_handle_id() -> u64 {
 /// Lua-facing handle returned by `ttymap.register_palette_command(...)`.
 ///
 /// `:remove()` calls
-/// [`PluginRegistry::remove_palette_entry`](crate::lua::registrar::PluginRegistry::remove_palette_entry)
+/// [`LuaRegistry::remove_palette_entry`](crate::lua::registrar::LuaRegistry::remove_palette_entry)
 /// — the entry is gone from the next palette open. If the palette
 /// is already on screen with the entry visible, selecting it after
 /// removal silently no-ops (the registry lookup at execute time
 /// returns `None`).
 pub struct PaletteCommandHandle {
     id: u64,
-    registry: PluginRegistryHandle,
+    registry: LuaRegistryHandle,
 }
 
 impl PaletteCommandHandle {
-    pub fn new(id: u64, registry: PluginRegistryHandle) -> Self {
+    pub fn new(id: u64, registry: LuaRegistryHandle) -> Self {
         Self { id, registry }
     }
 }
@@ -65,16 +65,16 @@ impl UserData for PaletteCommandHandle {
 /// Lua-facing handle returned by `ttymap.register_keybind(...)`.
 ///
 /// `:remove()` calls
-/// [`PluginRegistry::remove_activation`](crate::lua::registrar::PluginRegistry::remove_activation)
+/// [`LuaRegistry::remove_activation`](crate::lua::registrar::LuaRegistry::remove_activation)
 /// — the next keypress for that key falls through to the keymap as
 /// if the plugin had never bound it.
 pub struct KeybindHandle {
     id: u64,
-    registry: PluginRegistryHandle,
+    registry: LuaRegistryHandle,
 }
 
 impl KeybindHandle {
-    pub fn new(id: u64, registry: PluginRegistryHandle) -> Self {
+    pub fn new(id: u64, registry: LuaRegistryHandle) -> Self {
         Self { id, registry }
     }
 }
@@ -92,7 +92,7 @@ impl UserData for KeybindHandle {
 mod tests {
     use super::*;
     use crate::compositor::{Activation, Component, PaletteEntry};
-    use crate::lua::registrar::new_plugin_registry;
+    use crate::lua::registrar::new_lua_registry;
     use crossterm::event::{KeyCode, KeyModifiers};
 
     fn fake_palette_entry() -> PaletteEntry {
@@ -113,7 +113,7 @@ mod tests {
 
     #[test]
     fn palette_command_handle_remove_drops_entry_from_registry() {
-        let registry = new_plugin_registry();
+        let registry = new_lua_registry();
         let id = 42;
         registry
             .borrow_mut()
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn keybind_handle_remove_drops_activation_from_registry() {
-        let registry = new_plugin_registry();
+        let registry = new_lua_registry();
         let id = 7;
         registry.borrow_mut().add_activation(id, fake_activation());
         assert_eq!(registry.borrow().activation_count(), 1);

--- a/ttymap-tui/src/lua/init_lua.rs
+++ b/ttymap-tui/src/lua/init_lua.rs
@@ -27,7 +27,7 @@
 //! - `require "<name>"` — top-level requires resolve via the
 //!   plugin-aware searcher (see [`crate::lua::vm::install_plugin_searcher`]).
 //!   On hit, the plugin runs in the shared VM and its `register_*`
-//!   calls attribute to `<name>` in the [`PluginRegistry`].
+//!   calls attribute to `<name>` in the [`LuaRegistry`].
 //!
 //! Recovery posture matches the rest of the bridge: a missing,
 //! unreadable, or throwing `init.lua` logs a warning and the loader

--- a/ttymap-tui/src/lua/mod.rs
+++ b/ttymap-tui/src/lua/mod.rs
@@ -29,7 +29,7 @@ pub use handle::LuaHandle;
 pub use host::LuaHostShared;
 pub use init_lua::read_init_lua_config_only;
 pub use map_api::MapApi;
-pub use registrar::{PluginRegistry, PluginRegistryHandle, new_plugin_registry};
+pub use registrar::{LuaRegistry, LuaRegistryHandle, new_lua_registry};
 pub use runtimepath::{resolve_runtime_path, runtime_path, set_runtime_path};
 pub use vm::new_lua;
 
@@ -51,12 +51,12 @@ pub struct LuaSubsystem {
     /// Runtime handle to the Lua subsystem — semantic surface
     /// App uses to observe state changes and tick plugins.
     pub handle: LuaHandle,
-    /// Live registry of plugin-declared activations + palette
+    /// Live registry of Lua-registered activations + palette
     /// entries. Cloned into `BaseLayer` (for keypress dispatch) and
     /// the palette installer (for the `:` activation's per-open
     /// `CommandSeed` snapshot). Lua-side `PaletteCommandHandle:remove()`
     /// / `KeybindHandle:remove()` mutably borrow it to drop entries.
-    pub registry: PluginRegistryHandle,
+    pub registry: LuaRegistryHandle,
     /// `[<key> <label>]` footer hints harvested from the registry's
     /// palette entries at startup. Static for the program lifetime —
     /// adding / removing entries at runtime does not refresh this
@@ -103,7 +103,7 @@ pub struct LuaSubsystem {
 /// composition root after this returns, draining `palette_entries`
 /// into a default `:`-palette provider.
 pub fn build_subsystem(defaults: Config) -> (LuaSubsystem, Config, KeybindingOverrides, KeyMap) {
-    let registry = new_plugin_registry();
+    let registry = new_lua_registry();
     let shared = Arc::new(LuaHostShared::new(defaults.geoip.endpoint.clone()));
     let bus = std::rc::Rc::new(crate::event::EventBus::default());
     let ops = op::new_ops_buffer();
@@ -262,12 +262,12 @@ mod tests {
         source: &'static str,
     ) -> (
         mlua::Lua,
-        PluginRegistryHandle,
+        LuaRegistryHandle,
         std::rc::Rc<crate::event::EventBus>,
     ) {
         let lua = new_lua();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
-        let registry = new_plugin_registry();
+        let registry = new_lua_registry();
         api::install(
             &lua,
             host::LuaHostShared::empty(),
@@ -296,7 +296,7 @@ mod tests {
         layer: &Path,
     ) -> (
         mlua::Lua,
-        PluginRegistryHandle,
+        LuaRegistryHandle,
         Arc<host::LuaHostShared>,
         std::rc::Rc<crate::event::EventBus>,
     ) {
@@ -307,7 +307,7 @@ mod tests {
         vm::prepend_package_path(&lua, &layer.join("lua"));
         let shared = host::LuaHostShared::empty();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
-        let registry = new_plugin_registry();
+        let registry = new_lua_registry();
         api::install(
             &lua,
             shared.clone(),
@@ -358,7 +358,7 @@ mod tests {
         std::fs::write(dir.join("init.lua"), lua).expect("write plugin init.lua");
     }
 
-    fn labels(r: &PluginRegistryHandle) -> Vec<String> {
+    fn labels(r: &LuaRegistryHandle) -> Vec<String> {
         r.borrow()
             .palette_entries()
             .iter()
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn register_palette_command_and_keybind_land_in_registry() {
         // `ttymap.register_palette_command(spec)` + `ttymap.register_keybind(key, fn)`
-        // push directly into the live `PluginRegistry`. No deferred
+        // push directly into the live `LuaRegistry`. No deferred
         // capture — the entries are visible the moment the chunk
         // returns.
         let (_lua, registry, _bus) = run_in_fresh_vm(

--- a/ttymap-tui/src/lua/registrar.rs
+++ b/ttymap-tui/src/lua/registrar.rs
@@ -1,9 +1,9 @@
-//! `PluginRegistry` — live home for plugin-declared activations and
+//! `LuaRegistry` — live home for Lua-registered activations and
 //! palette entries.
 //!
 //! Lua scripts call `ttymap.register_keybind(key, fn)` /
 //! `ttymap.register_palette_command(spec)` and each call pushes
-//! directly into [`PluginRegistry`] paired with a monotonic handle
+//! directly into [`LuaRegistry`] paired with a monotonic handle
 //! ID. The Lua-facing handle (`KeybindHandle` / `PaletteCommandHandle`)
 //! exposes `:remove()` which finds and drops the entry by that ID.
 //! The host has no notion of "plugin" — that's purely a Lua-side
@@ -18,7 +18,7 @@
 //! - `PaletteCommandHandle:remove()` / `KeybindHandle:remove()` from
 //!   Lua mutably borrow it to drop the matching entry by ID
 //!
-//! `PluginRegistry` stays alive for the program's lifetime, owned
+//! `LuaRegistry` stays alive for the program's lifetime, owned
 //! jointly through `Rc` clones by every consumer.
 //!
 //! Lives in `lua/` rather than `compositor/` because it's purely the
@@ -31,29 +31,29 @@ use crossterm::event::{KeyCode, KeyModifiers};
 
 use crate::compositor::{Activation, PaletteEntry};
 
-/// Live registry of plugin-supplied activations + palette entries.
+/// Live registry of Lua-registered activations + palette entries.
 /// Each entry is paired with the handle ID Lua holds, so a
 /// `:remove()` from Lua can find and drop the exact entry.
 ///
-/// Order is registration order (a `Vec<(id, T)>`), mirroring the
-/// loader's iteration order over capture specs. Removal is `retain`
-/// — `O(n)` linear, but the entry counts top out at the
-/// total-plugin-count plus a handful per plugin in practice.
+/// Order is registration order (a `Vec<(id, T)>`). Removal is
+/// `retain` — `O(n)` linear, but the entry counts stay small in
+/// practice (a handful of registrations per script across the
+/// whole program lifetime).
 #[derive(Default)]
-pub struct PluginRegistry {
+pub struct LuaRegistry {
     activations: Vec<(u64, Activation)>,
     palette_entries: Vec<(u64, PaletteEntry)>,
 }
 
-/// Cheap-clone shared owner of a [`PluginRegistry`]. Cloned into
+/// Cheap-clone shared owner of a [`LuaRegistry`]. Cloned into
 /// every consumer that needs to read or mutate the registry.
-pub type PluginRegistryHandle = Rc<RefCell<PluginRegistry>>;
+pub type LuaRegistryHandle = Rc<RefCell<LuaRegistry>>;
 
-pub fn new_plugin_registry() -> PluginRegistryHandle {
-    Rc::new(RefCell::new(PluginRegistry::default()))
+pub fn new_lua_registry() -> LuaRegistryHandle {
+    Rc::new(RefCell::new(LuaRegistry::default()))
 }
 
-impl PluginRegistry {
+impl LuaRegistry {
     pub fn add_activation(&mut self, id: u64, a: Activation) {
         self.activations.push((id, a));
     }
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn add_then_remove_activation_round_trip() {
-        let mut r = PluginRegistry::default();
+        let mut r = LuaRegistry::default();
         r.add_activation(7, fake_activation('a'));
         r.add_activation(8, fake_activation('b'));
         assert_eq!(r.activation_count(), 2);
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn add_then_remove_palette_entry_round_trip() {
-        let mut r = PluginRegistry::default();
+        let mut r = LuaRegistry::default();
         r.add_palette_entry(11, fake_palette_entry("alpha"));
         r.add_palette_entry(12, fake_palette_entry("beta"));
         assert_eq!(r.palette_entry_count(), 2);
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn palette_entries_iter_preserves_registration_order() {
-        let mut r = PluginRegistry::default();
+        let mut r = LuaRegistry::default();
         r.add_palette_entry(1, fake_palette_entry("first"));
         r.add_palette_entry(2, fake_palette_entry("second"));
         r.add_palette_entry(3, fake_palette_entry("third"));

--- a/ttymap-tui/src/main.rs
+++ b/ttymap-tui/src/main.rs
@@ -180,7 +180,7 @@ fn run_event_loop(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     lua.handle.set_attribution(map.attribution.clone());
 
     // Palette is a built-in (not a plugin): build a CommandSeed
-    // around the live PluginRegistry and append the `:` activation
+    // around the live LuaRegistry and append the `:` activation
     // to a fresh built-ins Vec. Must run after every plugin's
     // register call so the seed sees them.
     let mut builtin_activations: Vec<ttymap_tui::compositor::Activation> = Vec::new();

--- a/ttymap-tui/src/palette/mod.rs
+++ b/ttymap-tui/src/palette/mod.rs
@@ -214,7 +214,7 @@ impl Component for PaletteComponent {
 /// Install the palette as a built-in. Unlike a plugin's `register`,
 /// this is a **sink**: prebuild a [`CommandSeed`] that holds the
 /// static map-action half plus a clone of the live
-/// [`PluginRegistryHandle`](crate::lua::PluginRegistryHandle), and
+/// [`LuaRegistryHandle`](crate::lua::LuaRegistryHandle), and
 /// append a single `:` activation. Each open snapshots the registry
 /// freshly so plugins can `:remove()` (or, in a future PR, register
 /// at runtime) and the next open reflects it. Must be called
@@ -222,7 +222,7 @@ impl Component for PaletteComponent {
 pub fn install(
     keymap: &KeyMap,
     activations: &mut Vec<Activation>,
-    registry: crate::lua::PluginRegistryHandle,
+    registry: crate::lua::LuaRegistryHandle,
 ) {
     let seed = Rc::new(CommandSeed::build(keymap, registry));
     let seed_for_spawn = seed;

--- a/ttymap-tui/src/palette/provider/command.rs
+++ b/ttymap-tui/src/palette/provider/command.rs
@@ -4,7 +4,7 @@
 //! - map actions (harvested from [`MapAction::all_listed`] with keymap
 //!   hints — static, cached on [`CommandSeed`])
 //! - plugin palette entries — read live from the shared
-//!   [`PluginRegistry`](crate::lua::PluginRegistry) so plugin
+//!   [`LuaRegistry`](crate::lua::LuaRegistry) so plugin
 //!   `:remove()` / dynamic registration is reflected on the next
 //!   palette open
 //!
@@ -22,7 +22,7 @@ use std::rc::Rc;
 use crate::UserCommand;
 use crate::compositor::Context;
 use crate::input::keymap::KeyMap;
-use crate::lua::PluginRegistryHandle;
+use crate::lua::LuaRegistryHandle;
 use crate::theme::ThemeId;
 use ttymap_engine::map::MapAction;
 
@@ -34,11 +34,11 @@ use super::{PaletteAction, PaletteItem, PaletteProvider, ThemeProvider};
 /// [`CommandProvider::build`] time per open.
 pub struct CommandSeed {
     map_actions: Vec<(MapAction, String)>, // (action, key hint)
-    registry: PluginRegistryHandle,
+    registry: LuaRegistryHandle,
 }
 
 impl CommandSeed {
-    pub fn build(keymap: &KeyMap, registry: PluginRegistryHandle) -> Self {
+    pub fn build(keymap: &KeyMap, registry: LuaRegistryHandle) -> Self {
         let map_actions = MapAction::all_listed()
             .iter()
             .map(|a| {
@@ -59,7 +59,7 @@ enum Kind {
     MapAction(MapAction),
     /// Plugin-registered entry — selecting looks up the matching
     /// [`PaletteEntry`](crate::compositor::PaletteEntry) in the live
-    /// [`PluginRegistry`](crate::lua::PluginRegistry) by ID and
+    /// [`LuaRegistry`](crate::lua::LuaRegistry) by ID and
     /// invokes its factory. If the entry has been `:remove()`d
     /// since this snapshot was built, the lookup returns `None` and
     /// the palette closes silently.


### PR DESCRIPTION
## Summary

Follow-up to #284 — that PR dropped the \"plugin\" *concept* from Rust but left the *name* `PluginRegistry` lingering. After the cleanup, this struct is just a \`Vec\` of activations + palette entries that Lua scripts register via \`ttymap.register_*\`; the host doesn't model plugins anywhere.

The new name matches the existing \`Lua*\` convention in \`lua/\`:

\`\`\`
PluginRegistry        → LuaRegistry
PluginRegistryHandle  → LuaRegistryHandle
new_plugin_registry   → new_lua_registry
\`\`\`

Pure rename — no behaviour change. Doc comments updated where they referenced \"plugin-declared\" / \"plugin-supplied\".

## Test plan

- [x] \`cargo build --workspace\` passes
- [x] \`cargo test --workspace\` — 414 passed
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt -- --check\` clean