### PR TITLE
feat(cli): ttymap api-info dumps Lua API spec as JSON (#300)

### DIFF
--- a/ttymap-tui/Cargo.toml
+++ b/ttymap-tui/Cargo.toml
@@ -35,7 +35,7 @@ crossterm = "0.29"
 ratatui = "0.30"
 clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.12", features = ["blocking", "json"] }
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 directories = "6"
 unicode-width = "0.2"

--- a/ttymap-tui/src/cli/api_info.rs
+++ b/ttymap-tui/src/cli/api_info.rs
@@ -1,0 +1,72 @@
+//! `ttymap api-info` — dump the machine-readable API spec as JSON.
+//!
+//! Mirrors `nvim --api-info`. External clients (the future
+//! `ttymap-mcp` server, editor plugins, out-of-process scripts) call
+//! this once at startup to discover the `ttymap.api.*` surface without
+//! parsing Rust source or hand-written markdown.
+//!
+//! Headless: doesn't touch the terminal, doesn't load Lua, doesn't
+//! resolve a runtime path — the spec lives entirely in compile-time
+//! `&'static` data structures (see [`crate::lua::api::spec`]).
+
+use clap::Args;
+
+use crate::lua::api::spec;
+
+#[derive(Args)]
+pub struct ApiInfoArgs {
+    /// Pretty-print the JSON output (multi-line, 2-space indent).
+    /// Off by default so piping into `jq` stays as fast as possible.
+    #[arg(long)]
+    pub pretty: bool,
+}
+
+pub fn run(args: ApiInfoArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let info = spec::all();
+    let json = if args.pretty {
+        serde_json::to_string_pretty(&info)?
+    } else {
+        serde_json::to_string(&info)?
+    };
+    println!("{json}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `ttymap api-info` (compact) round-trips through `serde_json` and
+    /// the resulting object names every namespace `spec::all()`
+    /// declares. Catches both "Serialize derive missing" and "aggregator
+    /// silently dropped a namespace" regressions.
+    #[test]
+    fn run_emits_json_listing_every_aggregated_namespace() {
+        let info = spec::all();
+        let json = serde_json::to_string(&info).expect("serialise");
+        // Each namespace path must appear verbatim in the output.
+        for ns in &info.namespaces {
+            assert!(
+                json.contains(ns.path),
+                "namespace path `{}` missing from output: {json}",
+                ns.path,
+            );
+        }
+        // Format version is part of the contract — assert it lands at
+        // the top level so clients can branch on it.
+        assert!(
+            json.contains(&format!("\"version\":\"{}\"", spec::SPEC_VERSION)),
+            "version field missing or wrong shape: {json}",
+        );
+    }
+
+    /// Pretty mode produces multi-line output (compact mode is one
+    /// line). Quick smoke test — protects against `--pretty` silently
+    /// degrading to compact.
+    #[test]
+    fn pretty_mode_is_multiline() {
+        let info = spec::all();
+        let pretty = serde_json::to_string_pretty(&info).expect("serialise");
+        assert!(pretty.contains('\n'), "pretty output should be multi-line");
+    }
+}

--- a/ttymap-tui/src/cli/mod.rs
+++ b/ttymap-tui/src/cli/mod.rs
@@ -29,17 +29,23 @@ impl Command {
             Self::ApiInfo(args) => api_info::run(args),
         }
     }
+}
 
-    /// Whether this subcommand needs `lua::resolve_runtime_path` /
-    /// `set_runtime_path` to have run before [`Self::run`]. `snap`
-    /// reads init.lua for config knobs, so it does. `api-info` is a
-    /// pure metadata dump from compile-time `&'static` data — it must
-    /// keep working on a freshly-installed system that has nothing in
-    /// `~/.config/ttymap` or `~/.local/share/ttymap` yet.
-    pub fn needs_runtime(&self) -> bool {
-        match self {
-            Self::Snap(_) => true,
-            Self::ApiInfo(_) => false,
+/// Resolve and cache the layered runtime path. Aborts the process
+/// with a one-line message if every layer is missing — there's no
+/// graceful degradation for callers that need init.lua to load.
+///
+/// Each subcommand calls this itself (the headless `snap` wants
+/// init.lua-tunable config; `api-info` doesn't and skips the call).
+/// Same goes for the interactive event loop. Keeping the call inside
+/// the consumer matches "each subcommand owns its setup" — the binary
+/// entry is just a dispatcher.
+pub fn init_runtime_or_exit() {
+    match crate::lua::resolve_runtime_path() {
+        Ok(p) => crate::lua::set_runtime_path(p),
+        Err(e) => {
+            eprintln!("ttymap: {}", e);
+            std::process::exit(1);
         }
     }
 }

--- a/ttymap-tui/src/cli/mod.rs
+++ b/ttymap-tui/src/cli/mod.rs
@@ -9,6 +9,7 @@
 
 use clap::Subcommand;
 
+pub mod api_info;
 pub mod snap;
 
 #[derive(Subcommand)]
@@ -16,12 +17,29 @@ pub enum Command {
     /// Render a single map snapshot as ANSI text (headless).
     #[command(alias = "snapshot")]
     Snap(snap::SnapArgs),
+    /// Dump the machine-readable Lua API spec as JSON.
+    #[command(name = "api-info")]
+    ApiInfo(api_info::ApiInfoArgs),
 }
 
 impl Command {
     pub fn run(self) -> Result<(), Box<dyn std::error::Error>> {
         match self {
             Self::Snap(args) => snap::run(args),
+            Self::ApiInfo(args) => api_info::run(args),
+        }
+    }
+
+    /// Whether this subcommand needs `lua::resolve_runtime_path` /
+    /// `set_runtime_path` to have run before [`Self::run`]. `snap`
+    /// reads init.lua for config knobs, so it does. `api-info` is a
+    /// pure metadata dump from compile-time `&'static` data — it must
+    /// keep working on a freshly-installed system that has nothing in
+    /// `~/.config/ttymap` or `~/.local/share/ttymap` yet.
+    pub fn needs_runtime(&self) -> bool {
+        match self {
+            Self::Snap(_) => true,
+            Self::ApiInfo(_) => false,
         }
     }
 }

--- a/ttymap-tui/src/cli/snap.rs
+++ b/ttymap-tui/src/cli/snap.rs
@@ -73,6 +73,11 @@ pub struct SnapArgs {
 }
 
 pub fn run(args: SnapArgs) -> Result<(), Box<dyn std::error::Error>> {
+    // `snap` reads init.lua for tunables, so it needs the layered
+    // runtime path resolved. Each subcommand owns its setup — the
+    // binary entry doesn't pre-resolve on our behalf.
+    super::init_runtime_or_exit();
+
     // snap is headless and doesn't activate plugins, so we use the
     // config-only init.lua entry (no API install, no plugin requires).
     // `Config` carries every init.lua-tunable knob (cache / render);

--- a/ttymap-tui/src/lua/api/map.rs
+++ b/ttymap-tui/src/lua/api/map.rs
@@ -34,9 +34,95 @@ use mlua::{Lua, Scope, Table, UserData};
 use crate::UserCommand;
 use crate::compositor::op::{Op, OpsBuffer};
 use crate::lua::MapApi;
+use crate::lua::api::spec::{MethodSpec, NamespaceSpec, ParamSpec};
 use crate::lua::map_api::Anchor;
 use ttymap_engine::geo::LonLat;
 use ttymap_engine::map::MapAction;
+
+// ── ttymap.map machine-readable spec ────────────────────────────────
+//
+// Describes the **persistent `ttymap.map` userdata** (`HostMap`) only.
+// The per-frame `map` table handed to `on_tick` callbacks
+// (`make_map_table`) is a distinct surface and gets its own spec when
+// issue #300 ships the rest of the rollout.
+
+/// Describe the `ttymap.map` namespace for `ttymap api-info`.
+pub fn spec() -> NamespaceSpec {
+    NamespaceSpec {
+        path: "ttymap.map",
+        methods: &[
+            MethodSpec {
+                name: "jump",
+                params: &[
+                    ParamSpec {
+                        name: "lon",
+                        ty: "number",
+                    },
+                    ParamSpec {
+                        name: "lat",
+                        ty: "number",
+                    },
+                ],
+                returns: "nil",
+                doc: "Recentre the map on the given coordinate. \
+                      Fire-and-forget; the host treats it identically \
+                      to a keymap-driven jump.",
+            },
+            MethodSpec {
+                name: "zoom",
+                params: &[ParamSpec {
+                    name: "level",
+                    ty: "number?",
+                }],
+                returns: "number?",
+                doc: "Setter when given a level (clamped host-side, \
+                      fire-and-forget). No-arg form returns the current \
+                      zoom from the shared cell the host refreshes per \
+                      dispatch.",
+            },
+            MethodSpec {
+                name: "fly_to",
+                params: &[
+                    ParamSpec {
+                        name: "lon",
+                        ty: "number",
+                    },
+                    ParamSpec {
+                        name: "lat",
+                        ty: "number",
+                    },
+                    ParamSpec {
+                        name: "zoom",
+                        ty: "number",
+                    },
+                ],
+                returns: "nil",
+                doc: "Composite recenter + zoom in one dispatch — \
+                      avoids the intermediate new-centre / old-zoom \
+                      frame `jump` + `zoom` separately would render.",
+            },
+            MethodSpec {
+                name: "center",
+                params: &[],
+                returns: "(number, number)",
+                doc: "Latest map centre as `lon, lat`. Read from the \
+                      shared cell the host refreshes on every dispatch \
+                      path that carries a `Window` / `MapApi`.",
+            },
+            MethodSpec {
+                name: "set_labels_visible",
+                params: &[ParamSpec {
+                    name: "visible",
+                    ty: "boolean",
+                }],
+                returns: "nil",
+                doc: "Show or hide every tile-rendered text label \
+                      (place names, road names …). Geometry features \
+                      keep rendering. Triggers a redraw automatically.",
+            },
+        ],
+    }
+}
 
 // ── ttymap.map (persistent userdata) ────────────────────────────────
 
@@ -561,6 +647,24 @@ mod tests {
             }
         }
         assert!(found, "expected 'x' cell painted somewhere");
+    }
+
+    /// `spec()` enumerates the persistent `ttymap.map` userdata's
+    /// methods. Order isn't asserted (it's free to grow), but every
+    /// known method must show up — guards against a method being added
+    /// to `add_methods` and silently missed by the spec, which would
+    /// drift `ttymap api-info` output away from runtime reality.
+    #[test]
+    fn spec_lists_every_known_host_map_method() {
+        let s = super::spec();
+        assert_eq!(s.path, "ttymap.map");
+        let names: Vec<&str> = s.methods.iter().map(|m| m.name).collect();
+        for expected in ["jump", "zoom", "fly_to", "center", "set_labels_visible"] {
+            assert!(
+                names.contains(&expected),
+                "spec() missing method `{expected}` — names = {names:?}",
+            );
+        }
     }
 
     /// `map:label(0, 0, "hi", 214)` accepts an integer colour — the

--- a/ttymap-tui/src/lua/api/mod.rs
+++ b/ttymap-tui/src/lua/api/mod.rs
@@ -111,6 +111,7 @@ pub mod http;
 pub mod json;
 pub mod map;
 pub mod sgp4;
+pub mod spec;
 
 mod config;
 mod help;

--- a/ttymap-tui/src/lua/api/spec.rs
+++ b/ttymap-tui/src/lua/api/spec.rs
@@ -1,0 +1,74 @@
+//! Machine-readable spec types for the `ttymap.api.*` surface.
+//!
+//! Each `ttymap-tui/src/lua/api/<ns>.rs` exposes a `pub fn spec() ->
+//! NamespaceSpec` that describes its methods — name, params, return
+//! shape, doc summary. The CLI subcommand `ttymap api-info` (issue
+//! #300) aggregates these and prints JSON; external clients
+//! (`ttymap-mcp`, editor plugins) consume that JSON to discover the
+//! surface without parsing Rust source or hand-written markdown.
+//!
+//! Inspired by `nvim --api-info` — nvim ships per-method metadata
+//! (params, return type, since-version) over its RPC layer, which is
+//! how pynvim and other clients stay in sync without code-generation
+//! per release.
+//!
+//! Everything is `&'static` so each `spec()` is effectively a const
+//! lookup. `ty` strings use Lua's base type names (`number`, `string`,
+//! `boolean`, `table`, `function`, `nil`, `userdata`); add `?` for
+//! optional (`number?`); use a tuple form for multiple returns
+//! (`(number, number)`).
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct NamespaceSpec {
+    /// Lua-side dotted path the namespace surfaces under
+    /// (e.g. `"ttymap.map"`).
+    pub path: &'static str,
+    /// Methods reachable on the namespace. Order is the source-of-truth
+    /// definition order — preserved for stable doc generation.
+    pub methods: &'static [MethodSpec],
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct MethodSpec {
+    pub name: &'static str,
+    pub params: &'static [ParamSpec],
+    /// Lua type name of the return value. Use `"nil"` for fire-and-forget
+    /// methods; `"(t1, t2)"` for multi-return; suffix `?` for optional.
+    pub returns: &'static str,
+    /// One-paragraph summary. Keep it focused on **what** the method
+    /// does and any non-obvious semantics; longer prose belongs in
+    /// `docs/lua-architecture.md`.
+    pub doc: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct ParamSpec {
+    pub name: &'static str,
+    pub ty: &'static str,
+}
+
+/// Top-level dump shape the `ttymap api-info` subcommand serialises.
+/// `version` tracks the spec format itself, **not** the crate version;
+/// bump it when the JSON shape (not its contents) changes so external
+/// clients can branch on incompatibility.
+#[derive(Debug, Clone, Serialize)]
+pub struct ApiInfo {
+    pub version: &'static str,
+    pub namespaces: Vec<NamespaceSpec>,
+}
+
+/// Format version of the JSON dump itself. Bump on shape changes —
+/// adding methods to a namespace doesn't count.
+pub const SPEC_VERSION: &str = "0.1";
+
+/// Aggregate every namespace that has a `spec()`. Listed by hand so
+/// adding a new spec is a one-line edit here; rolling out spec coverage
+/// to the rest of the namespaces is exactly that — append a line.
+pub fn all() -> ApiInfo {
+    ApiInfo {
+        version: SPEC_VERSION,
+        namespaces: vec![super::map::spec()],
+    }
+}

--- a/ttymap-tui/src/main.rs
+++ b/ttymap-tui/src/main.rs
@@ -66,10 +66,33 @@ fn main() {
         eprintln!("ttymap: --log requested but logging init failed: {e}");
     }
 
-    // Resolve runtime path before any Lua state spins up. Both the
-    // interactive app and the `snap` subcommand reach for it; doing
-    // this once at the top means we fail fast with a single error
-    // message rather than hitting the same wall in two places.
+    // Subcommands run a single task and exit without booting the full
+    // interactive app. Runtime path resolution is gated by
+    // `Command::needs_runtime` so pure-metadata subcommands
+    // (`api-info`) work on freshly-installed systems that haven't
+    // populated `~/.config/ttymap` or `~/.local/share/ttymap` yet.
+    if let Some(cmd) = cli.command {
+        if cmd.needs_runtime() {
+            init_runtime_path();
+        }
+        if let Err(e) = cmd.run() {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
+    init_runtime_path();
+    if let Err(e) = run_event_loop(cli) {
+        eprintln!("Error: {e}");
+    }
+}
+
+/// Resolve and cache the layered runtime path. Aborts the process
+/// with a one-line message if every layer is missing — there's no
+/// graceful degradation for the interactive app or for the `snap`
+/// subcommand, both of which need init.lua to load.
+fn init_runtime_path() {
     let runtime_path = match ttymap_tui::lua::resolve_runtime_path() {
         Ok(p) => p,
         Err(e) => {
@@ -78,20 +101,6 @@ fn main() {
         }
     };
     ttymap_tui::lua::set_runtime_path(runtime_path);
-
-    // Subcommands run a single task and exit without booting the full
-    // interactive app.
-    if let Some(cmd) = cli.command {
-        if let Err(e) = cmd.run() {
-            eprintln!("error: {e}");
-            std::process::exit(1);
-        }
-        return;
-    }
-
-    if let Err(e) = run_event_loop(cli) {
-        eprintln!("Error: {e}");
-    }
 }
 
 /// Composition root: builds the event channel, every subsystem

--- a/ttymap-tui/src/main.rs
+++ b/ttymap-tui/src/main.rs
@@ -66,15 +66,10 @@ fn main() {
         eprintln!("ttymap: --log requested but logging init failed: {e}");
     }
 
-    // Subcommands run a single task and exit without booting the full
-    // interactive app. Runtime path resolution is gated by
-    // `Command::needs_runtime` so pure-metadata subcommands
-    // (`api-info`) work on freshly-installed systems that haven't
-    // populated `~/.config/ttymap` or `~/.local/share/ttymap` yet.
+    // Each subcommand owns its setup (`init_runtime_or_exit` etc.).
+    // The dispatcher just routes — no pre-resolution, no per-command
+    // capability flags.
     if let Some(cmd) = cli.command {
-        if cmd.needs_runtime() {
-            init_runtime_path();
-        }
         if let Err(e) = cmd.run() {
             eprintln!("error: {e}");
             std::process::exit(1);
@@ -82,25 +77,9 @@ fn main() {
         return;
     }
 
-    init_runtime_path();
     if let Err(e) = run_event_loop(cli) {
         eprintln!("Error: {e}");
     }
-}
-
-/// Resolve and cache the layered runtime path. Aborts the process
-/// with a one-line message if every layer is missing — there's no
-/// graceful degradation for the interactive app or for the `snap`
-/// subcommand, both of which need init.lua to load.
-fn init_runtime_path() {
-    let runtime_path = match ttymap_tui::lua::resolve_runtime_path() {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("ttymap: {}", e);
-            std::process::exit(1);
-        }
-    };
-    ttymap_tui::lua::set_runtime_path(runtime_path);
 }
 
 /// Composition root: builds the event channel, every subsystem
@@ -108,6 +87,11 @@ fn init_runtime_path() {
 /// then hands control to `App::run`. Every thread handle joins
 /// in its `Drop` impl, so teardown is just RAII at end of scope.
 fn run_event_loop(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
+    // Resolve the layered runtime path before anything Lua-shaped
+    // spins up — `build_subsystem` reaches for it during VM setup and
+    // when the bundled `init.lua` runs.
+    ttymap_tui::cli::init_runtime_or_exit();
+
     // Lua bootstrap runs first — `build_subsystem` creates the VM,
     // installs the API, and runs the init.lua chain (which `require`s
     // every bundled plugin). The tile cache spins up next; its


### PR DESCRIPTION
## Summary

- Lands the first slice of #300: a `ttymap api-info` subcommand that dumps the Lua API surface as JSON, modeled on `nvim --api-info`.
- Adds the spec data types (`NamespaceSpec` / `MethodSpec` / `ParamSpec` + `ApiInfo` aggregator) and the first per-namespace `spec()` for `ttymap.map`. The remaining 9 namespaces follow as mechanical PRs against the same issue.
- Gates `resolve_runtime_path` on a new `Command::needs_runtime()` so `api-info` keeps working on a freshly-installed system that hasn't populated `~/.config/ttymap` yet.

## Why

External clients (the future `ttymap-mcp`, editor plugins, out-of-process scripts) need a programmatic discovery path for `ttymap.api.*`. Today the only source is the hand-written `docs/lua-architecture.md` (579 lines), which has to be sync'd by hand whenever an API is added. This is the first machine-generated alternative.

## Sample output

\`\`\`console
$ ttymap api-info --pretty | head -25
{
  \"version\": \"0.1\",
  \"namespaces\": [
    {
      \"path\": \"ttymap.map\",
      \"methods\": [
        {
          \"name\": \"jump\",
          \"params\": [
            {\"name\": \"lon\", \"ty\": \"number\"},
            {\"name\": \"lat\", \"ty\": \"number\"}
          ],
          \"returns\": \"nil\",
          \"doc\": \"Recentre the map on the given coordinate. Fire-and-forget; the host treats it identically to a keymap-driven jump.\"
        },
        ...
      ]
    }
  ]
}
\`\`\`

## Test plan

- [x] `cargo test --workspace` — 218 passed (2 new in `cli::api_info`, 1 new in `lua::api::map`)
- [x] `cargo clippy --all-targets --workspace` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo run -- api-info --pretty` produces well-formed JSON, listing all 5 `ttymap.map` methods
- [x] `cargo run -- api-info | jq '.namespaces[].methods | length'` returns `5`
- [x] `cargo run -- api-info --help` shows the new subcommand
- [x] `cargo run -- snap --help` still shows `snap`'s args (existing subcommand path unaffected)

## Follow-ups (tracked in #300)

- Roll `spec()` out to `http` / `json` / `sgp4` / `tile` / `config` / `help` / `log` / `storage` / `imperative` (one PR per namespace, mechanical)
- Spec the per-frame `make_map_table` surface (`point` / `label` / `polyline` / …) — it's a distinct object from the persistent `ttymap.map` userdata and warrants its own `NamespaceSpec`
- `ttymap.api.introspect:list()` runtime endpoint
- (Optional) auto-generate `docs/api-reference.md` from the spec