### PR TITLE
feat(lua): add ttymap.json:stringify (#213)

### DIFF
--- a/docs/lua-architecture.md
+++ b/docs/lua-architecture.md
@@ -64,7 +64,8 @@ ttymap-tui/src/lua/
                    also installs top-level `ttymap.notify` /
                    `ttymap.on_event` on the global
     http.rs        ttymap.http   :fetch / :fetch_cached / :url_encode
-    json.rs        ttymap.json   :parse
+    json.rs        ttymap.json   :parse / :stringify
+                                  (lua_to_json shared with storage.rs)
     sgp4.rs        ttymap.sgp4   TLE parse / propagate
     map.rs         ttymap.map    HostMap userdata (jump/zoom/fly_to/center)
                                 + make_map_table (per-frame on_tick `map` arg)
@@ -138,7 +139,7 @@ userdatas:
 |------------------|------------------------------------------------------------------------------------------------|
 | `ttymap.http`    | `:fetch(url)`, `:fetch_cached(url, ttl_secs)`, `:url_encode(s)`                                |
 | `ttymap.map`     | `:jump(lon, lat)`, `:zoom(level)`, `:zoom()` getter, `:fly_to(lon, lat, zoom)`, `:center()`    |
-| `ttymap.json`    | `:parse(s)` → table or nil                                                                     |
+| `ttymap.json`    | `:parse(s)` → table or nil, `:stringify(value)` → string                                       |
 | `ttymap.sgp4`    | `:parse_tle`, `:parse_tles`, `:propagate`, `:propagate_batch`                                  |
 | `ttymap.tile`    | `:attribution()`                                                                               |
 | `ttymap.config`  | `:geoip_endpoint()`                                                                            |

--- a/ttymap-tui/src/lua/api/json.rs
+++ b/ttymap-tui/src/lua/api/json.rs
@@ -1,11 +1,23 @@
 //! `ttymap.json` — JSON parsing surface for Lua plugins.
 //!
-//! Single-method userdata: `ttymap.json:parse(s) -> value | nil`.
-//! Wraps `serde_json` so plugins don't need a Lua-side JSON
-//! library to consume HTTP response bodies. Objects become
-//! string-keyed Lua tables, arrays become 1-indexed Lua tables,
-//! `null` becomes `nil`. Parse errors are swallowed (warning
-//! logged) so a flaky upstream doesn't take a plugin down.
+//! Two methods on a single userdata:
+//! - `ttymap.json:parse(s) -> value | nil` — JSON text → Lua value.
+//!   Objects become string-keyed tables, arrays become 1-indexed
+//!   tables, `null` becomes `nil`. Parse errors are swallowed
+//!   (warning logged) so a flaky upstream doesn't take a plugin down.
+//! - `ttymap.json:stringify(value) -> string` — Lua value → JSON
+//!   text. Type-strict: function / userdata / thread are rejected
+//!   with an error so a silent drop can't corrupt persisted state.
+//!   Mixed-key tables (integer + string keys) are rejected for the
+//!   same reason. NaN / Infinity become JSON `null`.
+//!
+//! `lua_to_json` is the bidirectional sibling of `json_to_lua` and
+//! is shared with `ttymap.storage` (which JSON-encodes values
+//! before atomic-writing to disk).
+//!
+//! The two methods round-trip: `parse(stringify(x))` preserves
+//! type for the supported value set (nil / boolean / integer /
+//! number / string / array table / object table).
 
 use mlua::UserData;
 
@@ -23,6 +35,11 @@ impl UserData for HostJson {
                 }
             },
         );
+
+        methods.add_method("stringify", |_lua, _this, value: mlua::Value| {
+            let json = lua_to_json(&value)?;
+            serde_json::to_string(&json).map_err(mlua::Error::external)
+        });
     }
 }
 
@@ -30,7 +47,10 @@ impl UserData for HostJson {
 /// `mlua::Value`. Objects map to string-keyed tables, arrays to
 /// 1-indexed tables (Lua convention), null to nil, integers to
 /// `Integer` when they fit and `Number` otherwise.
-fn json_to_lua(lua: &mlua::Lua, value: &serde_json::Value) -> mlua::Result<mlua::Value> {
+///
+/// `pub(super)` so `ttymap.storage` (sibling) can reuse the same
+/// decoder when reading a JSON-on-disk value back into Lua.
+pub(super) fn json_to_lua(lua: &mlua::Lua, value: &serde_json::Value) -> mlua::Result<mlua::Value> {
     match value {
         serde_json::Value::Null => Ok(mlua::Value::Nil),
         serde_json::Value::Bool(b) => Ok(mlua::Value::Boolean(*b)),
@@ -62,5 +82,282 @@ fn json_to_lua(lua: &mlua::Lua, value: &serde_json::Value) -> mlua::Result<mlua:
             }
             Ok(mlua::Value::Table(table))
         }
+    }
+}
+
+/// Translate a `mlua::Value` into a `serde_json::Value`.
+///
+/// Type rules (kept tight to avoid silent corruption of persisted
+/// state):
+/// - `nil` → `null`
+/// - `boolean` → `bool`
+/// - `integer` → integer JSON number
+/// - `number` → `f64` JSON number; `NaN` / `±Infinity` → `null`
+///   (JSON has no way to express them — we drop rather than fail
+///   so that a single bad cell in a larger table doesn't sink the
+///   whole encode)
+/// - `string` → JSON string (UTF-8; non-UTF-8 bytes are rejected)
+/// - `table` → array if every key is `1..=#t` consecutive integers,
+///   otherwise object (string keys only). Mixed integer + string
+///   keys are rejected with an error.
+/// - `function` / `userdata` / `thread` / `lightuserdata` are
+///   rejected with an error.
+pub(crate) fn lua_to_json(value: &mlua::Value) -> mlua::Result<serde_json::Value> {
+    match value {
+        mlua::Value::Nil => Ok(serde_json::Value::Null),
+        mlua::Value::Boolean(b) => Ok(serde_json::Value::Bool(*b)),
+        mlua::Value::Integer(i) => Ok(serde_json::Value::from(*i)),
+        mlua::Value::Number(n) => {
+            if n.is_finite() {
+                Ok(serde_json::Value::from(*n))
+            } else {
+                Ok(serde_json::Value::Null)
+            }
+        }
+        mlua::Value::String(s) => Ok(serde_json::Value::String(s.to_str()?.to_owned())),
+        mlua::Value::Table(t) => table_to_json(t),
+        other => Err(mlua::Error::external(format!(
+            "ttymap.json:stringify: unsupported value type {}",
+            other.type_name()
+        ))),
+    }
+}
+
+/// Decide whether a Lua table is a JSON array or object and encode
+/// accordingly. The decision is purely structural: every key is a
+/// positive integer covering `1..=n` exactly → array; every key is
+/// a string → object; anything else → error.
+fn table_to_json(table: &mlua::Table) -> mlua::Result<serde_json::Value> {
+    // First sweep: peek at every key to classify the table. We don't
+    // start emitting until we know which container to build, because
+    // a half-encoded array can't be promoted to an object.
+    let mut max_int: i64 = 0;
+    let mut int_count: usize = 0;
+    let mut has_string_key = false;
+    for pair in table.clone().pairs::<mlua::Value, mlua::Value>() {
+        let (k, _) = pair?;
+        match k {
+            mlua::Value::Integer(i) if i >= 1 => {
+                int_count += 1;
+                if i > max_int {
+                    max_int = i;
+                }
+            }
+            mlua::Value::String(_) => has_string_key = true,
+            mlua::Value::Integer(_) | mlua::Value::Number(_) => {
+                return Err(mlua::Error::external(
+                    "ttymap.json:stringify: table has non-positive numeric key",
+                ));
+            }
+            other => {
+                return Err(mlua::Error::external(format!(
+                    "ttymap.json:stringify: table has unsupported key type {}",
+                    other.type_name()
+                )));
+            }
+        }
+    }
+
+    let is_pure_array = int_count > 0 && !has_string_key && max_int as usize == int_count;
+    let is_pure_object = has_string_key && int_count == 0;
+    let is_empty = int_count == 0 && !has_string_key;
+
+    if is_empty {
+        // Empty Lua table → empty JSON object. Lua plugins overwhelm-
+        // ingly use `{}` to mean "object I haven't put anything in
+        // yet" (see config tables, opts arguments). The asymmetric
+        // rare case — empty array — can be expressed by stringifying
+        // a populated array; round-trip preserves it.
+        return Ok(serde_json::Value::Object(serde_json::Map::new()));
+    }
+
+    if is_pure_array {
+        let mut items = Vec::with_capacity(int_count);
+        for i in 1..=max_int {
+            let v: mlua::Value = table.get(i)?;
+            items.push(lua_to_json(&v)?);
+        }
+        return Ok(serde_json::Value::Array(items));
+    }
+
+    if is_pure_object {
+        let mut map = serde_json::Map::with_capacity(int_count + (has_string_key as usize));
+        for pair in table.clone().pairs::<mlua::String, mlua::Value>() {
+            let (k, v) = pair?;
+            map.insert(k.to_str()?.to_owned(), lua_to_json(&v)?);
+        }
+        return Ok(serde_json::Value::Object(map));
+    }
+
+    Err(mlua::Error::external(
+        "ttymap.json:stringify: table mixes integer and string keys (cannot encode as JSON)",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host() -> mlua::Lua {
+        let lua = mlua::Lua::new();
+        lua.globals()
+            .set("json", lua.create_userdata(HostJson).unwrap())
+            .unwrap();
+        lua
+    }
+
+    #[test]
+    fn stringify_primitives() {
+        let lua = host();
+        let cases = [
+            ("nil", "null"),
+            ("true", "true"),
+            ("false", "false"),
+            ("0", "0"),
+            ("42", "42"),
+            ("-7", "-7"),
+            ("1.5", "1.5"),
+            ("\"hi\"", "\"hi\""),
+            ("\"a\\nb\"", "\"a\\nb\""),
+        ];
+        for (input, want) in cases {
+            let got: String = lua
+                .load(format!("return json:stringify({input})"))
+                .eval()
+                .unwrap_or_else(|e| panic!("stringify({input}): {e}"));
+            assert_eq!(got, want, "stringify({input})");
+        }
+    }
+
+    #[test]
+    fn stringify_array_table() {
+        let lua = host();
+        let got: String = lua.load("return json:stringify({1, 2, 3})").eval().unwrap();
+        assert_eq!(got, "[1,2,3]");
+    }
+
+    #[test]
+    fn stringify_object_table() {
+        let lua = host();
+        // Order is not guaranteed across runs, so parse round-trip
+        // and assert key set instead of literal string match.
+        let got: String = lua
+            .load(r#"return json:stringify({name = "Tokyo", lon = 139.7, lat = 35.6})"#)
+            .eval()
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&got).unwrap();
+        let obj = v.as_object().expect("object");
+        assert_eq!(obj["name"], "Tokyo");
+        assert_eq!(obj["lon"], 139.7);
+        assert_eq!(obj["lat"], 35.6);
+    }
+
+    #[test]
+    fn stringify_nested() {
+        let lua = host();
+        let got: String = lua
+            .load(r#"return json:stringify({{name = "A", lon = 1}, {name = "B", lon = 2}})"#)
+            .eval()
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&got).unwrap();
+        let arr = v.as_array().expect("array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["name"], "A");
+        assert_eq!(arr[1]["lon"], 2);
+    }
+
+    #[test]
+    fn stringify_empty_table_is_object() {
+        // Lua's overwhelming convention for `{}` is "empty object".
+        // Document the choice via test.
+        let lua = host();
+        let got: String = lua.load("return json:stringify({})").eval().unwrap();
+        assert_eq!(got, "{}");
+    }
+
+    #[test]
+    fn stringify_mixed_key_table_errors() {
+        let lua = host();
+        let err = lua
+            .load("return json:stringify({1, 2, name = 'oops'})")
+            .eval::<String>()
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("mixes integer and string keys"),
+            "expected mixed-key error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn stringify_unsupported_function_errors() {
+        let lua = host();
+        let err = lua
+            .load("return json:stringify(function() end)")
+            .eval::<String>()
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unsupported value type"),
+            "expected unsupported-value error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn stringify_nan_and_infinity_become_null() {
+        let lua = host();
+        let nan: String = lua.load("return json:stringify(0/0)").eval().unwrap();
+        let inf: String = lua.load("return json:stringify(1/0)").eval().unwrap();
+        let neg_inf: String = lua.load("return json:stringify(-1/0)").eval().unwrap();
+        assert_eq!(nan, "null");
+        assert_eq!(inf, "null");
+        assert_eq!(neg_inf, "null");
+    }
+
+    #[test]
+    fn stringify_sparse_array_errors() {
+        // {[1]=1, [3]=3} has gap at 2 — not a valid JSON array. Reject
+        // rather than silently fill with null.
+        let lua = host();
+        let err = lua
+            .load("return json:stringify({[1]=1, [3]=3})")
+            .eval::<String>()
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("mixes integer and string keys") || msg.contains("non-positive"),
+            "expected sparse-array rejection, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn round_trip_preserves_types() {
+        let lua = host();
+        // Each script asserts the round-trip on its own value so we
+        // exercise integer / number / bool / string / nested object.
+        lua.load(
+            r#"
+            local input = {
+                name = "Tokyo Tower",
+                lon = 139.7454,
+                lat = 35.6586,
+                zoom = 15,
+                visited = true,
+                tags = { "tower", "landmark" },
+            }
+            local s = json:stringify(input)
+            local out = json:parse(s)
+            assert(out.name == input.name, "name")
+            assert(out.lon == input.lon, "lon")
+            assert(out.lat == input.lat, "lat")
+            assert(out.zoom == input.zoom, "zoom")
+            assert(out.visited == input.visited, "visited")
+            assert(#out.tags == 2, "tags len")
+            assert(out.tags[1] == "tower", "tags[1]")
+            assert(out.tags[2] == "landmark", "tags[2]")
+            "#,
+        )
+        .exec()
+        .unwrap();
     }
 }

--- a/ttymap-tui/src/lua/api/mod.rs
+++ b/ttymap-tui/src/lua/api/mod.rs
@@ -39,6 +39,10 @@
 //!                                            new-centre / old-zoom frame)
 //! ttymap.map    :center() -> lon, lat       latest centre, refreshed per dispatch
 //! ttymap.json   :parse(s) -> value|nil      JSON → Lua tables (errors → nil)
+//! ttymap.json   :stringify(value) -> string Lua → JSON (mixed-key tables /
+//!                                            function / userdata → error;
+//!                                            NaN / Infinity → null;
+//!                                            empty `{}` → empty object)
 //! ttymap.sgp4   :parse_tle(text) -> handle  parse a TLE for SGP4 propagation
 //! ttymap.sgp4   :parse_tles(text) -> array  parse a multi-TLE block (groups)
 //! ttymap.sgp4   :propagate(h[, t]) -> table propagate a handle to unix time t


### PR DESCRIPTION
## Summary

- Add `ttymap.json:stringify(value) -> string` — the missing pair to `:parse`.
- Strict type rules: mixed-key tables / function / userdata / sparse arrays → error; NaN / Infinity → null; empty `{}` → empty JSON object.
- `lua_to_json` is exposed at `pub(crate)` so the upcoming `ttymap.storage` (#194) can reuse it.

Closes #213.

## Test plan

- [x] `cargo test -p ttymap-tui --lib lua::api::json` — 10/10 new tests pass (round-trip, mixed-key error, sparse-array error, unsupported-value error, NaN/Inf → null, empty-table → object, primitives, array, object, nested).
- [x] `cargo test --workspace` — full suite green.
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

## Design notes

- **Empty `{}` → object, not array.** Lua's overwhelming convention for `{}` is "empty object I haven't filled yet"; choosing object means `{name=…}` and `{}` agree on shape. The rare empty-array case can be expressed by stringifying a populated array first.
- **Sparse arrays are rejected**, not back-filled with null. A `{[1]=1, [3]=3}` table is never the user's intent; silent null-fill would corrupt persisted state.
- **NaN / Infinity → null**, not error. JSON has no representation for them; one bad cell shouldn't sink the entire encode.