### PR TITLE
chore: drop unused reqwest dependency from ttymap-tui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,7 +3018,6 @@ dependencies = [
  "log",
  "mlua",
  "ratatui",
- "reqwest",
  "serde",
  "serde_json",
  "sgp4",

--- a/ttymap-tui/Cargo.toml
+++ b/ttymap-tui/Cargo.toml
@@ -34,7 +34,6 @@ ttymap-engine = { path = "../ttymap-engine", version = "0.1.0" }
 crossterm = "0.29"
 ratatui = "0.30"
 clap = { version = "4", features = ["derive"] }
-reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde = "1"
 serde_json = "1"
 directories = "6"


### PR DESCRIPTION
Closes #315.

## Summary
- `reqwest` was declared in `ttymap-tui/Cargo.toml` but never referenced from `ttymap-tui/src/**/*.rs` (the Lua HTTP bridge re-borrows `ttymap_engine::shared::http::HttpClient`).
- Removed the entry; `Cargo.lock` drops the line in the `ttymap-tui` deps list.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --workspace`
- [x] `cargo test` (pre-commit hook, 215 passed)