### PR TITLE
feat(tui): show scrollbar in command palette

### DIFF
--- a/ttymap-tui/src/palette/panel.rs
+++ b/ttymap-tui/src/palette/panel.rs
@@ -108,4 +108,19 @@ pub fn render_panel(widget: &PaletteComponent, win: &mut RenderWindow) {
         .column_spacing(1);
 
     win.table(table, chunks[2], &mut state);
+
+    // Match the rail to the table chunk (not the full popup) so it
+    // doesn't bleed alongside the prompt/blank rows above. The helper
+    // shrinks by 1 row each side internally, so pad by 1 here.
+    let table_chunk = chunks[2];
+    let scrollbar_rect = Rect::new(
+        popup_area.x,
+        table_chunk.y.saturating_sub(1),
+        popup_area.width,
+        table_chunk.height + 2,
+    );
+    let position = (widget.selected as u16)
+        .saturating_add(1)
+        .saturating_sub(rows);
+    win.scrollbar(scrollbar_rect, items.len() as u16, position, rows);
 }


### PR DESCRIPTION
## Summary

- Draw a vertical scrollbar on the right edge of the `:`-palette when items overflow `MAX_VISIBLE_ROWS`, using the existing `RenderWindow::scrollbar` helper.
- Rail rect is aligned to the table chunk (not the full popup), padded by 1 row each side to cancel the helper's internal `Margin(1, 0)`, so the rail doesn't bleed alongside the prompt/blank rows above.
- `position` = `selected + 1 − rows` (saturating) — matches ratatui's offset clamp when `TableState` is freshly constructed each frame.
- Title-based `selected/total` indicator kept (it's the selection cursor, distinct from viewport position).

Closes #344.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets`
- [x] `cargo test -p ttymap-tui`
- [x] Manual: open `:`, type a query that yields >10 results, scroll through and confirm thumb tracks viewport. Confirm no scrollbar when results fit.
- [x] Manual: confirm small terminals (height clamped below `MAX_VISIBLE_ROWS`) still render cleanly.