### PR TITLE
ci: add tag-triggered release workflow with git-cliff notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+# Tag-triggered: push `vX.Y.Z` and a GitHub Release with auto-generated
+# notes is created. Notes come from git-cliff reading Conventional
+# Commit subjects between the previous tag and this one (config in
+# cliff.toml at repo root).
+on:
+  push:
+    tags: ["v*.*.*"]
+  # Manual run for re-generating notes against an existing tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.1.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # git-cliff needs the full history + all tags to compute the
+          # range between the previous tag and HEAD.
+          fetch-depth: 0
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate release notes
+        id: cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          # `--latest` = only commits between the previous tag and this
+          # one, so each release's notes stand alone (no full-history
+          # repeat).
+          args: --latest --strip header
+        env:
+          OUTPUT: RELEASE_NOTES.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: ${{ steps.tag.outputs.name }}
+          body_path: ${{ steps.cliff.outputs.changelog }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,44 @@
+# git-cliff config — generates release notes from Conventional Commits.
+# Used by .github/workflows/release.yml on tag push.
+
+[changelog]
+header = ""
+body = """
+{% if version %}\
+## {{ version | trim_start_matches(pat="v") }} — {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## Unreleased
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | upper_first }}\
+{% if commit.remote.pr_number %} (#{{ commit.remote.pr_number }}){% endif %}\
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+# Map commit `type` → section heading. Order here is the order in the changelog.
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^demo", group = "Demos" },
+    # Drop noise — chore / test / ci / build / style don't earn a line in release notes.
+    { message = "^chore", skip = true },
+    { message = "^test", skip = true },
+    { message = "^ci", skip = true },
+    { message = "^build", skip = true },
+    { message = "^style", skip = true },
+]
+filter_commits = true
+tag_pattern = "v[0-9]*"
+sort_commits = "newest"


### PR DESCRIPTION
## Summary
- Push a `vX.Y.Z` tag (or run via `workflow_dispatch`) → GitHub Release auto-created with notes.
- `cliff.toml` groups Conventional Commits into Features / Bug Fixes / Performance / Refactor / Documentation / Demos; chore/test/ci/build/style are skipped.
- `--latest` so each release's notes only cover commits since the previous tag.

## Test plan
- [ ] After merge, push `v0.1.0` and confirm the Actions run creates a Release with sensible grouped notes.
- [ ] If notes look off, adjust `cliff.toml` and re-run via `workflow_dispatch` against the same tag.

## Notes
- First tag has no predecessor, so git-cliff will roll up the full history into the v0.1.0 notes — expected.
- `permissions: contents: write` is scoped to the release job only.