### PR TITLE
feat(lua): add ttymap.location shared user-location cache (#307)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Rust 2024 edition. The build uses `protox` so no system `protoc` is needed.
 
 - **[docs/architecture.md](docs/architecture.md)** — system layout, threads, message + render flow, focus model, concurrency.
 - **[docs/configuration.md](docs/configuration.md)** — `init.lua` reference, runtime path resolution, file locations.
-- **[docs/lua-architecture.md](docs/lua-architecture.md)** — plugin authoring guide: `ttymap.api.*` surface, shared libraries (`ttymap.fmt` / `.sidebar` / `.animation` / `.director`), plugin shapes, dispatcher semantics.
+- **[docs/lua-architecture.md](docs/lua-architecture.md)** — plugin authoring guide: `ttymap.api.*` surface, shared libraries (`ttymap.fmt` / `.sidebar` / `.animation` / `.director` / `.location`), plugin shapes, dispatcher semantics.
 - **[docs/design.md](docs/design.md)** — load-bearing design decisions (UserCommand vs direct call, controller split, Drop-based cleanup).
 
 ## Origin

--- a/docs/lua-architecture.md
+++ b/docs/lua-architecture.md
@@ -518,6 +518,7 @@ here.
 | `ttymap.animation`      | `.fly_to(lon, lat, zoom, opts?)` — frame-based pan animation  |
 | `ttymap.director`       | `.run(fn, opts?)` / `.fly` / `.wait` / `.tween` — coroutine-based scheduler |
 | `ttymap.cities`         | array of `{lon, lat, name, country}` — ~170 worldwide cities  |
+| `ttymap.location`       | `.get(cb)` / `.refresh(cb)` / `.cached()` — shared IP-geoip user-location cache |
 
 `ttymap.animation.fly_to` interpolates `ttymap.map:fly_to` over ~30
 frames (default), with optional `on_done` / `on_cancel` callbacks
@@ -553,6 +554,18 @@ explicit `handle:cancel()`. A natural function return ends the
 script without firing `on_cancel`. The travel plugin's pre /
 stop / post tour is one such script — the whole choreography is
 top-to-bottom procedural Lua, no hand-written state machine.
+
+`ttymap.location` resolves "where is the user, in lon/lat" once
+via IP geoip and serves the answer to every plugin that asks.
+Three layers: in-memory (this session), `ttymap.storage` (across
+sessions, TTL-bounded — default 24h), and an HTTP fetch against
+`require("ttymap.here").endpoint` (the canonical source, shared
+with the `here` plugin). Concurrent `loc.get` calls coalesce onto
+a single in-flight job; the cb fires sync on cache hit or once the
+shared response lands. Errors surface as `cb(nil, nil, "error")`
+plus a `ttymap.notify` warning. `loc.refresh(cb)` skips the TTL
+and always re-fetches; `loc.cached()` is a sync read that returns
+`nil, nil` on miss / stale and never starts a fetch.
 
 ## User plugins
 

--- a/ttymap-tui/runtime/lua/plugin/here.lua
+++ b/ttymap-tui/runtime/lua/plugin/here.lua
@@ -1,57 +1,27 @@
 -- here — palette action that jumps to the user's IP-geolocated
 -- coordinates.
 --
--- Windowless: nothing is pushed onto the compositor stack. The
--- palette `invoke` kicks a geoip GET if one isn't already in flight;
--- the per-frame `on_tick` callback polls the inflight job and, when
--- the response lands, hands the centre to `ttymap.animation.fly_to`
--- so the view glides over instead of teleporting (avoids the brief
--- black-tile gap from landing on un-prefetched coordinates).
+-- Location lookup is shared via ttymap.location, so subsequent
+-- presses in the same session (or after a recent ttymap run within
+-- the lib's TTL window) skip the network round-trip.
 --
 -- Endpoint comes from `ttymap.here.endpoint` (defaults to ipapi.co;
 -- override in init.lua via `require("ttymap.here").endpoint = "..."`).
 
 local anim = require "ttymap.animation"
-local config = require "ttymap.here"
-
-local state = { job = nil }
-local tick_handle = nil  -- on_tick subscription while a fetch is in flight
-
-local function drain(_map)
-    if not state.job then return end
-    local body = state.job:try_take()
-    if body then
-        local p = ttymap.json:parse(body)
-        if p
-            and type(p.latitude) == "number"
-            and type(p.longitude) == "number" then
-            anim.fly_to(p.longitude, p.latitude)
-            ttymap.notify(string.format(
-                "Flew to %.4f, %.4f", p.latitude, p.longitude
-            ))
-        else
-            ttymap.notify("here: geoip response missing lat/lon",
-                          { level = "warn" })
-        end
-        state.job = nil
-        -- Job done; remove ourselves from the tick bus until the
-        -- user invokes again. Avoids the per-frame `if not job` cost
-        -- across the whole program lifetime.
-        if tick_handle then
-            tick_handle:remove()
-            tick_handle = nil
-        end
-    end
-end
+local loc  = require "ttymap.location"
 
 ttymap.register_palette_command({
     label = "Jump to here (current location)",
     invoke = function()
-        if not state.job then
-            state.job = ttymap.http:fetch(config.endpoint)
-            if not tick_handle then
-                tick_handle = ttymap.api.frame.on_tick(drain)
-            end
-        end
+        loc.get(function(lat, lon)
+            -- nil on error — location lib already surfaced the warn
+            -- via ttymap.notify, so we just drop it here.
+            if not lat then return end
+            anim.fly_to(lon, lat)
+            ttymap.notify(string.format(
+                "Flew to %.4f, %.4f", lat, lon
+            ))
+        end)
     end,
 })

--- a/ttymap-tui/runtime/lua/ttymap/location.lua
+++ b/ttymap-tui/runtime/lua/ttymap/location.lua
@@ -1,0 +1,180 @@
+-- ttymap.location — shared user-location cache.
+--
+-- Resolves "where is the user" (IP geoip) once and serves the answer
+-- to every plugin that asks. Three layers: in-memory (this session),
+-- ttymap.storage (across sessions, TTL-bounded), and HTTP fetch (the
+-- canonical source). Plugins that previously rolled their own geoip
+-- fetch state machine can replace it with a single `loc.get(cb)`.
+--
+-- Usage:
+--   local loc = require "ttymap.location"
+--
+--   -- Async getter — cb fires sync on cache hit, async on network.
+--   -- Concurrent calls coalesce onto a single in-flight fetch.
+--   -- On failure cb fires with (nil, nil, "error").
+--   loc.get(function(lat, lon, source)
+--       if lat then ... else ... end
+--   end)
+--
+--   -- Force refresh — skip TTL, always hit the network.
+--   loc.refresh(function(lat, lon, source) end)
+--
+--   -- Sync read — returns nil, nil on miss or stale. Never fetches.
+--   local lat, lon = loc.cached()
+--
+-- Config (mutate via `require("ttymap.location").<field> = ...`):
+--   ttl_seconds  TTL for cache freshness (default 24h)
+--
+-- Endpoint config is shared with the `here` plugin — override via
+-- `require("ttymap.here").endpoint = "..."`.
+
+local here = require "ttymap.here"
+
+local M = {
+    ttl_seconds = 24 * 60 * 60,
+}
+
+local STORE_NS  = "location"
+local STORE_KEY = "here"
+
+local store_handle = nil   -- resolved lazily; ttymap.storage may not
+                           -- exist when the module is loaded (no XDG
+                           -- data dir → see api/storage.rs `new()`).
+
+local _mem         = nil   -- { lat, lon, ts } or nil
+local _job         = nil   -- in-flight ttymap.http job, if any
+local _waiters     = {}    -- callbacks awaiting the current job
+local _tick_handle = nil   -- on_tick subscription while job in flight
+
+local function now()
+    return os.time()
+end
+
+local function fresh(entry)
+    if not entry then return false end
+    return (now() - (entry.ts or 0)) < M.ttl_seconds
+end
+
+local function store()
+    if not store_handle then
+        if not (ttymap and ttymap.storage) then
+            return nil
+        end
+        store_handle = ttymap.storage:open(STORE_NS)
+    end
+    return store_handle
+end
+
+local function load_from_storage()
+    local s = store()
+    if not s then return nil end
+    local hit = s:get(STORE_KEY, nil)
+    if hit
+        and type(hit.lat) == "number"
+        and type(hit.lon) == "number"
+        and type(hit.ts)  == "number" then
+        return hit
+    end
+    return nil
+end
+
+local function save_to_storage(entry)
+    local s = store()
+    if not s then return end
+    s:set(STORE_KEY, entry)
+end
+
+-- Drain `_waiters` exactly once, swapping the buffer first so that a
+-- callback re-entering via `loc.get` enqueues into a fresh list.
+local function notify_waiters(lat, lon, source)
+    local pending = _waiters
+    _waiters = {}
+    for _, cb in ipairs(pending) do
+        cb(lat, lon, source)
+    end
+end
+
+local function clear_job()
+    _job = nil
+    if _tick_handle then
+        _tick_handle:remove()
+        _tick_handle = nil
+    end
+end
+
+local function drain()
+    if not _job then return end
+    local body = _job:try_take()
+    if not body then return end
+
+    clear_job()
+
+    local parsed = ttymap.json:parse(body)
+    if parsed
+        and type(parsed.latitude)  == "number"
+        and type(parsed.longitude) == "number" then
+        local entry = {
+            lat = parsed.latitude,
+            lon = parsed.longitude,
+            ts  = now(),
+        }
+        _mem = entry
+        save_to_storage(entry)
+        notify_waiters(entry.lat, entry.lon, "network")
+    else
+        ttymap.notify("location: geoip response missing lat/lon",
+                      { level = "warn" })
+        notify_waiters(nil, nil, "error")
+    end
+end
+
+-- Kick off the HTTP fetch + subscribe to on_tick. Idempotent — extra
+-- callers piggyback on the in-flight job via `_waiters`.
+local function start_fetch()
+    if _job then return end
+    _job = ttymap.http:fetch(here.endpoint)
+    _tick_handle = ttymap.api.frame.on_tick(drain)
+end
+
+function M.get(cb)
+    if type(cb) ~= "function" then
+        error("ttymap.location.get: callback must be a function", 2)
+    end
+
+    if fresh(_mem) then
+        cb(_mem.lat, _mem.lon, "memory")
+        return
+    end
+
+    local disk = load_from_storage()
+    if fresh(disk) then
+        _mem = disk
+        cb(disk.lat, disk.lon, "storage")
+        return
+    end
+
+    _waiters[#_waiters + 1] = cb
+    start_fetch()
+end
+
+function M.refresh(cb)
+    if type(cb) ~= "function" then
+        error("ttymap.location.refresh: callback must be a function", 2)
+    end
+    _waiters[#_waiters + 1] = cb
+    start_fetch()
+end
+
+function M.cached()
+    if fresh(_mem) then
+        return _mem.lat, _mem.lon
+    end
+    local disk = load_from_storage()
+    if fresh(disk) then
+        _mem = disk
+        return disk.lat, disk.lon
+    end
+    return nil, nil
+end
+
+return M


### PR DESCRIPTION
## Summary

- New bundled lib `runtime/lua/ttymap/location.lua` — three-layer cache (memory → `ttymap.storage` → HTTP geoip) for "where is the user". Concurrent `loc.get` calls coalesce onto a single in-flight fetch; cb fires sync on cache hit or async once the shared response lands. `loc.refresh` skips the TTL; `loc.cached()` is a sync read. Errors surface as `cb(nil, nil, "error")` plus a `ttymap.notify` warn.
- Migrates the bundled `here` plugin off its own fetch/drain state machine. `:Jump to here` becomes a single `loc.get` call — second press in the same session (or within the storage TTL, default 24h) skips the network round-trip entirely.
- Docs: `docs/lua-architecture.md` Shared-libraries table + paragraph; README pointer list.

Closes #307.

## API

\`\`\`lua
local loc = require "ttymap.location"

loc.get(function(lat, lon, source) end)   -- source: "memory" | "storage" | "network"
loc.refresh(function(lat, lon, source) end)
local lat, lon = loc.cached()             -- nil, nil on miss/stale
\`\`\`

Endpoint config (`require("ttymap.here").endpoint`) is shared with the `here` plugin, so one override applies to every consumer.

## Test plan

- [x] `cargo test --workspace` — 215 pass / 0 fail
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean
- [x] `every_bundled_script_registers_via_init_lua_chain` runs the real `runtime/init.lua` against every bundled plugin, so the migrated `here.lua`'s `require "ttymap.location"` is integration-checked
- [x] Manual: `:` → "Jump to here" — first press fetches + flies, second press in the same session flies instantly (memory hit)
- [x] Manual: restart ttymap within 24h of a prior run — first `:Jump to here` flies instantly (storage hit)

## Follow-up

#338 (`ttymap.geocode` cache lib) — separate sibling lib for forward + reverse geocoding with spatial bucketing, addressing duplicate Nominatim calls in `info` / `search` / `wiki`.