### PR TITLE
feat(net): per-host rate limit + Retry-After for third-party APIs (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,23 @@ Rust 2024 edition. The build uses `protox` so no system `protoc` is needed.
 - **[docs/lua-architecture.md](docs/lua-architecture.md)** — plugin authoring guide: `ttymap.api.*` surface, shared libraries (`ttymap.fmt` / `.sidebar` / `.animation` / `.director`), plugin shapes, dispatcher semantics.
 - **[docs/design.md](docs/design.md)** — load-bearing design decisions (UserCommand vs direct call, controller split, Drop-based cleanup).
 
+## Third-party services
+
+ttymap talks to a few public APIs out of the box. The Rust HTTP layer caps per-host request rates globally (token bucket per host suffix in `ttymap-engine/src/shared/http/rate_limit.rs`) so usage from many users stays within published limits, but for **heavy / automated use you should run your own**.
+
+- **Tiles** — default source is **`http://mapscii.me/`** (vector tiles, OpenMapTiles schema). Fine for casual use; for scripted overlays that pan continuously, anything multi-host, or anything you'd be uncomfortable having attributed to your IP, host your own. Alternate backends are in flight ([#30](https://github.com/Kohei-Wada/ttymap/issues/30) MBTiles, [#31](https://github.com/Kohei-Wada/ttymap/issues/31) PMTiles).
+- **Forward geocoding** (search palette) — public **Nominatim** (`https://nominatim.openstreetmap.org`). Capped at **1 rps globally** per [OSMF policy](https://operations.osmfoundation.org/policies/nominatim/). Override in `init.lua` to point at a private instance:
+  ```lua
+  require("ttymap.search").endpoint = "https://my-nominatim.example.com/search"
+  ```
+- **IP geolocation** (`--here`) — public **`ipapi.co`**. One-shot, on startup only.
+- **Wikipedia / Wikimedia** (wiki plugin) — `*.wikipedia.org` capped at **5 rps globally** (self-imposed safety margin; Wikipedia has no hard QPS but advises against bursts).
+- **Earthquake feed** (quake plugin) — USGS public summary feed (no rate limit; their CDN handles it).
+- **Aircraft** (aircraft plugin) — OpenSky anonymous endpoint ([#98](https://github.com/Kohei-Wada/ttymap/issues/98) tracks the strict daily quota — register an API key for higher limits).
+- **Satellites** (satellite plugin) — CelesTrak TLE feed; refresh window is hours, not seconds.
+
+User-Agent on every request is `ttymap/<version> (https://github.com/Kohei-Wada/ttymap)` so upstream operators can tell us apart from anonymous traffic.
+
 ## Origin
 
 ttymap started as a Rust port of [mapscii](https://github.com/rastapasta/mapscii) — same Braille rendering, same MVT pipeline, same vim-style nav. The Lua plugin runtime and the scriptable-scenes layer (animation + director) grew on top once the engine was solid; the result is a different category of tool now, but mapscii is the seed and deserves the credit.

--- a/ttymap-engine/src/shared/http/mod.rs
+++ b/ttymap-engine/src/shared/http/mod.rs
@@ -5,13 +5,35 @@
 //! domain (nominatim, wiki, tile, …) constructs its own instance with
 //! a `tag` used as the log prefix, then calls `get_json` / `get_bytes`.
 
+pub mod rate_limit;
 pub mod url;
 
 use std::fmt;
+use std::thread;
 use std::time::Duration;
 
 use log::debug;
 use serde::de::DeserializeOwned;
+
+/// Cap for `Retry-After`-driven retries. We honour the upstream's
+/// requested wait once; if the *retry* also returns 429/503 we
+/// surface the error rather than loop indefinitely. One honour is
+/// enough to absorb the common "you broke a token-bucket window"
+/// case without giving a sustained-overload upstream a way to
+/// pin our worker thread.
+const MAX_RETRY_AFTER_HONOURS: u32 = 1;
+
+/// Fallback sleep when `Retry-After` is absent / unparseable. Long
+/// enough that we don't immediately retry on the same window, short
+/// enough that the user isn't waiting on something that's never
+/// coming back.
+const DEFAULT_RETRY_AFTER: Duration = Duration::from_secs(1);
+
+/// Hard ceiling on `Retry-After` waits. An adversarial server
+/// asking us to sleep for an hour would otherwise pin a worker
+/// thread; we cap at a value the user might plausibly tolerate
+/// before they give up on the fetch.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(30);
 
 const USER_AGENT: &str = concat!(
     "ttymap/",
@@ -69,16 +91,13 @@ impl HttpClient {
     /// GET + deserialize as JSON. Low-level `debug!` is emitted per
     /// failure so offline debugging has URL + tag context; callers
     /// get a classified [`FetchError`] for policy decisions.
+    ///
+    /// Rate-limited per third-party-API ToS — see
+    /// [`rate_limit`] for the host registry. 429 / 503 responses
+    /// are honoured once via the `Retry-After` header; further
+    /// rate-limit responses surface as [`FetchError::Http`].
     pub fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T, FetchError> {
-        let response = self.inner.get(url).send().map_err(|e| {
-            debug!("{}: {}: request error: {}", self.tag, url, e);
-            FetchError::Network(e.to_string())
-        })?;
-        if !response.status().is_success() {
-            let status = response.status();
-            debug!("{}: {}: status {}", self.tag, url, status);
-            return Err(FetchError::Http(status.as_u16()));
-        }
+        let response = self.send_with_retry(url)?;
         response.json().map_err(|e| {
             debug!("{}: {}: parse error: {}", self.tag, url, e);
             FetchError::Parse(e.to_string())
@@ -87,7 +106,20 @@ impl HttpClient {
 
     /// GET + raw bytes. Body-streaming failures are reported as
     /// [`FetchError::Network`] (mid-stream disconnects are networky).
+    /// Same rate-limiting / retry policy as [`Self::get_json`].
     pub fn get_bytes(&self, url: &str) -> Result<Vec<u8>, FetchError> {
+        let response = self.send_with_retry(url)?;
+        response.bytes().map(|b| b.to_vec()).map_err(|e| {
+            debug!("{}: {}: body error: {}", self.tag, url, e);
+            FetchError::Network(e.to_string())
+        })
+    }
+
+    /// Single GET attempt, post-rate-limit. Returns the success
+    /// response or maps the error into [`FetchError`] with the same
+    /// debug-log shape as before.
+    fn send_once(&self, url: &str) -> Result<reqwest::blocking::Response, FetchError> {
+        rate_limit::limiter().acquire_for(url);
         let response = self.inner.get(url).send().map_err(|e| {
             debug!("{}: {}: request error: {}", self.tag, url, e);
             FetchError::Network(e.to_string())
@@ -97,10 +129,65 @@ impl HttpClient {
             debug!("{}: {}: status {}", self.tag, url, status);
             return Err(FetchError::Http(status.as_u16()));
         }
-        response.bytes().map(|b| b.to_vec()).map_err(|e| {
-            debug!("{}: {}: body error: {}", self.tag, url, e);
-            FetchError::Network(e.to_string())
-        })
+        Ok(response)
+    }
+
+    /// Retry-After-aware wrapper around [`Self::send_once`]. On 429
+    /// or 503 we look at the `Retry-After` header (delta-seconds or
+    /// HTTP-date), sleep up to [`MAX_RETRY_AFTER`], and retry once.
+    /// Any other error short-circuits.
+    fn send_with_retry(&self, url: &str) -> Result<reqwest::blocking::Response, FetchError> {
+        let mut honours = 0;
+        loop {
+            match self.send_once(url) {
+                Ok(r) => return Ok(r),
+                Err(FetchError::Http(status))
+                    if (status == 429 || status == 503) && honours < MAX_RETRY_AFTER_HONOURS =>
+                {
+                    // We can't read `Retry-After` from a `FetchError::Http`
+                    // (it discards the response), so re-issue the
+                    // request through reqwest directly to peek the
+                    // header before sleeping. Slightly wasteful but
+                    // keeps `send_once`'s shape simple, and the
+                    // re-issue happens only on the rate-limit path.
+                    let wait = self
+                        .peek_retry_after(url, status)
+                        .unwrap_or(DEFAULT_RETRY_AFTER);
+                    let wait = wait.min(MAX_RETRY_AFTER);
+                    debug!(
+                        "{}: {}: {} → honouring Retry-After {:?}",
+                        self.tag, url, status, wait
+                    );
+                    thread::sleep(wait);
+                    honours += 1;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Re-issue a HEAD-equivalent fetch only to read `Retry-After`.
+    /// Returns `None` if the header is absent or unparseable; the
+    /// caller falls back to [`DEFAULT_RETRY_AFTER`]. We do a GET
+    /// (not HEAD) because some servers reject HEAD on rate-limited
+    /// endpoints — and we already paid the rate-limit cost the
+    /// first time.
+    fn peek_retry_after(&self, url: &str, expected_status: u16) -> Option<Duration> {
+        rate_limit::limiter().acquire_for(url);
+        let response = self.inner.get(url).send().ok()?;
+        if response.status().as_u16() != expected_status {
+            return None;
+        }
+        let header = response.headers().get(reqwest::header::RETRY_AFTER)?;
+        let raw = header.to_str().ok()?;
+        // Delta-seconds form (the common case for token-bucket APIs).
+        if let Ok(secs) = raw.trim().parse::<u64>() {
+            return Some(Duration::from_secs(secs));
+        }
+        // HTTP-date form. We don't pull a date parser for this; if
+        // the server insists on a date format the fallback is fine.
+        None
     }
 }
 

--- a/ttymap-engine/src/shared/http/rate_limit.rs
+++ b/ttymap-engine/src/shared/http/rate_limit.rs
@@ -1,0 +1,326 @@
+//! Process-wide HTTP rate limiter.
+//!
+//! ttymap fans out HTTP fetches from many places (engine tile
+//! pipeline, every Lua plugin via `ttymap.http:fetch`, geoip
+//! resolver, …). Each clones an [`HttpClient`] but they all need to
+//! respect a *global* per-host cap — Nominatim's policy is "1
+//! request / second across all of your code", not "1 / second per
+//! consumer". So the bucket map lives in a process-wide singleton,
+//! not per `HttpClient` instance.
+//!
+//! Default registry covers the two upstreams ttymap actively
+//! disagrees with by ToS:
+//!
+//! - `nominatim.openstreetmap.org` — **1 rps** (OSM Foundation
+//!   policy, see <https://operations.osmfoundation.org/policies/nominatim/>).
+//! - `*.wikipedia.org` / `*.wikimedia.org` — **5 rps** as a self-
+//!   imposed safety margin; Wikipedia has no hard QPS but bursts
+//!   over ~200/s from one IP risk a temporary block.
+//!
+//! Hosts that don't match any registered suffix pass through with no
+//! rate limit. mapscii.me tile fetches are intentionally not in the
+//! registry — the upstream has no published cap and the worker pool
+//! already bounds in-flight count.
+//!
+//! A user pointing at a private Nominatim (e.g. via the search
+//! plugin's Lua-side `require("ttymap.search").endpoint = "..."`)
+//! automatically falls through the registry and runs unthrottled —
+//! that's the right default for self-hosted infrastructure.
+//!
+//! Implementation is a token bucket per host: `acquire_for` blocks
+//! until a token is available, then consumes one. Refill happens
+//! lazily on each `acquire` call; no background thread.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// One token bucket. `acquire` blocks (with `thread::sleep`) until
+/// `tokens >= 1`, then decrements. Lazy refill keeps the bucket
+/// thread-light — no timer, no background work.
+struct TokenBucket {
+    capacity: f64,
+    tokens: f64,
+    refill_per_sec: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(capacity: f64, refill_per_sec: f64) -> Self {
+        Self {
+            capacity,
+            tokens: capacity,
+            refill_per_sec,
+            last_refill: Instant::now(),
+        }
+    }
+
+    fn refill(&mut self) {
+        let now = Instant::now();
+        let dt = now
+            .saturating_duration_since(self.last_refill)
+            .as_secs_f64();
+        if dt > 0.0 {
+            self.tokens = (self.tokens + dt * self.refill_per_sec).min(self.capacity);
+            self.last_refill = now;
+        }
+    }
+
+    /// How long until the bucket has at least one token, given the
+    /// current tokens count and refill rate. Returns zero when a
+    /// token is available now.
+    fn time_until_token(&self) -> Duration {
+        if self.tokens >= 1.0 {
+            return Duration::ZERO;
+        }
+        let needed = 1.0 - self.tokens;
+        let secs = needed / self.refill_per_sec;
+        Duration::from_secs_f64(secs)
+    }
+
+    fn consume(&mut self) {
+        self.tokens -= 1.0;
+    }
+}
+
+/// Per-host registry. `Mutex<HashMap<...>>` rather than a lock-free
+/// map because the hot path is "one bucket, many hits" — contention
+/// is on the bucket, not the map.
+pub struct RateLimiter {
+    by_suffix: Mutex<HashMap<&'static str, Mutex<TokenBucket>>>,
+}
+
+impl RateLimiter {
+    fn empty() -> Self {
+        Self {
+            by_suffix: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn with_defaults() -> Self {
+        let r = Self::empty();
+        r.register("nominatim.openstreetmap.org", 1.0, 1.0);
+        // 5 rps for Wikipedia / Wikimedia — capacity 5 lets a burst
+        // through for the wiki plugin's geosearch + extracts pair
+        // (two hits per refresh) without per-call queueing.
+        r.register("wikipedia.org", 5.0, 5.0);
+        r.register("wikimedia.org", 5.0, 5.0);
+        r
+    }
+
+    /// Register (or replace) a token bucket for a host suffix. The
+    /// suffix matches with a leading-dot or full-equality check, so
+    /// `"wikipedia.org"` covers `en.wikipedia.org`, `ja.wikipedia.org`,
+    /// and the bare host.
+    pub fn register(&self, suffix: &'static str, capacity: f64, refill_per_sec: f64) {
+        let mut map = self.by_suffix.lock().expect("rate-limiter map poisoned");
+        map.insert(
+            suffix,
+            Mutex::new(TokenBucket::new(capacity, refill_per_sec)),
+        );
+    }
+
+    /// Block until a token is available for the host of `url`. If no
+    /// suffix matches, returns immediately (no rate limit).
+    pub fn acquire_for(&self, url: &str) {
+        let host = match host_from_url(url) {
+            Some(h) => h,
+            None => return,
+        };
+        let map = self.by_suffix.lock().expect("rate-limiter map poisoned");
+        let suffix = map.keys().copied().find(|s| host_matches(host, s));
+        let suffix = match suffix {
+            Some(s) => s,
+            None => return,
+        };
+        // Drop the outer map lock before sleeping on the inner
+        // bucket — otherwise an N-rps bucket on host A would stall
+        // unrelated host B's lookup. The two-phase lock is the
+        // whole reason the inner bucket has its own Mutex.
+        //
+        // We can't hold a reference into `map` past the drop, so
+        // copy the suffix key out and re-look up the bucket on a
+        // fresh borrow each spin. `register()` is rare and only
+        // adds entries, so the ref stays valid; the cost of the
+        // re-lookup is one HashMap probe per ~tens of milliseconds
+        // of sleep, dwarfed by the sleep itself.
+        drop(map);
+        loop {
+            let map = self.by_suffix.lock().expect("rate-limiter map poisoned");
+            let bucket_mutex = match map.get(suffix) {
+                Some(b) => b,
+                None => return, // entry was somehow removed — give up the limit
+            };
+            let mut bucket = bucket_mutex.lock().expect("rate-limiter bucket poisoned");
+            bucket.refill();
+            if bucket.tokens >= 1.0 {
+                bucket.consume();
+                return;
+            }
+            let wait = bucket.time_until_token();
+            // Drop both locks before sleeping so other hosts can
+            // make progress.
+            drop(bucket);
+            drop(map);
+            thread::sleep(wait);
+        }
+    }
+}
+
+/// Extract the host segment of a URL. Lightweight parser — we don't
+/// pull `url::Url` for one field. Returns `None` for inputs that
+/// don't look like an absolute URL (relative paths, malformed input);
+/// callers treat that as "no rate limit applies" because there's no
+/// host to bucket on.
+fn host_from_url(url: &str) -> Option<&str> {
+    let after_scheme = url.split_once("://")?.1;
+    let host_with_path = after_scheme
+        .split_once('/')
+        .map_or(after_scheme, |(h, _)| h);
+    // Strip optional userinfo (user:pass@host) and port (host:port).
+    let host_with_port = host_with_path
+        .rsplit_once('@')
+        .map_or(host_with_path, |(_, h)| h);
+    let host = host_with_port
+        .split_once(':')
+        .map_or(host_with_port, |(h, _)| h);
+    if host.is_empty() { None } else { Some(host) }
+}
+
+/// `host_matches("en.wikipedia.org", "wikipedia.org")` → true;
+/// `host_matches("evilwikipedia.org", "wikipedia.org")` → false.
+/// The dot guard prevents the substring trick where a malicious host
+/// suffix-matches a legitimate one without sharing the actual domain
+/// boundary.
+fn host_matches(host: &str, suffix: &str) -> bool {
+    if host == suffix {
+        return true;
+    }
+    if host.len() <= suffix.len() {
+        return false;
+    }
+    let split = host.len() - suffix.len();
+    host.as_bytes().get(split - 1) == Some(&b'.') && &host[split..] == suffix
+}
+
+/// Process-wide singleton. Initialised lazily on first `acquire_for`.
+static RATE_LIMITER: OnceLock<RateLimiter> = OnceLock::new();
+
+pub fn limiter() -> &'static RateLimiter {
+    RATE_LIMITER.get_or_init(RateLimiter::with_defaults)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn host_from_url_extracts_host() {
+        assert_eq!(
+            host_from_url("https://example.com/path"),
+            Some("example.com")
+        );
+        assert_eq!(
+            host_from_url("http://en.wikipedia.org/wiki/X"),
+            Some("en.wikipedia.org")
+        );
+        assert_eq!(host_from_url("https://host:8080/"), Some("host"));
+        assert_eq!(
+            host_from_url("https://user:pw@host.example/"),
+            Some("host.example")
+        );
+        assert_eq!(
+            host_from_url("https://only-host-no-path"),
+            Some("only-host-no-path")
+        );
+        assert_eq!(host_from_url("not-a-url"), None);
+        assert_eq!(host_from_url("///path-only"), None);
+    }
+
+    #[test]
+    fn host_matches_requires_dot_boundary() {
+        assert!(host_matches("wikipedia.org", "wikipedia.org"));
+        assert!(host_matches("en.wikipedia.org", "wikipedia.org"));
+        assert!(host_matches("a.b.wikipedia.org", "wikipedia.org"));
+        // The dot-guard rejects this one — substring match without
+        // a real domain boundary.
+        assert!(!host_matches("evilwikipedia.org", "wikipedia.org"));
+        assert!(!host_matches("wikipedia.org.evil.com", "wikipedia.org"));
+        assert!(!host_matches("notthesame.org", "wikipedia.org"));
+        assert!(!host_matches("short", "wikipedia.org"));
+    }
+
+    #[test]
+    fn token_bucket_acquire_returns_immediately_when_token_available() {
+        let r = RateLimiter::empty();
+        r.register("example.com", 5.0, 1.0); // 5 burst, 1 rps refill
+        let start = Instant::now();
+        r.acquire_for("https://example.com/x");
+        r.acquire_for("https://example.com/x");
+        r.acquire_for("https://example.com/x");
+        // Three immediate acquisitions out of capacity 5 should be
+        // effectively instant — tolerate up to 50 ms of scheduler noise.
+        assert!(
+            start.elapsed() < Duration::from_millis(50),
+            "elapsed = {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn token_bucket_acquire_blocks_when_empty() {
+        // capacity 1, refill 5 rps → 200 ms between tokens. After
+        // consuming the initial token, the next acquire must wait
+        // ~200 ms.
+        let r = RateLimiter::empty();
+        r.register("example.com", 1.0, 5.0);
+        r.acquire_for("https://example.com/x"); // consume initial token
+        let start = Instant::now();
+        r.acquire_for("https://example.com/x");
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(150),
+            "expected ~200 ms wait, got {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < Duration::from_millis(400),
+            "wait was longer than expected: {:?}",
+            elapsed
+        );
+    }
+
+    #[test]
+    fn unregistered_host_passes_through() {
+        let r = RateLimiter::empty();
+        r.register("example.com", 1.0, 0.001); // very slow refill, but unrelated
+        let start = Instant::now();
+        for _ in 0..50 {
+            r.acquire_for("https://other-host.invalid/x");
+        }
+        assert!(
+            start.elapsed() < Duration::from_millis(50),
+            "elapsed = {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn suffix_matches_subdomains() {
+        // Wikipedia rule should cover en.wikipedia.org without
+        // a separate registration.
+        let r = RateLimiter::empty();
+        r.register("wikipedia.org", 1.0, 5.0);
+        r.acquire_for("https://en.wikipedia.org/x"); // consume
+        let start = Instant::now();
+        r.acquire_for("https://ja.wikipedia.org/x");
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(150),
+            "subdomain should share bucket; elapsed = {:?}",
+            elapsed
+        );
+    }
+}

--- a/ttymap-tui/runtime/lua/plugin/search/nominatim.lua
+++ b/ttymap-tui/runtime/lua/plugin/search/nominatim.lua
@@ -1,17 +1,23 @@
 -- search.nominatim — Nominatim forward-geocoding REST client.
 --
--- Source: https://nominatim.openstreetmap.org/search
--- Free public endpoint; debounce keeps it from being hammered while
--- the user types.
+-- Endpoint is read from `ttymap.search.endpoint` (default points at
+-- the public OSM Nominatim instance, rate-limited to 1 rps by the
+-- Rust HTTP layer per OSMF policy). Users with a private Nominatim
+-- override via `require("ttymap.search").endpoint = "..."` in
+-- init.lua; the change takes effect on the next query — no restart.
+--
+-- Debounce in the search palette keeps the same prefix from being
+-- re-fetched per keystroke; the rate-limiter is the global cap.
+
+local config = require "ttymap.search"
 
 local M = {}
 
-local SEARCH_URL = "https://nominatim.openstreetmap.org/search"
 local LIMIT = 5
 
 function M.url(query)
     return string.format("%s?q=%s&format=json&limit=%d",
-        SEARCH_URL, ttymap.http:url_encode(query), LIMIT)
+        config.endpoint, ttymap.http:url_encode(query), LIMIT)
 end
 
 function M.parse(payload)

--- a/ttymap-tui/runtime/lua/ttymap/search.lua
+++ b/ttymap-tui/runtime/lua/ttymap/search.lua
@@ -1,0 +1,27 @@
+-- ttymap.search — config holder for the bundled `search` plugin.
+--
+-- Lua-side seam for users who want a different forward-geocoder
+-- endpoint (private Nominatim, alternative provider with the same
+-- response shape, etc.) without shadowing the whole plugin file.
+--
+-- nvim-style: this module returns one cached table; the plugin
+-- requires the same table on activation, so any pre-pass mutation
+-- in init.lua is visible:
+--
+--     -- ~/.config/ttymap/init.lua
+--     require("ttymap.search").endpoint = "https://my-nominatim/search"
+--
+-- The bundled plugin reads `endpoint` on every fetch, so the
+-- override applies immediately on next query — no restart needed.
+--
+-- Default endpoint is the public OSM Nominatim instance, which is
+-- rate-limited to 1 rps by `ttymap-engine`'s shared HTTP client per
+-- the OSM Foundation usage policy
+-- (https://operations.osmfoundation.org/policies/nominatim/).
+-- Pointing at a self-hosted endpoint falls through the rate-limit
+-- registry on the Rust side (host suffix doesn't match
+-- `nominatim.openstreetmap.org`) and runs unthrottled.
+
+return {
+    endpoint = "https://nominatim.openstreetmap.org/search",
+}


### PR DESCRIPTION
## Summary

Closes #79.

ttymap fans out HTTP from many places (engine tile pipeline, every Lua plugin via `ttymap.http:fetch`, geoip resolver). Without a global per-host cap, uncoordinated requests across all of our users would have got the public Nominatim / Wikipedia upstreams to block ttymap's User-Agent — which kills it for everyone.

This PR adds:

- **Process-wide token bucket per host suffix** (`ttymap-engine/src/shared/http/rate_limit.rs`). Lazy refill, no background thread. Defaults:
  - `nominatim.openstreetmap.org` → **1 rps** (OSMF policy: <https://operations.osmfoundation.org/policies/nominatim/>)
  - `*.wikipedia.org` / `*.wikimedia.org` → **5 rps** (self-imposed safety margin)
- **Retry-After honour on 429 / 503**: parse `delta-seconds`, sleep up to 30 s, retry once. Further rate-limit responses surface as `FetchError::Http`.
- **Suffix matcher with dot-boundary guard** so `evilwikipedia.org` can't ride `wikipedia.org`'s bucket (`host_matches` test covers this).

Per-plugin endpoint config moves to **Lua-side** (`runtime/lua/ttymap/search.lua`) instead of adding a Rust `[geocoder]` section — `geocoder` / `nominatim` etc. are specific third-party API names that don't belong in the Rust API surface. Users override:

```lua
require("ttymap.search").endpoint = "https://my-nominatim.example.com/search"
```

A self-hosted endpoint falls through the rate-limit registry (host suffix doesn't match) and runs unthrottled — the right default for private infrastructure.

User-Agent (\`ttymap/<version> (https://github.com/Kohei-Wada/ttymap)\`) already met the issue's third acceptance criterion; verified, no change.

README gains a **Third-party services** section enumerating each upstream we talk to, its rate cap, and the override pattern for self-hosting.

## Acceptance criteria (issue #79)

- [x] Token-bucket rate limiter shared across the process (1 rps Nominatim, 5 rps Wikipedia)
- [x] 429 / 503 responses honored via \`Retry-After\`
- [x] User-Agent string includes project URL and version (auto from \`env!(\"CARGO_PKG_*\")\`)
- [x] README mentions default tile source is mapscii.me and encourages users to self-host for heavy use
- [x] Config option for private Nominatim — implemented as Lua-side \`require(\"ttymap.search\").endpoint\` instead of a Rust \`[geocoder]\` section (see design note above)

## Test plan

- [x] \`cargo test -p ttymap-engine --lib shared::http::rate_limit\` — 6/6 new tests (host parsing, dot-boundary, immediate-acquire, blocking-acquire, unregistered-passthrough, subdomain-shares-bucket)
- [x] \`cargo test --workspace\` — 222 + 216 pass
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean