### PR TITLE
refactor(tui): inline event publish at each handler site

### DIFF
--- a/docs/lua-architecture.md
+++ b/docs/lua-architecture.md
@@ -48,8 +48,12 @@ ttymap-tui/src/lua/
   init_lua.rs      run_init_lua_chain (system → user init.lua in
                    the shared VM); read_init_lua_config_only is
                    the snap-only thin path
-  handle.rs        LuaHandle — shared host plumbing (drain_ops, tick,
-                   notify_*) the App calls into
+  handle.rs        LuaHandle — cheap-to-clone host plumbing
+                   (drain_ops, tick, sync_view, set_current_frame,
+                   set_attribution) shared by App + Dispatcher.
+                   Event publishing is not on this surface — App
+                   and Dispatcher hold `Rc<EventBus>` directly and
+                   publish inline at each handler site (#334).
   registrar.rs     LuaRegistry — live registry of activations +
                    palette entries; `register_*` calls push directly
                    here, Lua handles `:remove()` drop entries by ID

--- a/ttymap-tui/src/app/dispatcher.rs
+++ b/ttymap-tui/src/app/dispatcher.rs
@@ -18,6 +18,7 @@
 //! core/front directory experiment (Phase 4) was reverted in
 //! favour of a flat layout — see `src/lib.rs` header.
 
+use std::rc::Rc;
 use std::time::Duration;
 
 use crossterm::event::KeyEvent;
@@ -28,6 +29,7 @@ use super::sidebar::SidebarPolicy;
 use crate::UserCommand;
 use crate::compositor::op::Op;
 use crate::compositor::{Compositor, Context};
+use crate::event::{Event, EventBus};
 use crate::lua::LuaHandle;
 use crate::theme::ThemeId;
 use crate::theme::UiTheme;
@@ -41,6 +43,11 @@ pub(super) struct Dispatcher {
     theme_id: ThemeId,
     ui_theme: UiTheme,
     lua: LuaHandle,
+    /// Shared with App + the Lua subsystem. Dispatcher handlers
+    /// publish observable events on this directly, alongside the
+    /// state mutation that produced them — no wrapper layer, no
+    /// second match on `UserCommand` (see #334).
+    bus: Rc<EventBus>,
     compositor: Compositor,
     sidebar: SidebarPolicy,
     cursor: Option<(u16, u16)>,
@@ -52,6 +59,7 @@ impl Dispatcher {
         theme_id: ThemeId,
         map: MapHandle,
         lua: LuaHandle,
+        bus: Rc<EventBus>,
         compositor: Compositor,
         sidebar_width: u16,
         overlay_redraw_interval: Duration,
@@ -63,6 +71,7 @@ impl Dispatcher {
             theme_id,
             ui_theme,
             lua,
+            bus,
             compositor,
             sidebar: SidebarPolicy::new(sidebar_width),
             cursor: None,
@@ -114,27 +123,6 @@ impl Dispatcher {
         }
     }
 
-    /// Forward a frame-ready signal to subscribers. Called from
-    /// `App::handle_event` when a fresh `MapFrame` arrives off the
-    /// render thread.
-    pub(super) fn notify_frame_ready(&self) {
-        self.lua.notify_frame_ready();
-    }
-
-    /// Hand a [`crate::event::Event`] to the bus for fan-out. Used by
-    /// `App::handle_event` to forward cross-thread `AppEvent::Bus`
-    /// publishes onto the main-thread bus.
-    pub(super) fn publish_bus_event(&self, event: crate::event::Event) {
-        self.lua.bus().publish(event);
-    }
-
-    /// Mirror the latest [`MapFrame`] into the shared cell Lua reads
-    /// via `ttymap.api.frame.to_ansi()`. Called by `App::handle_event`
-    /// on every `AppEvent::FrameReady`.
-    pub(super) fn set_current_frame_for_lua(&self, frame: MapFrame) {
-        self.lua.set_current_frame(frame);
-    }
-
     /// Drain queued Lua-side ops and apply them. App calls this once
     /// per loop iteration after event handling, before render.
     pub(super) fn apply_lua_ops(&mut self) {
@@ -153,7 +141,7 @@ impl Dispatcher {
                 }
                 Op::Close(id) => self.compositor.close_by_id(id),
                 Op::Command(cmd) => self.dispatch(cmd),
-                Op::Publish(event) => self.lua.bus().publish(event),
+                Op::Publish(event) => self.bus.publish(event),
             }
         }
     }
@@ -189,22 +177,48 @@ impl Dispatcher {
         self.overlay.should_redraw()
     }
 
-    /// Execute a [`UserCommand`] and broadcast the post-effect
-    /// notification on the bus. Single side-effect boundary for
-    /// app-level state changes.
+    /// Execute a [`UserCommand`]. Each arm mutates the state it owns
+    /// and, on the same beat, publishes the observable [`Event`]
+    /// (if any) that corresponds to "this just happened". No separate
+    /// notify pass, no per-arm helper that only one arm calls — the
+    /// full behaviour of each command is readable in one place.
+    ///
+    /// `handle_resize` stays a private helper because three call
+    /// sites share it (`Resize` arm here, `ToggleSidebar` arm here,
+    /// `poll_compositor` auto-resize after a sidebar count change).
+    /// `request_map_redraw` likewise — it's invoked from every arm
+    /// that wants the next frame.
+    ///
+    /// `PanCells`, `ZoomAt`, `CursorMoved`, `CycleFocus`, the discrete
+    /// `Pan*` keymap actions, and `Quit` are deliberately not
+    /// broadcast — they're either noisy or internal.
     pub(super) fn dispatch(&mut self, msg: UserCommand) {
-        let snapshot = msg.clone();
         match msg {
             UserCommand::Map(action) => {
                 if self.map.apply_action(&action) {
                     self.request_map_redraw();
+                }
+                match &action {
+                    MapAction::Jump(ll) => self.bus.publish(Event::MapJumped(*ll)),
+                    MapAction::SetZoom(z) => self.bus.publish(Event::MapZoomSet(*z)),
+                    MapAction::FlyTo { center, zoom } => {
+                        self.bus.publish(Event::MapFlewTo(*center, *zoom));
+                    }
+                    _ => {}
                 }
             }
             UserCommand::Quit => {
                 debug!("UserCommand::Quit — stopping event loop");
                 self.running = false;
             }
-            UserCommand::SetTheme(new_id) => self.switch_theme(new_id),
+            UserCommand::SetTheme(new_id) => {
+                self.theme_id = new_id;
+                self.ui_theme = UiTheme::from_palette(new_id.palette());
+                self.map.set_theme(new_id);
+                self.bus
+                    .publish(Event::ThemeChanged(new_id.name().to_string()));
+                self.request_map_redraw();
+            }
             UserCommand::CursorMoved(col, row) => {
                 self.cursor = Some((col, row));
             }
@@ -212,55 +226,26 @@ impl Dispatcher {
                 self.compositor.cycle(forward);
             }
             UserCommand::Resize(cols, rows) => self.handle_resize(cols, rows),
-            UserCommand::ToggleSidebar => self.toggle_sidebar(),
+            UserCommand::ToggleSidebar => {
+                self.sidebar.toggle();
+                // The visible map area shrinks/expands — re-run the
+                // resize path so the render thread allocates the right
+                // canvas size.
+                let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+                self.handle_resize(cols, rows);
+            }
             UserCommand::SetLabelsVisible(visible) => {
                 self.map.set_labels_visible(visible);
                 self.request_map_redraw();
             }
         }
-        self.notify_post_command(&snapshot);
-    }
-
-    /// Broadcast post-effect notifications for the variants that
-    /// plugins want to observe. Skips noisy / internal commands so
-    /// the bus surface stays meaningful — bus events are "something
-    /// observable happened to the app", not "every state mutation".
-    fn notify_post_command(&self, msg: &UserCommand) {
-        match msg {
-            UserCommand::Map(MapAction::Jump(ll)) => self.lua.notify_map_jumped(*ll),
-            UserCommand::Map(MapAction::SetZoom(z)) => self.lua.notify_map_zoom_set(*z),
-            UserCommand::Map(MapAction::FlyTo { center, zoom }) => {
-                self.lua.notify_map_flew_to(*center, *zoom);
-            }
-            UserCommand::SetTheme(new_id) => self.lua.notify_theme_changed(new_id.name()),
-            UserCommand::Resize(cols, rows) => self.lua.notify_resized(*cols, *rows),
-            // Noisy or internal — `PanCells`, `ZoomAt`, `CursorMoved`,
-            // `CycleFocus`, the discrete `Pan*` keymap actions, and
-            // `Quit` (the App is tearing down anyway) are deliberately
-            // not broadcast. Adding them later is one match arm.
-            _ => {}
-        }
-    }
-
-    fn switch_theme(&mut self, new_id: ThemeId) {
-        self.theme_id = new_id;
-        self.ui_theme = UiTheme::from_palette(new_id.palette());
-        self.map.set_theme(new_id);
-        self.request_map_redraw();
     }
 
     fn handle_resize(&mut self, cols: u16, rows: u16) {
         let map_cols = self.sidebar.effective_map_cols(cols);
         self.map.handle_resize(map_cols, rows);
+        self.bus.publish(Event::Resized(cols, rows));
         self.request_map_redraw();
-    }
-
-    fn toggle_sidebar(&mut self) {
-        self.sidebar.toggle();
-        // The visible map area shrinks/expands — re-run the resize
-        // path so the render thread allocates the right canvas size.
-        let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
-        self.handle_resize(cols, rows);
     }
 
     pub(super) fn request_map_redraw(&mut self) {

--- a/ttymap-tui/src/app/mod.rs
+++ b/ttymap-tui/src/app/mod.rs
@@ -27,6 +27,7 @@ use dispatcher::Dispatcher;
 pub use event::AppEvent;
 
 use std::io;
+use std::rc::Rc;
 
 use crossterm::event::{Event, KeyCode, KeyModifiers};
 use log::{debug, info};
@@ -34,9 +35,10 @@ use log::{debug, info};
 use crate::UserCommand;
 use crate::compositor::{BaseLayer, Compositor};
 use crate::config::Config;
+use crate::event::EventBus;
 pub use crate::input::KeybindingOverrides;
 use crate::input::{KeyMap, MouseAdapter};
-use crate::lua::LuaSubsystem;
+use crate::lua::{LuaHandle, LuaSubsystem};
 use crate::theme::ThemeId;
 use ttymap_engine::map::MapHandle;
 use ttymap_engine::map::render::frame::MapFrame;
@@ -55,6 +57,15 @@ pub struct App {
     /// Mouse-event translator. App owns this because `handle_input`
     /// is the only consumer.
     mouse: MouseAdapter,
+    /// Shared with Dispatcher + the Lua subsystem. App publishes
+    /// directly on `AppEvent::FrameReady` / `AppEvent::Bus` so the
+    /// dispatch path stays purely UserCommand-driven (#334).
+    bus: Rc<EventBus>,
+    /// Cheap-to-clone handle into the Lua subsystem. App holds its
+    /// own clone so it can mirror the latest [`MapFrame`] into the
+    /// shared cell `ttymap.api.frame.to_ansi()` reads from without
+    /// routing through Dispatcher.
+    lua: LuaHandle,
     /// Main event-loop wake interval. Derived from
     /// `ttymap.opt.runtime.poll_timeout_ms` at startup. `pub` getter
     /// because `main` reads it to align the input thread / frame
@@ -81,6 +92,7 @@ impl App {
     ) -> Self {
         let LuaSubsystem {
             handle: lua,
+            bus,
             registry,
             footer_hints,
         } = lua;
@@ -104,13 +116,16 @@ impl App {
             dispatcher: Dispatcher::new(
                 theme_id,
                 map,
-                lua,
+                lua.clone(),
+                bus.clone(),
                 compositor,
                 config.runtime.sidebar_width,
                 std::time::Duration::from_millis(config.runtime.overlay_redraw_ms),
             ),
             map_frame: None,
             mouse: MouseAdapter::default(),
+            bus,
+            lua,
             poll_timeout: std::time::Duration::from_millis(config.runtime.poll_timeout_ms),
         }
     }
@@ -189,13 +204,13 @@ impl App {
             AppEvent::Command(msg) => self.dispatcher.dispatch(msg),
             AppEvent::FrameReady(frame) => {
                 // Mirror the frame into the shared cell Lua reads via
-                // `ttymap.api.frame.to_ansi()` *before* notifying
-                // subscribers — a `frame_ready` listener that
-                // immediately calls `to_ansi()` should see this frame,
-                // not the previous one.
-                self.dispatcher.set_current_frame_for_lua(frame.clone());
+                // `ttymap.api.frame.to_ansi()` *before* publishing
+                // `FrameReady` — a subscriber that immediately calls
+                // `to_ansi()` should see this frame, not the previous
+                // one.
+                self.lua.set_current_frame(frame.clone());
                 self.map_frame = Some(frame);
-                self.dispatcher.notify_frame_ready();
+                self.bus.publish(crate::event::Event::FrameReady);
             }
             AppEvent::Input(input) => self.handle_input(input, event_tx),
             // `Wake` exists purely to unblock `event_rx.recv()`. The
@@ -206,11 +221,11 @@ impl App {
             AppEvent::Wake => {}
             // Cross-thread bus publish. The main loop hands the event
             // straight to the bus, which fans out to every registered
-            // subscriber. Main-thread producers go via
-            // `Dispatcher`/`LuaHandle` instead — this branch exists
-            // only so off-thread code can reach Lua subscribers
-            // without owning an mlua state.
-            AppEvent::Bus(bus_event) => self.dispatcher.publish_bus_event(bus_event),
+            // subscriber. Main-thread producers publish inline at
+            // their handler site instead — this branch exists only so
+            // off-thread code can reach Lua subscribers without
+            // owning an mlua state.
+            AppEvent::Bus(bus_event) => self.bus.publish(bus_event),
         }
     }
 

--- a/ttymap-tui/src/lua/handle.rs
+++ b/ttymap-tui/src/lua/handle.rs
@@ -1,17 +1,22 @@
 //! Runtime handle to the Lua subsystem.
 //!
-//! App stores one of these as a private field. It exposes
-//! **semantic** methods (`notify_*`, `tick`, `sync_view`,
-//! `drain_ops`) so App never names the [`EventBus`], the event
-//! variants, or the per-plugin host channels. The "App doesn't know
-//! how Lua is wired internally" boundary — all bus dispatch and
-//! host-state plumbing lives behind this type.
+//! Cheap-to-clone Rc/Arc bundle that App + Dispatcher both hold so
+//! each can reach the Lua-side state they need (drain ops, sync
+//! per-plugin view mirrors, tick on draw, mirror the latest frame,
+//! set the tile attribution string) without routing through the
+//! other half.
+//!
+//! Event publishing is **not** part of this surface. The [`EventBus`]
+//! lives next to LuaHandle in [`crate::lua::LuaSubsystem`] and is
+//! held directly by App / Dispatcher — publishes happen inline
+//! alongside the state mutation that produced them, not through a
+//! `notify_*` wrapper layer here. See #334.
 
 use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::compositor::op::{Op, OpsBuffer};
-use crate::event::{Event, EventBus, Level};
+use crate::event::EventBus;
 use crate::lua::MapApi;
 use crate::lua::host::{LuaHostHandles, LuaHostShared};
 use crate::lua::tick;
@@ -19,15 +24,14 @@ use ttymap_engine::geo::LonLat;
 use ttymap_engine::map::render::frame::MapFrame;
 
 /// Runtime-held part of the Lua subsystem (built by
-/// [`crate::lua::build_subsystem`]). Wraps the event bus and
-/// per-plugin host-state channels so callers (App) interact through
-/// semantic methods rather than touching the bus or channels
-/// directly.
+/// [`crate::lua::build_subsystem`]). Clone is free — every field is
+/// already an `Rc` / `Arc` / cheap newtype, so App and Dispatcher
+/// share one logical instance through their clones.
 ///
-/// The bus is wrapped in [`Rc`] because the same instance is
-/// referenced by every `EventHandle` userdata returned to Lua
-/// (`ttymap.on_event` / `ttymap.api.frame.on_tick`) — they keep a
-/// `Rc<EventBus>` to call `remove(...)` on `:remove()`.
+/// The bus is held here only because [`Self::tick`] needs it to
+/// fan out the per-frame `"tick"` event. App / Dispatcher reach the
+/// bus directly via the clone stored on [`crate::lua::LuaSubsystem`].
+#[derive(Clone)]
 pub struct LuaHandle {
     bus: Rc<EventBus>,
     host_handles: Vec<LuaHostHandles>,
@@ -57,15 +61,6 @@ impl LuaHandle {
         }
     }
 
-    /// Borrow the underlying [`EventBus`] for direct publishes (e.g.
-    /// the App-mpsc drain branch that handles
-    /// [`crate::app::AppEvent::Bus`] hands the event straight to
-    /// `bus.publish`). Most callers should prefer the `notify_*`
-    /// semantic methods below.
-    pub fn bus(&self) -> &EventBus {
-        &self.bus
-    }
-
     /// Take every [`Op`] enqueued by Lua callbacks since the last
     /// drain. App calls this once per loop iteration and applies
     /// each op to the compositor / dispatch path.
@@ -79,15 +74,9 @@ impl LuaHandle {
         tick::dispatch_tick(&self.bus, map);
     }
 
-    /// Notify observers that a fresh frame was drained from the
-    /// render thread.
-    pub fn notify_frame_ready(&self) {
-        self.bus.publish(Event::FrameReady);
-    }
-
     /// Mirror the latest [`MapFrame`] into the shared cell that
-    /// `ttymap.api.frame.to_ansi()` reads from. Called by App on
-    /// every `AppEvent::FrameReady` before [`Self::notify_frame_ready`]
+    /// `ttymap.api.frame.to_ansi()` reads from. App calls this on
+    /// every `AppEvent::FrameReady` before publishing `Event::FrameReady`
     /// so subscribers that immediately query `to_ansi()` see the
     /// fresh frame.
     pub fn set_current_frame(&self, frame: MapFrame) {
@@ -104,45 +93,6 @@ impl LuaHandle {
     /// populated post-`build_subsystem`).
     pub fn set_attribution(&self, attribution: Option<String>) {
         self.shared.set_attribution(attribution);
-    }
-
-    /// Notify observers that the map centred on a new location.
-    pub fn notify_map_jumped(&self, ll: LonLat) {
-        self.bus.publish(Event::MapJumped(ll));
-    }
-
-    /// Notify observers that the zoom level was set explicitly
-    /// (via `:zoom` or `MapAction::SetZoom`).
-    pub fn notify_map_zoom_set(&self, zoom: f64) {
-        self.bus.publish(Event::MapZoomSet(zoom));
-    }
-
-    /// Notify observers that the map flew to a (centre, zoom) pair
-    /// in one combined dispatch.
-    pub fn notify_map_flew_to(&self, center: LonLat, zoom: f64) {
-        self.bus.publish(Event::MapFlewTo(center, zoom));
-    }
-
-    /// Notify observers that the active theme switched.
-    pub fn notify_theme_changed(&self, theme_name: &str) {
-        self.bus
-            .publish(Event::ThemeChanged(theme_name.to_string()));
-    }
-
-    /// Notify observers that the terminal resized.
-    pub fn notify_resized(&self, cols: u16, rows: u16) {
-        self.bus.publish(Event::Resized(cols, rows));
-    }
-
-    /// Push a transient toast onto the bus. The bundled `notify.lua`
-    /// renderer subscribes and paints recent ones top-left for ~3s.
-    /// Callable from any main-thread Rust path; cross-thread
-    /// producers route through `AppEvent::Bus` instead.
-    pub fn notify(&self, message: impl Into<String>, level: Level) {
-        self.bus.publish(Event::Notify {
-            message: message.into(),
-            level,
-        });
     }
 
     /// Refresh the per-plugin `center` / `zoom` mirror cells that

--- a/ttymap-tui/src/lua/host.rs
+++ b/ttymap-tui/src/lua/host.rs
@@ -151,6 +151,7 @@ impl LuaHostShared {
 /// shared [`OpsBuffer`](crate::compositor::op::OpsBuffer) as
 /// [`Op::Push`](crate::compositor::op::Op::Push) and the App drains them
 /// alongside [`Op::Close`](crate::compositor::op::Op::Close).
+#[derive(Clone)]
 pub struct LuaHostHandles {
     pub center: Arc<Mutex<LonLat>>,
     /// Latest zoom level mirrored from the host so

--- a/ttymap-tui/src/lua/mod.rs
+++ b/ttymap-tui/src/lua/mod.rs
@@ -52,6 +52,11 @@ pub struct LuaSubsystem {
     /// Runtime handle to the Lua subsystem — semantic surface
     /// App uses to observe state changes and tick plugins.
     pub handle: LuaHandle,
+    /// Lua-agnostic pub/sub primitive. Shared with every
+    /// `EventHandle` userdata returned to Lua (for `:remove()`) and
+    /// with the App + Dispatcher (who publish directly inline beside
+    /// the state mutation that produced each event — see #334).
+    pub bus: std::rc::Rc<crate::event::EventBus>,
     /// Live registry of Lua-registered activations + palette
     /// entries. Cloned into `BaseLayer` (for keypress dispatch) and
     /// the palette installer (for the `:` activation's per-open
@@ -121,7 +126,8 @@ pub fn build_subsystem(defaults: Config) -> (LuaSubsystem, Config, KeybindingOve
             let keymap = KeyMap::with_overrides(&KeybindingOverrides::new());
             return (
                 LuaSubsystem {
-                    handle: LuaHandle::new(bus, Vec::new(), ops, shared),
+                    handle: LuaHandle::new(bus.clone(), Vec::new(), ops, shared),
+                    bus,
                     registry,
                     footer_hints: Vec::new(),
                 },
@@ -148,7 +154,8 @@ pub fn build_subsystem(defaults: Config) -> (LuaSubsystem, Config, KeybindingOve
             let keymap = KeyMap::with_overrides(&KeybindingOverrides::new());
             return (
                 LuaSubsystem {
-                    handle: LuaHandle::new(bus, Vec::new(), ops, shared),
+                    handle: LuaHandle::new(bus.clone(), Vec::new(), ops, shared),
+                    bus,
                     registry,
                     footer_hints: Vec::new(),
                 },
@@ -199,11 +206,12 @@ pub fn build_subsystem(defaults: Config) -> (LuaSubsystem, Config, KeybindingOve
         })
         .collect();
 
-    let handle = LuaHandle::new(bus, vec![host_handles], ops, shared);
+    let handle = LuaHandle::new(bus.clone(), vec![host_handles], ops, shared);
 
     (
         LuaSubsystem {
             handle,
+            bus,
             registry,
             footer_hints,
         },


### PR DESCRIPTION
Closes #334, #320.

## Summary
Drops the notify-wrapper layer between `Dispatcher` and `EventBus`. Each `UserCommand` handler now publishes its observable `Event` (if any) inline alongside the state mutation, instead of relying on a second match (`notify_post_command`) plus `LuaHandle::notify_*` shims that mapped commands back to events.

Before: `dispatch` matches on `UserCommand` → state mutates → returns to a *second* match (`notify_post_command`) that re-traverses `UserCommand` and calls a per-arm `LuaHandle::notify_<x>` wrapper, each of which is just `self.bus.publish(Event::<x>)`. Two sources of truth for the command → event mapping; the second match's "noisy / internal" skip rule was a runtime arm rather than a structural property.

After: each `dispatch` arm has the full "what happens for this command" in one place. `SetTheme` mutates the theme state **and** publishes `ThemeChanged` in the same block; `Map(Jump|SetZoom|FlyTo)` publish inline beside `map.apply_action`; etc. The `LuaHandle::notify_*` family + the second match + the three Dispatcher pass-throughs (`notify_frame_ready` / `publish_bus_event` / `set_current_frame_for_lua`) all delete.

\`switch_theme\` / \`toggle_sidebar\` had a single caller each after the inline-publish move; both inline into their dispatch arms so each command's full behaviour is readable in one place. \`handle_resize\` stays a helper — three call sites.

Why inline-per-handler over a `From<&UserCommand> for Option<Event>` mapping (the #320 proposal): any separated mapping layer ends up running parallel to the dispatch match itself (same enum, same arms, same shape). Inlining removes the second mapping entirely.

## Changes
- **`ttymap-tui/src/lua/handle.rs`**: drop `notify_frame_ready`, `notify_map_jumped`, `notify_map_zoom_set`, `notify_map_flew_to`, `notify_theme_changed`, `notify_resized`, `notify`, and the `bus()` accessor. Add \`#[derive(Clone)]\` — every field is already `Rc` / `Arc` so cloning is free. Module doc updated.
- **`ttymap-tui/src/lua/host.rs`**: \`#[derive(Clone)]\` on \`LuaHostHandles\` (required for `LuaHandle: Clone`).
- **`ttymap-tui/src/lua/mod.rs`**: \`LuaSubsystem\` now exposes the \`Rc<EventBus>\` so App can clone it for itself and for Dispatcher. All three `LuaSubsystem` construction sites updated.
- **`ttymap-tui/src/app/dispatcher.rs`**: Dispatcher takes & stores `Rc<EventBus>`. Each dispatch arm publishes inline. `notify_post_command` deleted. `switch_theme` / `toggle_sidebar` inlined into their arms.
- **`ttymap-tui/src/app/mod.rs`**: App holds its own `Rc<EventBus>` + `LuaHandle` clone. `AppEvent::FrameReady` publishes `Event::FrameReady` directly (after mirroring the frame for Lua via `self.lua.set_current_frame`); `AppEvent::Bus` publishes directly via `self.bus.publish`.
- **`docs/lua-architecture.md`**: refreshed the `LuaHandle` description.

Net: **-37 lines** (6 files, +117 / −154).

## Test plan
- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` (215 passed)
- [x] Pre-commit hook (test + clippy + fmt) all green