### PR TITLE
docs(lua): repoint stale lua-bridge-surface.md reference (closes #276)

### DIFF
--- a/ttymap-tui/src/lua/mod.rs
+++ b/ttymap-tui/src/lua/mod.rs
@@ -1,10 +1,11 @@
 //! Lua runtime scaffold for scripted plugins.
 //!
 //! Owns the shared [`mlua::Lua`] state. The bridge surface (Component
-//! adapter, MapApi, widget descriptors, etc.) lands in submodules as
-//! it gets built out per the audit in `docs/lua-bridge-surface.md`.
+//! adapter, MapApi, widget descriptors, etc.) lives in the submodules
+//! below — see `docs/lua-architecture.md` for the full per-namespace
+//! tour.
 //!
-//! Defaults that are deliberate and not provisional (see audit §13):
+//! Defaults that are deliberate and not provisional:
 //! - **Lua 5.4** via the `vendored` mlua feature: portable, no
 //!   system Lua dep, ~1 MB binary growth.
 //! - **No sandbox**: ttymap is single-user; trust the plugin author


### PR DESCRIPTION
## Summary

\`ttymap-tui/src/lua/mod.rs:5\` referenced \`docs/lua-bridge-surface.md\`, which doesn't exist — the Lua-side documentation lives at \`docs/lua-architecture.md\`. The \"as it gets built out per the audit\" phrasing was also stale; the bridge surface is built out at this point.

Repoints to the right doc and drops the audit framing.

Closes #276.

## Test plan

- [x] \`cargo build --workspace\` passes
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt -- --check\` clean