### PR TITLE
refactor: decouple event bus from mlua (#351 Step 1)

### DIFF
--- a/ttymap-app/src/app/mod.rs
+++ b/ttymap-app/src/app/mod.rs
@@ -108,6 +108,7 @@ impl App {
         let LuaSubsystem {
             handle: lua,
             bus,
+            ticks: _,
             registry,
             footer_hints,
         } = lua;

--- a/ttymap-app/src/event/bus.rs
+++ b/ttymap-app/src/event/bus.rs
@@ -1,17 +1,26 @@
 //! [`EventBus`] — main-thread pub/sub registry.
 //!
-//! Subscribers (Rust closures and Lua callbacks) register against an
+//! Subscribers (plain `Fn(&Event)` closures) register against an
 //! event name, and [`Self::publish`] fans an [`Event`] out to every
-//! registered subscriber for that name. Errors in any one Lua
-//! subscriber are logged + swallowed so a single broken plugin can't
-//! freeze the host.
+//! registered subscriber for that name.
+//!
+//! # Lua-agnostic
+//!
+//! The bus stores `Rc<dyn Fn(&Event)>` — it does not know about
+//! `mlua`. Lua plugins subscribe through `ttymap.on_event(name, fn)`
+//! (see `lua/api/register.rs`), which wraps the Lua callback in a
+//! Rust closure that captures the `mlua::Lua` + `RegistryKey` and
+//! handles the Lua call site (error logging, typed arg conversion).
+//! The per-frame `tick` event is **not** routed through the bus at
+//! all — it needs a borrowed `MapApi` that can't fit `&Event`, and
+//! lives in `lua/tick.rs` with its own `TickRegistry`.
 //!
 //! # Thread model
 //!
-//! Dispatch is **main-thread only** — `mlua::Lua` is `!Send`, so Lua
-//! callbacks must run there, and the [`Subscriber::Lua`] variant
-//! holds non-Send state. The bus uses [`RefCell`] (not `Mutex`)
-//! since there is exactly one accessor.
+//! Dispatch is **main-thread only** (`mlua::Lua` is `!Send`, and Lua
+//! callbacks captured into subscriber closures must run there). The
+//! bus uses [`RefCell`] (not `Mutex`) since there is exactly one
+//! accessor.
 //!
 //! Cross-thread publish is reachable through the App-level mpsc:
 //! producers wrap an [`Event`] in
@@ -20,60 +29,35 @@
 //!
 //! # Identity and removal
 //!
-//! Each successful `subscribe_*` call returns a monotonic `u64`. The
+//! Each successful `subscribe` call returns a monotonic `u64`. The
 //! Lua surface (e.g. `EventHandle`) wraps that ID so plugins can
 //! `:remove()` themselves later without name/lhs collisions.
 //!
 //! Dispatch is implemented as **ID snapshot + per-call lookup**: the
-//! bucket's IDs are cloned up front, then each subscriber is looked
-//! up by ID under a short-lived borrow that drops before the Lua
-//! callback runs. A callback may therefore call [`Self::remove`]
-//! (which takes `borrow_mut`) — concurrent removal naturally drops
-//! out at the next iteration's lookup. Re-subscription during
-//! dispatch is also safe; the new entry is *not* visible to the
-//! current dispatch (its ID is not in the snapshot) and will fire
-//! from the next `publish`.
-//!
-//! # The `tick` event
-//!
-//! `tick` is **Lua-only** and lives outside this file: per-frame
-//! draw needs a borrowed `MapApi`, which doesn't fit the typed
-//! [`Event`] shape, and pulling `MapApi` into `event/` would create
-//! a circular dep with `lua/`. The Lua-side tick dispatcher walks
-//! this bus's `tick` bucket via [`Self::for_each_lua_subscriber`].
+//! bucket's IDs are cloned up front, then each subscriber is cloned
+//! out under a short-lived borrow that drops before the callback
+//! runs. A callback may therefore call [`Self::remove`] (which takes
+//! `borrow_mut`) — concurrent removal naturally drops out at the
+//! next iteration's lookup. Re-subscription during dispatch is also
+//! safe; the new entry is *not* visible to the current dispatch (its
+//! ID is not in the snapshot) and will fire from the next `publish`.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use mlua::{Lua, RegistryKey};
-
 use super::Event;
 
-/// One registered subscriber. Stored under an event name in
-/// [`EventBus::subscribers`] paired with its issued ID, and invoked
-/// once per [`EventBus::publish`] for that name.
-pub enum Subscriber {
-    /// Pure-Rust callback. Sees the typed [`Event`] enum and decides
-    /// what to do (re-publish, mutate a side cache, etc). Boxed as
-    /// `Rc<dyn Fn>` so dispatch can clone the callback out, drop the
-    /// bus borrow, and *then* invoke — making it safe for the
-    /// callback to call `subscribe_*` / `remove` (both need
-    /// `borrow_mut`) on the bus.
-    Rust(Rc<dyn Fn(&Event)>),
-    /// Lua callback. The mlua state is the shared subsystem VM; the
-    /// registry key points at the function the script handed to
-    /// `ttymap.on_event` or `ttymap.api.frame.on_tick`.
-    Lua { lua: Lua, callback: RegistryKey },
-}
+/// One subscriber slot — its monotonic id paired with the callback.
+type Subscriber = (u64, Rc<dyn Fn(&Event)>);
 
 /// Pub/sub registry. Keyed by event name (the same string Lua
 /// scripts pass to `ttymap.on_event`). Subscribers within one bucket
 /// fire in registration order.
 #[derive(Default)]
 pub struct EventBus {
-    subscribers: RefCell<HashMap<&'static str, Vec<(u64, Subscriber)>>>,
+    subscribers: RefCell<HashMap<&'static str, Vec<Subscriber>>>,
     next_id: AtomicU64,
 }
 
@@ -82,27 +66,18 @@ impl EventBus {
         self.next_id.fetch_add(1, Ordering::Relaxed)
     }
 
-    /// Register a Rust subscriber for `event_name`. Returns a
-    /// monotonic ID that can be passed to [`Self::remove`].
-    pub fn subscribe_rust<F: Fn(&Event) + 'static>(&self, event_name: &'static str, f: F) -> u64 {
+    /// Register a subscriber for `event_name`. Returns a monotonic
+    /// ID that can be passed to [`Self::remove`]. The closure is
+    /// stored as `Rc<dyn Fn>` so dispatch can clone it out and drop
+    /// the bus borrow before invoking — letting the callback call
+    /// `subscribe` / `remove` on the bus without panicking.
+    pub fn subscribe<F: Fn(&Event) + 'static>(&self, event_name: &'static str, f: F) -> u64 {
         let id = self.allocate_id();
         self.subscribers
             .borrow_mut()
             .entry(event_name)
             .or_default()
-            .push((id, Subscriber::Rust(Rc::new(f))));
-        id
-    }
-
-    /// Register a Lua subscriber for `event_name`. Returns a
-    /// monotonic ID that can be passed to [`Self::remove`].
-    pub fn subscribe_lua(&self, event_name: &'static str, lua: Lua, callback: RegistryKey) -> u64 {
-        let id = self.allocate_id();
-        self.subscribers
-            .borrow_mut()
-            .entry(event_name)
-            .or_default()
-            .push((id, Subscriber::Lua { lua, callback }));
+            .push((id, Rc::new(f)));
         id
     }
 
@@ -119,8 +94,7 @@ impl EventBus {
         before != bucket.len()
     }
 
-    /// Total subscriber count across every bucket. Used as a
-    /// lower-bound smoke check by `every_bundled_script_registers`.
+    /// Total subscriber count across every bucket.
     pub fn len(&self) -> usize {
         self.subscribers.borrow().values().map(|v| v.len()).sum()
     }
@@ -138,154 +112,35 @@ impl EventBus {
         self.subscribers.borrow().values().all(|v| v.is_empty())
     }
 
-    /// Snapshot the current ID list for `event_name`. Order matches
-    /// registration order. Helper for the snapshot-then-lookup
-    /// dispatch pattern used by [`Self::publish`] and
-    /// [`Self::for_each_lua_subscriber`].
-    fn snapshot_ids(&self, event_name: &str) -> Vec<u64> {
-        self.subscribers
-            .borrow()
-            .get(event_name)
-            .map(|bucket| bucket.iter().map(|(id, _)| *id).collect())
-            .unwrap_or_default()
-    }
-
     /// Fan an [`Event`] out to every subscriber registered under
-    /// `event.name()`. Rust subscribers see `&Event` directly; Lua
-    /// subscribers receive the variant's typed Lua args
-    /// (`map_jumped` → `(lon, lat)`, `notify` → `{ message, level }`,
-    /// etc).
+    /// `event.name()`.
     ///
     /// Dispatch is snapshot-driven: a callback may call
-    /// [`Self::remove`] (including on itself) without disturbing the
-    /// in-flight dispatch.
+    /// [`Self::remove`] (including on itself) or `subscribe` from
+    /// inside without disturbing the in-flight dispatch.
     pub fn publish(&self, event: Event) {
         let name = event.name();
-        let ids = self.snapshot_ids(name);
-
-        // Per-call dispatch action — extracted from the bus under a
-        // short borrow so the borrow can drop before invoking. Lets
-        // a callback (Rust or Lua) call `subscribe_*` / `remove`
-        // (both `borrow_mut`) without panicking.
-        enum Action {
-            Skip,
-            Rust(Rc<dyn Fn(&Event)>),
-            Lua(Lua, mlua::Function),
-        }
+        let ids: Vec<u64> = self
+            .subscribers
+            .borrow()
+            .get(name)
+            .map(|bucket| bucket.iter().map(|(id, _)| *id).collect())
+            .unwrap_or_default();
 
         for id in ids {
-            let action = {
+            let extracted = {
                 let subs = self.subscribers.borrow();
                 let Some(bucket) = subs.get(name) else {
                     continue;
                 };
-                let Some((_, sub)) = bucket.iter().find(|(i, _)| *i == id) else {
-                    continue;
-                };
-                match sub {
-                    Subscriber::Rust(f) => Action::Rust(Rc::clone(f)),
-                    Subscriber::Lua { lua, callback } => {
-                        match lua.registry_value::<mlua::Function>(callback) {
-                            Ok(func) => Action::Lua(lua.clone(), func),
-                            Err(e) => {
-                                log::warn!(
-                                    "lua: {} subscriber registry lookup failed: {}",
-                                    name,
-                                    e
-                                );
-                                Action::Skip
-                            }
-                        }
-                    }
-                }
+                bucket
+                    .iter()
+                    .find(|(i, _)| *i == id)
+                    .map(|(_, f)| Rc::clone(f))
             };
-            match action {
-                Action::Skip => {}
-                Action::Rust(f) => f(&event),
-                Action::Lua(lua, func) => {
-                    if let Err(e) = call_lua_with_event(&func, &lua, &event) {
-                        log::warn!("lua: {} subscriber failed: {}", name, e);
-                    }
-                }
+            if let Some(f) = extracted {
+                f(&event);
             }
-        }
-    }
-
-    /// Run `f` once per Lua subscriber of `event_name`. Used by
-    /// callers that need to construct a custom Lua call site
-    /// per-subscriber — today only the `tick` dispatcher in
-    /// `lua/` (which builds a per-frame `MapApi` table inside
-    /// `Lua::scope`). Rust subscribers are skipped.
-    ///
-    /// Carved out so this module stays free of `crate::lua::*`
-    /// imports — the Lua-specific tick path is in `lua/` where it
-    /// belongs.
-    ///
-    /// `f` receives the `Function` directly (already resolved from
-    /// the registry key) so the bus can drop its borrow before
-    /// calling — a callback may therefore `remove` itself.
-    pub fn for_each_lua_subscriber<F>(&self, event_name: &str, mut f: F)
-    where
-        F: FnMut(&Lua, &mlua::Function),
-    {
-        let ids = self.snapshot_ids(event_name);
-        for id in ids {
-            let extracted = {
-                let subs = self.subscribers.borrow();
-                let Some(bucket) = subs.get(event_name) else {
-                    continue;
-                };
-                let Some((_, sub)) = bucket.iter().find(|(i, _)| *i == id) else {
-                    continue;
-                };
-                match sub {
-                    Subscriber::Lua { lua, callback } => {
-                        match lua.registry_value::<mlua::Function>(callback) {
-                            Ok(func) => Some((lua.clone(), func)),
-                            Err(e) => {
-                                log::warn!(
-                                    "lua: {} subscriber registry lookup failed: {}",
-                                    event_name,
-                                    e
-                                );
-                                None
-                            }
-                        }
-                    }
-                    Subscriber::Rust(_) => None,
-                }
-            };
-            if let Some((lua, func)) = extracted {
-                f(&lua, &func);
-            }
-        }
-    }
-}
-
-/// Build the Lua arg tuple for `event` and call `f`. Each [`Event`]
-/// variant maps to the same shape Lua plugins have always seen — so
-/// existing scripts (`function on_jump(lon, lat) … end`) keep working.
-fn call_lua_with_event(f: &mlua::Function, lua: &Lua, event: &Event) -> mlua::Result<()> {
-    use crate::event::Level;
-    match event {
-        Event::FrameReady => f.call::<()>(()),
-        Event::MapJumped(ll) => f.call::<()>((ll.lon, ll.lat)),
-        Event::MapZoomSet(z) => f.call::<()>(*z),
-        Event::MapFlewTo(ll, z) => f.call::<()>((ll.lon, ll.lat, *z)),
-        Event::ThemeChanged(name) => f.call::<()>(name.as_str()),
-        Event::Resized(c, r) => f.call::<()>((*c, *r)),
-        Event::Notify { message, level } => {
-            let t = lua.create_table()?;
-            t.set("message", message.as_str())?;
-            t.set(
-                "level",
-                match level {
-                    Level::Info => "info",
-                    Level::Warn => "warn",
-                    Level::Error => "error",
-                },
-            )?;
-            f.call::<()>(t)
         }
     }
 }
@@ -293,166 +148,51 @@ fn call_lua_with_event(f: &mlua::Function, lua: &Lua, event: &Event) -> mlua::Re
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
     use ttymap_engine::geo::LonLat;
 
     #[test]
     fn publish_only_runs_subscribers_for_the_named_event() {
-        let lua = Lua::new();
-        lua.load(
-            r#"
-            other_count = 0
-            function bump() other_count = other_count + 1 end
-            "#,
-        )
-        .exec()
-        .unwrap();
-        let f: mlua::Function = lua.globals().get("bump").unwrap();
-        let key = lua.create_registry_value(f).unwrap();
-
         let bus = EventBus::default();
-        bus.subscribe_lua("frame_ready", lua.clone(), key);
+        let other_count = Rc::new(Cell::new(0));
+        let sink = other_count.clone();
+        bus.subscribe("frame_ready", move |_| sink.set(sink.get() + 1));
+
         bus.publish(Event::MapJumped(LonLat { lon: 1.0, lat: 2.0 }));
 
-        let n: i64 = lua.globals().get("other_count").unwrap();
-        assert_eq!(n, 0, "publish must skip buckets for other event names");
+        assert_eq!(
+            other_count.get(),
+            0,
+            "publish must skip buckets for other event names",
+        );
     }
 
     #[test]
-    fn publish_passes_typed_args_through() {
-        let lua = Lua::new();
-        lua.load(
-            r#"
-            captured_lon = 0.0
-            captured_lat = 0.0
-            function record(lon, lat)
-                captured_lon = lon
-                captured_lat = lat
-            end
-            "#,
-        )
-        .exec()
-        .unwrap();
-        let f: mlua::Function = lua.globals().get("record").unwrap();
-        let key = lua.create_registry_value(f).unwrap();
-
+    fn publish_passes_typed_event_through() {
         let bus = EventBus::default();
-        bus.subscribe_lua("map_jumped", lua.clone(), key);
+        let captured: Rc<RefCell<Option<LonLat>>> = Rc::new(RefCell::new(None));
+        let sink = captured.clone();
+        bus.subscribe("map_jumped", move |e| {
+            if let Event::MapJumped(ll) = e {
+                *sink.borrow_mut() = Some(*ll);
+            }
+        });
         bus.publish(Event::MapJumped(LonLat {
             lon: 139.7595,
             lat: 35.6828,
         }));
 
-        let lon: f64 = lua.globals().get("captured_lon").unwrap();
-        let lat: f64 = lua.globals().get("captured_lat").unwrap();
-        assert!((lon - 139.7595).abs() < 1e-9);
-        assert!((lat - 35.6828).abs() < 1e-9);
-    }
-
-    #[test]
-    fn notify_event_passes_table_payload_with_message_and_level() {
-        let lua = Lua::new();
-        lua.load(
-            r#"
-            captured_msg = ""
-            captured_level = ""
-            function on_notify(e)
-                captured_msg = e.message
-                captured_level = e.level
-            end
-            "#,
-        )
-        .exec()
-        .unwrap();
-        let f: mlua::Function = lua.globals().get("on_notify").unwrap();
-        let key = lua.create_registry_value(f).unwrap();
-
-        let bus = EventBus::default();
-        bus.subscribe_lua("notify", lua.clone(), key);
-        bus.publish(Event::Notify {
-            message: "hello".to_string(),
-            level: super::super::Level::Warn,
-        });
-
-        let msg: String = lua.globals().get("captured_msg").unwrap();
-        let level: String = lua.globals().get("captured_level").unwrap();
-        assert_eq!(msg, "hello");
-        assert_eq!(level, "warn");
-    }
-
-    #[test]
-    fn rust_subscriber_sees_typed_event_directly() {
-        use std::cell::RefCell;
-        use std::rc::Rc;
-
-        let captured = Rc::new(RefCell::new(0_f64));
-        let sink = captured.clone();
-        let bus = EventBus::default();
-        bus.subscribe_rust("map_zoom_set", move |e| {
-            if let Event::MapZoomSet(z) = e {
-                *sink.borrow_mut() = *z;
-            }
-        });
-        bus.publish(Event::MapZoomSet(7.5));
-        assert!((*captured.borrow() - 7.5).abs() < 1e-9);
-    }
-
-    #[test]
-    fn dispatch_continues_after_a_lua_subscriber_errors() {
-        let lua_bad = Lua::new();
-        lua_bad
-            .load(r#"function bang() error("boom") end"#)
-            .exec()
-            .unwrap();
-        let bad_fn: mlua::Function = lua_bad.globals().get("bang").unwrap();
-        let bad_key = lua_bad.create_registry_value(bad_fn).unwrap();
-
-        let lua_good = Lua::new();
-        lua_good
-            .load(
-                r#"
-                ok_count = 0
-                function bump() ok_count = ok_count + 1 end
-                "#,
-            )
-            .exec()
-            .unwrap();
-        let good_fn: mlua::Function = lua_good.globals().get("bump").unwrap();
-        let good_key = lua_good.create_registry_value(good_fn).unwrap();
-
-        let bus = EventBus::default();
-        bus.subscribe_lua("frame_ready", lua_bad, bad_key);
-        bus.subscribe_lua("frame_ready", lua_good.clone(), good_key);
-
-        bus.publish(Event::FrameReady);
-
-        let ok: i64 = lua_good.globals().get("ok_count").unwrap();
-        assert_eq!(ok, 1, "good subscriber must still fire after bad errors");
-    }
-
-    #[test]
-    fn for_each_lua_subscriber_skips_rust_and_other_buckets() {
-        let lua = Lua::new();
-        let make_noop = || {
-            let f: mlua::Function = lua.load(r#"return function() end"#).eval().unwrap();
-            lua.create_registry_value(f).unwrap()
-        };
-
-        let bus = EventBus::default();
-        bus.subscribe_lua("tick", lua.clone(), make_noop());
-        bus.subscribe_rust("tick", |_| {});
-        bus.subscribe_lua("frame_ready", lua.clone(), make_noop());
-
-        let mut count = 0;
-        bus.for_each_lua_subscriber("tick", |_, _| count += 1);
-        assert_eq!(count, 1, "must skip the Rust sub and the other bucket");
+        let ll = captured.borrow().expect("subscriber must have captured");
+        assert!((ll.lon - 139.7595).abs() < 1e-9);
+        assert!((ll.lat - 35.6828).abs() < 1e-9);
     }
 
     #[test]
     fn subscribe_returns_distinct_monotonic_ids() {
         let bus = EventBus::default();
-        let id_a = bus.subscribe_rust("frame_ready", |_| {});
-        let id_b = bus.subscribe_rust("frame_ready", |_| {});
-        let id_c = bus.subscribe_rust("map_jumped", |_| {});
+        let id_a = bus.subscribe("frame_ready", |_| {});
+        let id_b = bus.subscribe("frame_ready", |_| {});
+        let id_c = bus.subscribe("map_jumped", |_| {});
         assert_ne!(id_a, id_b);
         assert!(id_b > id_a);
         assert!(id_c > id_b, "ids are global, not per-bucket");
@@ -460,16 +200,13 @@ mod tests {
 
     #[test]
     fn remove_drops_only_the_named_subscriber() {
-        use std::cell::Cell;
-        use std::rc::Rc;
-
         let a = Rc::new(Cell::new(0));
         let b = Rc::new(Cell::new(0));
         let bus = EventBus::default();
         let a_sink = a.clone();
         let b_sink = b.clone();
-        let id_a = bus.subscribe_rust("frame_ready", move |_| a_sink.set(a_sink.get() + 1));
-        let _id_b = bus.subscribe_rust("frame_ready", move |_| b_sink.set(b_sink.get() + 1));
+        let id_a = bus.subscribe("frame_ready", move |_| a_sink.set(a_sink.get() + 1));
+        let _id_b = bus.subscribe("frame_ready", move |_| b_sink.set(b_sink.get() + 1));
 
         bus.publish(Event::FrameReady);
         assert_eq!(a.get(), 1);
@@ -482,57 +219,42 @@ mod tests {
 
         assert!(
             !bus.remove("frame_ready", id_a),
-            "second remove returns false"
+            "second remove returns false",
         );
         assert!(
             !bus.remove("nonexistent", 999),
-            "missing bucket returns false"
+            "missing bucket returns false",
         );
     }
 
     #[test]
-    fn lua_callback_can_remove_itself_during_dispatch() {
-        // The bus must not panic when a Lua callback calls
+    fn callback_can_remove_itself_during_dispatch() {
+        // The bus must not panic when a callback calls
         // `EventBus::remove(...)` on itself from inside dispatch —
-        // exercises the "drop borrow before calling Lua" property
-        // that future Lua-side `:remove()` will rely on.
-        use std::cell::Cell;
-        use std::rc::Rc;
+        // exercises the "drop borrow before calling" property the
+        // Lua `:remove()` surface relies on.
+        let bus = Rc::new(EventBus::default());
+        let fire_count = Rc::new(Cell::new(0));
 
-        let lua = Lua::new();
-        lua.load(
-            r#"
-            fire_count = 0
-            function bump() fire_count = fire_count + 1 end
-            "#,
-        )
-        .exec()
-        .unwrap();
-        let f: mlua::Function = lua.globals().get("bump").unwrap();
-        let key = lua.create_registry_value(f).unwrap();
-
-        let bus = std::rc::Rc::new(EventBus::default());
-        let id = bus.subscribe_lua("frame_ready", lua.clone(), key);
-
-        // A Rust sub that, when dispatched, removes the Lua sub from
-        // the same bucket. This is the in-dispatch removal path.
-        let bus_for_closure = Rc::clone(&bus);
-        let saw_lua = Rc::new(Cell::new(false));
-        let saw_lua_for_closure = saw_lua.clone();
-        bus.subscribe_rust("frame_ready", move |_| {
-            // Confirm the Lua sub has fired by this point if it was
-            // first in registration order (it was — id allocated
-            // before this rust closure).
-            saw_lua_for_closure.set(true);
-            bus_for_closure.remove("frame_ready", id);
+        // Subscriber A: counts its own fires AND removes itself.
+        let bus_for_a = Rc::clone(&bus);
+        let fire_for_a = fire_count.clone();
+        let id_holder: Rc<Cell<u64>> = Rc::new(Cell::new(0));
+        let id_holder_for_a = id_holder.clone();
+        let id = bus.subscribe("frame_ready", move |_| {
+            fire_for_a.set(fire_for_a.get() + 1);
+            bus_for_a.remove("frame_ready", id_holder_for_a.get());
         });
+        id_holder.set(id);
 
         bus.publish(Event::FrameReady);
         bus.publish(Event::FrameReady);
 
-        let n: i64 = lua.globals().get("fire_count").unwrap();
-        assert_eq!(n, 1, "lua sub should fire once then be removed");
-        assert!(saw_lua.get(), "rust sub also fired");
+        assert_eq!(
+            fire_count.get(),
+            1,
+            "callback should fire once then be removed",
+        );
     }
 
     #[test]
@@ -541,33 +263,28 @@ mod tests {
         // RefCell. The new entry is *not* visible to the in-flight
         // publish (it's not in the snapshot), but a subsequent
         // publish must fire it.
-        use std::cell::Cell;
-        use std::rc::Rc;
-
-        let bus = std::rc::Rc::new(EventBus::default());
+        let bus = Rc::new(EventBus::default());
         let inner_fired = Rc::new(Cell::new(0));
         let inner_fired_clone = inner_fired.clone();
         let bus_for_closure = Rc::clone(&bus);
         let outer_fired = Rc::new(Cell::new(0));
         let outer_fired_clone = outer_fired.clone();
-        bus.subscribe_rust("frame_ready", move |_| {
+        bus.subscribe("frame_ready", move |_| {
             outer_fired_clone.set(outer_fired_clone.get() + 1);
-            // Subscribe a new closure during dispatch.
             let inner_sink = inner_fired_clone.clone();
-            bus_for_closure.subscribe_rust("frame_ready", move |_| {
+            bus_for_closure.subscribe("frame_ready", move |_| {
                 inner_sink.set(inner_sink.get() + 1);
             });
         });
 
         bus.publish(Event::FrameReady);
-        // Inner sub registered during dispatch but not in this
-        // snapshot, so it shouldn't have fired yet.
-        assert_eq!(inner_fired.get(), 0);
+        assert_eq!(
+            inner_fired.get(),
+            0,
+            "inner registered during dispatch must not be in this snapshot",
+        );
         assert_eq!(outer_fired.get(), 1);
 
-        // Second publish: snapshot now includes the inner sub plus
-        // ANOTHER copy registered by the outer firing again, etc.
-        // Just assert nothing panics and inner_fired increments.
         bus.publish(Event::FrameReady);
         assert!(inner_fired.get() >= 1);
     }

--- a/ttymap-app/src/event/mod.rs
+++ b/ttymap-app/src/event/mod.rs
@@ -7,14 +7,17 @@
 //! [`crate::app::AppEvent::Bus`] and push onto the App-level mpsc;
 //! the main loop drains and calls [`EventBus::publish`].
 //!
-//! Subscribers come in two flavours:
-//! - [`Subscriber::Rust`] — a closure invoked with `&Event`.
-//! - [`Subscriber::Lua`] — an `mlua::Function` invoked with the
-//!   event's typed Lua args (`map_jumped` → `(lon, lat)`, etc).
+//! Subscribers are plain `Fn(&Event)` closures stored as
+//! `Rc<dyn Fn>`. Lua plugins subscribe through
+//! `ttymap.on_event(name, fn)` (see `crate::lua::api::register`),
+//! which wraps the Lua callback in a Rust closure that captures the
+//! `mlua::Lua` + `RegistryKey` and handles the Lua call site —
+//! keeping `event/` free of any `mlua` import.
 //!
-//! The `tick` per-frame draw hook is **not** an [`Event`] variant —
-//! it requires a borrowed `MapApi` for that frame and lives in
-//! [`EventBus::dispatch_tick`].
+//! The `tick` per-frame draw hook is **not** an [`Event`] variant
+//! and is **not** routed through the bus at all — it requires a
+//! borrowed `MapApi` that can't fit `&Event`, and lives in
+//! `crate::lua::tick` with its own `TickRegistry`.
 //!
 //! Pattern modelled after Yazi's `yazi-dds` (Rust + Lua TUI with
 //! exactly this constraint set).
@@ -22,5 +25,5 @@
 pub mod bus;
 pub mod payload;
 
-pub use bus::{EventBus, Subscriber};
+pub use bus::EventBus;
 pub use payload::{Event, Level};

--- a/ttymap-app/src/lua/api/imperative.rs
+++ b/ttymap-app/src/lua/api/imperative.rs
@@ -30,8 +30,8 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::compositor::op::{Op, OpsBuffer};
-use crate::event::EventBus;
 use crate::lua::host::LuaHostShared;
+use crate::lua::tick::TickRegistry;
 
 /// Build the `ttymap.api` sub-table and attach it. Called from
 /// [`super::install`] after activation surfaces are registered.
@@ -40,13 +40,13 @@ pub(super) fn install(
     ttymap: &Table,
     ops: OpsBuffer,
     shared: Arc<LuaHostShared>,
-    bus: Rc<EventBus>,
+    ticks: Rc<TickRegistry>,
 ) -> mlua::Result<()> {
     let api = lua.create_table()?;
 
     api.set("card", build_card_table(lua, ops.clone())?)?;
     api.set("palette", build_palette_table(lua, ops.clone())?)?;
-    api.set("frame", build_frame_table(lua, ops, shared, bus)?)?;
+    api.set("frame", build_frame_table(lua, ops, shared, ticks)?)?;
 
     ttymap.set("api", api)?;
     Ok(())
@@ -122,7 +122,7 @@ fn build_frame_table(
     lua: &Lua,
     _ops: OpsBuffer,
     shared: Arc<LuaHostShared>,
-    bus: Rc<EventBus>,
+    ticks: Rc<TickRegistry>,
 ) -> mlua::Result<Table> {
     let frame_api = lua.create_table()?;
 
@@ -146,9 +146,10 @@ fn build_frame_table(
     // it reads more naturally for the per-frame use case. New
     // event surfaces should use `ttymap.on_event` directly.
     //
-    // Subscribes directly against the [`EventBus`] at call time and
-    // returns an [`EventHandle`] so the caller can `:remove()` later.
-    let bus_for_on_tick = bus;
+    // Subscribes against the [`TickRegistry`] (not the typed-event
+    // bus) at call time and returns an [`EventHandle`] whose
+    // `:remove()` drops the subscriber.
+    let ticks_for_on_tick = ticks;
     frame_api.set(
         "on_tick",
         lua.create_function(
@@ -157,8 +158,11 @@ fn build_frame_table(
                   -> mlua::Result<crate::lua::bridge::event_handle::EventHandle> {
                 use crate::lua::bridge::event_handle::EventHandle;
                 let key = lua.create_registry_value(callback)?;
-                let id = bus_for_on_tick.subscribe_lua("tick", lua.clone(), key);
-                Ok(EventHandle::new(bus_for_on_tick.clone(), "tick", id))
+                let id = ticks_for_on_tick.subscribe(lua.clone(), key);
+                let ticks_for_remove = Rc::clone(&ticks_for_on_tick);
+                Ok(EventHandle::new(Rc::new(move || {
+                    ticks_for_remove.remove(id);
+                })))
             },
         )?,
     )?;

--- a/ttymap-app/src/lua/api/mod.rs
+++ b/ttymap-app/src/lua/api/mod.rs
@@ -158,6 +158,7 @@ pub fn install(
     shared: Arc<LuaHostShared>,
     ops: crate::compositor::op::OpsBuffer,
     bus: std::rc::Rc<crate::event::EventBus>,
+    ticks: std::rc::Rc<crate::lua::tick::TickRegistry>,
     registry: crate::lua::registrar::LuaRegistryHandle,
 ) -> mlua::Result<LuaHostHandles> {
     // Fire-and-forget Lua intents (`map:jump`, `:zoom`, `:fly_to`,
@@ -212,14 +213,14 @@ pub fn install(
     // Activation surfaces (`register_palette_command` /
     // `register_keybind` / `on_event`) — every call pushes directly
     // into the live `LuaRegistry` (or, for `on_event`, subscribes
-    // directly against the bus) and returns a Lua-facing handle.
-    // No deferred capture, no per-script slot.
-    register::install(lua, &ttymap, bus.clone(), registry, shared.clone())?;
+    // directly against the bus / tick registry) and returns a
+    // Lua-facing handle. No deferred capture, no per-script slot.
+    register::install(lua, &ttymap, bus, ticks.clone(), registry, shared.clone())?;
 
     // Imperative primitives (`ttymap.api.{card,palette,frame}`) —
     // runtime-time `open` / `to_ansi` / `on_tick` calls a plugin
     // makes from inside its callbacks.
-    imperative::install(lua, &ttymap, ops.clone(), shared.clone(), bus)?;
+    imperative::install(lua, &ttymap, ops.clone(), shared.clone(), ticks)?;
 
     // ── ttymap.notify ────────────────────────────────────────────────
     //
@@ -279,9 +280,17 @@ mod tests {
         let lua = mlua::Lua::new();
         let ops = crate::compositor::op::new_ops_buffer();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
+        let ticks = std::rc::Rc::new(crate::lua::tick::TickRegistry::default());
         let registry = crate::lua::new_lua_registry();
-        let handles = install(&lua, LuaHostShared::empty(), ops.clone(), bus, registry)
-            .expect("install ttymap table");
+        let handles = install(
+            &lua,
+            LuaHostShared::empty(),
+            ops.clone(),
+            bus,
+            ticks,
+            registry,
+        )
+        .expect("install ttymap table");
         (lua, handles, ops)
     }
 
@@ -408,11 +417,13 @@ mod tests {
         let lua = mlua::Lua::new();
         let shared = LuaHostShared::empty();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
+        let ticks = std::rc::Rc::new(crate::lua::tick::TickRegistry::default());
         let _handles = install(
             &lua,
             shared.clone(),
             crate::compositor::op::new_ops_buffer(),
             bus,
+            ticks,
             crate::lua::new_lua_registry(),
         )
         .expect("install ttymap table");
@@ -438,16 +449,20 @@ mod tests {
     }
 
     #[test]
-    fn api_frame_on_tick_subscribes_each_callback_against_the_bus() {
+    fn api_frame_on_tick_subscribes_each_callback_against_the_tick_registry() {
         // Each `ttymap.api.frame.on_tick(fn)` call subscribes
-        // directly to the bus (one entry per call).
+        // directly to the per-frame `TickRegistry` (not the
+        // typed-event bus — the tick payload is a borrowed
+        // `MapApi` that can't ride `&Event`).
         let lua = mlua::Lua::new();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
+        let ticks = std::rc::Rc::new(crate::lua::tick::TickRegistry::default());
         let _handles = install(
             &lua,
             LuaHostShared::empty(),
             crate::compositor::op::new_ops_buffer(),
-            bus.clone(),
+            bus,
+            ticks.clone(),
             crate::lua::new_lua_registry(),
         )
         .expect("install ttymap table");
@@ -460,24 +475,26 @@ mod tests {
         .exec()
         .expect("exec");
         assert_eq!(
-            bus.count("tick"),
+            ticks.len(),
             2,
-            "two on_tick calls -> two bus subscribers"
+            "two on_tick calls -> two tick-registry subscribers",
         );
     }
 
     #[test]
     fn on_event_subscribes_against_the_named_bucket() {
-        // `ttymap.on_event(name, fn)` — generic surface. Each call
-        // subscribes directly under its event name on the shared
-        // bus; multiple distinct names land in distinct buckets.
+        // `ttymap.on_event(name, fn)` — generic surface. Routing:
+        // `"tick"` goes to the per-frame `TickRegistry`, everything
+        // else subscribes against the typed-event bus.
         let lua = mlua::Lua::new();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
+        let ticks = std::rc::Rc::new(crate::lua::tick::TickRegistry::default());
         let _handles = install(
             &lua,
             LuaHostShared::empty(),
             crate::compositor::op::new_ops_buffer(),
             bus.clone(),
+            ticks.clone(),
             crate::lua::new_lua_registry(),
         )
         .expect("install ttymap table");
@@ -490,7 +507,12 @@ mod tests {
         )
         .exec()
         .expect("exec");
-        assert_eq!(bus.count("tick"), 1);
+        assert_eq!(ticks.len(), 1, "tick lands in the tick registry");
+        assert_eq!(
+            bus.count("tick"),
+            0,
+            "tick never lands on the typed-event bus",
+        );
         assert_eq!(bus.count("frame_ready"), 2);
     }
 
@@ -501,11 +523,13 @@ mod tests {
         // the bus. Idempotent: a second call is a no-op.
         let lua = mlua::Lua::new();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
+        let ticks = std::rc::Rc::new(crate::lua::tick::TickRegistry::default());
         let _handles = install(
             &lua,
             LuaHostShared::empty(),
             crate::compositor::op::new_ops_buffer(),
             bus.clone(),
+            ticks,
             crate::lua::new_lua_registry(),
         )
         .expect("install ttymap table");
@@ -523,7 +547,7 @@ mod tests {
         assert_eq!(
             bus.count("frame_ready"),
             0,
-            "handle:remove() must drop the subscriber"
+            "handle:remove() must drop the subscriber",
         );
     }
 
@@ -534,11 +558,13 @@ mod tests {
         // error at register time so the plugin author finds it.
         let lua = mlua::Lua::new();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
+        let ticks = std::rc::Rc::new(crate::lua::tick::TickRegistry::default());
         let _handles = install(
             &lua,
             LuaHostShared::empty(),
             crate::compositor::op::new_ops_buffer(),
             bus,
+            ticks,
             crate::lua::new_lua_registry(),
         )
         .expect("install ttymap table");

--- a/ttymap-app/src/lua/api/register.rs
+++ b/ttymap-app/src/lua/api/register.rs
@@ -21,24 +21,26 @@ use crossterm::event::{KeyCode, KeyModifiers};
 use mlua::{Lua, Table};
 
 use crate::compositor::{Activation, PaletteEntry, SpawnComponent};
-use crate::event::EventBus;
+use crate::event::{Event, EventBus, Level};
 use crate::lua::bridge::event_handle::EventHandle;
 use crate::lua::bridge::registrar_handle::{
     KeybindHandle, PaletteCommandHandle, allocate_handle_id,
 };
 use crate::lua::host::{HelpEntry, LuaHostShared};
 use crate::lua::registrar::LuaRegistryHandle;
+use crate::lua::tick::TickRegistry;
 
 pub(super) fn install(
     lua: &Lua,
     ttymap: &Table,
     bus: Rc<EventBus>,
+    ticks: Rc<TickRegistry>,
     registry: LuaRegistryHandle,
     shared: Arc<LuaHostShared>,
 ) -> mlua::Result<()> {
     install_register_palette_command(lua, ttymap, registry.clone(), shared)?;
     install_register_keybind(lua, ttymap, registry)?;
-    install_on_event(lua, ttymap, bus)?;
+    install_on_event(lua, ttymap, bus, ticks)?;
     Ok(())
 }
 
@@ -181,10 +183,25 @@ fn intern_event_name(name: &str) -> &'static str {
 }
 
 /// `ttymap.on_event(name, fn) -> EventHandle` — generic pub/sub
-/// subscription. Subscribes directly against the
-/// [`EventBus`](crate::event::EventBus) at call time and returns a
-/// handle whose `:remove()` drops the exact subscriber.
-fn install_on_event(lua: &Lua, ttymap: &Table, bus: Rc<EventBus>) -> mlua::Result<()> {
+/// subscription. Routes by name:
+///
+/// - `"tick"` goes to the [`TickRegistry`] (per-frame callback with
+///   a `map` arg) — same path as `ttymap.api.frame.on_tick(fn)`.
+/// - everything else subscribes against the [`EventBus`], with the
+///   Lua callback wrapped in a Rust closure that captures the
+///   `mlua::Lua` + `RegistryKey` and converts each [`Event`] variant
+///   to the typed Lua args historic plugins expect
+///   (`map_jumped` → `(lon, lat)`, `notify` → `{ message, level }`,
+///   etc).
+///
+/// Returns a handle whose `:remove()` drops the exact subscriber
+/// from the registry it landed in.
+fn install_on_event(
+    lua: &Lua,
+    ttymap: &Table,
+    bus: Rc<EventBus>,
+    ticks: Rc<TickRegistry>,
+) -> mlua::Result<()> {
     ttymap.set(
         "on_event",
         lua.create_function(
@@ -196,11 +213,73 @@ fn install_on_event(lua: &Lua, ttymap: &Table, bus: Rc<EventBus>) -> mlua::Resul
                         "ttymap.on_event: event name must be a non-empty string",
                     ));
                 }
+
+                if event_name == "tick" {
+                    // `tick` payload is a per-frame `map` table built
+                    // in `TickRegistry::dispatch` — can't ride the
+                    // typed-Event bus.
+                    let key = lua.create_registry_value(callback)?;
+                    let id = ticks.subscribe(lua.clone(), key);
+                    let ticks_for_remove = Rc::clone(&ticks);
+                    return Ok(EventHandle::new(Rc::new(move || {
+                        ticks_for_remove.remove(id);
+                    })));
+                }
+
                 let interned = intern_event_name(&event_name);
-                let key = lua.create_registry_value(callback)?;
-                let id = bus.subscribe_lua(interned, lua.clone(), key);
-                Ok(EventHandle::new(bus.clone(), interned, id))
+                let key = Rc::new(lua.create_registry_value(callback)?);
+                let lua_for_closure = lua.clone();
+                let key_for_closure = Rc::clone(&key);
+                let id = bus.subscribe(interned, move |event| {
+                    let f: mlua::Function =
+                        match lua_for_closure.registry_value::<mlua::Function>(&key_for_closure) {
+                            Ok(f) => f,
+                            Err(e) => {
+                                log::warn!(
+                                    "lua: {} subscriber registry lookup failed: {}",
+                                    interned,
+                                    e,
+                                );
+                                return;
+                            }
+                        };
+                    if let Err(e) = call_lua_with_event(&f, &lua_for_closure, event) {
+                        log::warn!("lua: {} subscriber failed: {}", interned, e);
+                    }
+                });
+
+                let bus_for_remove = Rc::clone(&bus);
+                Ok(EventHandle::new(Rc::new(move || {
+                    bus_for_remove.remove(interned, id);
+                })))
             },
         )?,
     )
+}
+
+/// Build the Lua arg tuple for `event` and call `f`. Each [`Event`]
+/// variant maps to the same shape Lua plugins have always seen — so
+/// existing scripts (`function on_jump(lon, lat) … end`) keep working.
+fn call_lua_with_event(f: &mlua::Function, lua: &Lua, event: &Event) -> mlua::Result<()> {
+    match event {
+        Event::FrameReady => f.call::<()>(()),
+        Event::MapJumped(ll) => f.call::<()>((ll.lon, ll.lat)),
+        Event::MapZoomSet(z) => f.call::<()>(*z),
+        Event::MapFlewTo(ll, z) => f.call::<()>((ll.lon, ll.lat, *z)),
+        Event::ThemeChanged(name) => f.call::<()>(name.as_str()),
+        Event::Resized(c, r) => f.call::<()>((*c, *r)),
+        Event::Notify { message, level } => {
+            let t = lua.create_table()?;
+            t.set("message", message.as_str())?;
+            t.set(
+                "level",
+                match level {
+                    Level::Info => "info",
+                    Level::Warn => "warn",
+                    Level::Error => "error",
+                },
+            )?;
+            f.call::<()>(t)
+        }
+    }
 }

--- a/ttymap-app/src/lua/bridge/event_handle.rs
+++ b/ttymap-app/src/lua/bridge/event_handle.rs
@@ -1,41 +1,49 @@
 //! `ttymap.api.frame.on_tick(fn) -> EventHandle` and
 //! `ttymap.on_event(name, fn) -> EventHandle` — Lua-facing handle to
-//! one bus subscription, whose only method is `:remove()`.
+//! one subscription, whose only method is `:remove()`.
 //!
 //! Disposable shape (VS Code-style): the Rust side returns a handle
-//! at registration time; calling `:remove()` removes that exact
-//! subscriber from the [`EventBus`]. Idempotent — a second `:remove()`
-//! is a no-op (the bus's `remove` returns false but doesn't panic).
+//! at registration time; calling `:remove()` invokes the captured
+//! remove closure, which drops the subscriber from whichever
+//! registry it was stored in (the [`EventBus`] for typed events, the
+//! [`TickRegistry`] for `tick`). Idempotent — a second `:remove()`
+//! is a no-op because every registry's `remove` returns `false`
+//! without panicking on an already-dropped ID.
+//!
+//! Held as `Rc<dyn Fn()>` rather than a `Box` so the same handle can
+//! be cloned by Lua's userdata machinery and `:remove()` is callable
+//! from any clone. Cleared to a no-op closure after the first call
+//! to short-circuit follow-up borrows on a stale registry.
 //!
 //! Distinct type from [`super::card_handle::CardHandle`] /
 //! [`super::palette_handle::PaletteHandle`] because the receptacle
 //! and verb differ — the latter close compositor stack entries
-//! (`Op::Close`), this one removes a bus subscription. Same pattern,
+//! (`Op::Close`), this one removes a subscription. Same pattern,
 //! intentionally different identity so `:remove()` vs `:close()`
 //! reads naturally to plugin authors.
+//!
+//! [`EventBus`]: crate::event::EventBus
+//! [`TickRegistry`]: crate::lua::tick::TickRegistry
 
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use mlua::UserData;
 
-use crate::event::EventBus;
-
 /// Lua-facing handle returned by `ttymap.api.frame.on_tick(...)` and
-/// `ttymap.on_event(name, fn)`. Holds a back-reference to the bus
-/// plus the `(event_name, id)` pair the bus needs to drop the right
-/// subscriber.
+/// `ttymap.on_event(name, fn)`. Holds a one-shot remove closure that
+/// targets the right registry (bus or tick).
 pub struct EventHandle {
-    bus: Rc<EventBus>,
-    event_name: &'static str,
-    id: u64,
+    remove: RefCell<Option<Rc<dyn Fn()>>>,
 }
 
 impl EventHandle {
-    pub fn new(bus: Rc<EventBus>, event_name: &'static str, id: u64) -> Self {
+    /// Wrap a remove closure. The closure should drop the
+    /// subscriber from whichever registry the caller registered
+    /// against; the handle calls it at most once.
+    pub fn new(remove: Rc<dyn Fn()>) -> Self {
         Self {
-            bus,
-            event_name,
-            id,
+            remove: RefCell::new(Some(remove)),
         }
     }
 }
@@ -43,7 +51,9 @@ impl EventHandle {
 impl UserData for EventHandle {
     fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
         methods.add_method("remove", |_, this, _: ()| {
-            this.bus.remove(this.event_name, this.id);
+            if let Some(f) = this.remove.borrow_mut().take() {
+                f();
+            }
             Ok(())
         });
     }
@@ -52,37 +62,34 @@ impl UserData for EventHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::Event;
+    use crate::event::{Event, EventBus};
 
     #[test]
     fn remove_drops_the_subscriber_and_is_idempotent() {
         let bus = Rc::new(EventBus::default());
-        let lua = mlua::Lua::new();
-        lua.load(
-            r#"
-            fired = 0
-            function bump() fired = fired + 1 end
-            "#,
-        )
-        .exec()
-        .unwrap();
-        let f: mlua::Function = lua.globals().get("bump").unwrap();
-        let key = lua.create_registry_value(f).unwrap();
-        let id = bus.subscribe_lua("frame_ready", lua.clone(), key);
+        let fired: Rc<std::cell::Cell<i64>> = Rc::new(std::cell::Cell::new(0));
+        let sink = fired.clone();
+        let id = bus.subscribe("frame_ready", move |_| sink.set(sink.get() + 1));
 
         bus.publish(Event::FrameReady);
-        let n: i64 = lua.globals().get("fired").unwrap();
-        assert_eq!(n, 1);
+        assert_eq!(fired.get(), 1);
 
-        let ud = lua
-            .create_userdata(EventHandle::new(Rc::clone(&bus), "frame_ready", id))
-            .unwrap();
+        let bus_for_remove = Rc::clone(&bus);
+        let handle = EventHandle::new(Rc::new(move || {
+            bus_for_remove.remove("frame_ready", id);
+        }));
+
+        let lua = mlua::Lua::new();
+        let ud = lua.create_userdata(handle).unwrap();
         lua.load("local h = ...; h:remove(); h:remove()")
             .call::<()>(ud)
             .unwrap();
 
         bus.publish(Event::FrameReady);
-        let n: i64 = lua.globals().get("fired").unwrap();
-        assert_eq!(n, 1, "subscriber removed; second publish must not refire");
+        assert_eq!(
+            fired.get(),
+            1,
+            "subscriber removed; second publish must not refire",
+        );
     }
 }

--- a/ttymap-app/src/lua/bridge/palette_provider.rs
+++ b/ttymap-app/src/lua/bridge/palette_provider.rs
@@ -242,11 +242,13 @@ mod tests {
     fn build_provider(script: &str) -> LuaPaletteProvider {
         let lua = Lua::new();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
+        let ticks = std::rc::Rc::new(crate::lua::tick::TickRegistry::default());
         let _handles = install(
             &lua,
             LuaHostShared::empty(),
             crate::compositor::op::new_ops_buffer(),
             bus,
+            ticks,
             crate::lua::new_lua_registry(),
         )
         .expect("install ttymap");

--- a/ttymap-app/src/lua/handle.rs
+++ b/ttymap-app/src/lua/handle.rs
@@ -9,26 +9,29 @@
 //! lives next to LuaHandle in [`crate::lua::LuaSubsystem`] and is
 //! held directly by App; Dispatcher accumulates events into a
 //! buffer App drains and publishes (#334).
+//!
+//! [`EventBus`]: crate::event::EventBus
 
 use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::compositor::op::{Op, OpsBuffer};
-use crate::event::EventBus;
 use crate::lua::MapApi;
 use crate::lua::host::{LuaHostHandles, LuaHostShared};
-use crate::lua::tick;
+use crate::lua::tick::TickRegistry;
 use ttymap_engine::geo::LonLat;
 use ttymap_engine::map::render::frame::MapFrame;
 
 /// Runtime-held part of the Lua subsystem (built by
 /// [`crate::lua::build_subsystem`]).
 ///
-/// The bus is held here only because [`Self::tick`] needs it to
-/// fan out the per-frame `"tick"` event. App reaches the bus
-/// directly via the clone stored on [`crate::lua::LuaSubsystem`].
+/// Holds the per-frame [`TickRegistry`] (so [`Self::tick`] can fan
+/// out the `tick` hook) plus the read-mostly snapshot
+/// [`LuaHostShared`] that the bridge namespaces expose. App reaches
+/// the typed-event bus directly via the clone stored on
+/// [`crate::lua::LuaSubsystem`].
 pub struct LuaHandle {
-    bus: Rc<EventBus>,
+    ticks: Rc<TickRegistry>,
     host_handles: Vec<LuaHostHandles>,
     /// Shared buffer that Lua callbacks push [`Op`]s into; App
     /// drains via [`Self::drain_ops`] once per loop iteration.
@@ -43,13 +46,13 @@ pub struct LuaHandle {
 
 impl LuaHandle {
     pub fn new(
-        bus: Rc<EventBus>,
+        ticks: Rc<TickRegistry>,
         host_handles: Vec<LuaHostHandles>,
         ops: OpsBuffer,
         shared: Arc<LuaHostShared>,
     ) -> Self {
         Self {
-            bus,
+            ticks,
             host_handles,
             ops,
             shared,
@@ -63,10 +66,10 @@ impl LuaHandle {
         std::mem::take(&mut *self.ops.borrow_mut())
     }
 
-    /// Fire the per-frame `"tick"` event. Called by `ui::draw` once
-    /// per frame against the live [`MapApi`].
+    /// Fire the per-frame `tick` hook against a live [`MapApi`].
+    /// Called by `ui::draw` once per frame after composing the map.
     pub fn tick(&self, map: &mut MapApi<'_>) {
-        tick::dispatch_tick(&self.bus, map);
+        self.ticks.dispatch(map);
     }
 
     /// Mirror the latest [`MapFrame`] into the shared cell that

--- a/ttymap-app/src/lua/mod.rs
+++ b/ttymap-app/src/lua/mod.rs
@@ -52,11 +52,19 @@ pub struct LuaSubsystem {
     /// Runtime handle to the Lua subsystem — semantic surface
     /// App uses to observe state changes and tick plugins.
     pub handle: LuaHandle,
-    /// Lua-agnostic pub/sub primitive. Shared with every
-    /// `EventHandle` userdata returned to Lua (for `:remove()`) and
-    /// with [`crate::app::App`], which drains its accumulated event
-    /// buffer once per loop iteration onto this bus (#334, #336).
+    /// Lua-agnostic pub/sub primitive. Shared with the `on_event`
+    /// install site (which subscribes Rust closures wrapping Lua
+    /// callbacks) and with [`crate::app::App`], which drains its
+    /// accumulated event buffer once per loop iteration onto this
+    /// bus (#334, #336).
     pub bus: std::rc::Rc<crate::event::EventBus>,
+    /// Per-frame `tick` subscriber registry. Distinct from `bus`
+    /// because the tick payload is a borrowed `MapApi` (live
+    /// ratatui buffer + cursor + frame) that can't fit `&Event`;
+    /// see [`crate::lua::tick`]. Shared with `on_tick` / `on_event
+    /// "tick"` install sites for [`Self::handle`]'s
+    /// [`crate::lua::LuaHandle::tick`] to walk per draw.
+    pub ticks: std::rc::Rc<crate::lua::tick::TickRegistry>,
     /// Live registry of Lua-registered activations + palette
     /// entries. Cloned into `BaseLayer` (for keypress dispatch) and
     /// the palette installer (for the `:` activation's per-open
@@ -112,6 +120,7 @@ pub fn build_subsystem(defaults: Config) -> (LuaSubsystem, Config, KeybindingOve
     let registry = new_lua_registry();
     let shared = Arc::new(LuaHostShared::new());
     let bus = std::rc::Rc::new(crate::event::EventBus::default());
+    let ticks = std::rc::Rc::new(crate::lua::tick::TickRegistry::default());
     let ops = op::new_ops_buffer();
 
     let lua = vm::new_lua();
@@ -126,8 +135,9 @@ pub fn build_subsystem(defaults: Config) -> (LuaSubsystem, Config, KeybindingOve
             let keymap = KeyMap::with_overrides(&KeybindingOverrides::new());
             return (
                 LuaSubsystem {
-                    handle: LuaHandle::new(bus.clone(), Vec::new(), ops, shared),
+                    handle: LuaHandle::new(ticks.clone(), Vec::new(), ops, shared),
                     bus,
+                    ticks,
                     registry,
                     footer_hints: Vec::new(),
                 },
@@ -146,6 +156,7 @@ pub fn build_subsystem(defaults: Config) -> (LuaSubsystem, Config, KeybindingOve
         shared.clone(),
         ops.clone(),
         bus.clone(),
+        ticks.clone(),
         registry.clone(),
     ) {
         Ok(h) => h,
@@ -154,8 +165,9 @@ pub fn build_subsystem(defaults: Config) -> (LuaSubsystem, Config, KeybindingOve
             let keymap = KeyMap::with_overrides(&KeybindingOverrides::new());
             return (
                 LuaSubsystem {
-                    handle: LuaHandle::new(bus.clone(), Vec::new(), ops, shared),
+                    handle: LuaHandle::new(ticks.clone(), Vec::new(), ops, shared),
                     bus,
+                    ticks,
                     registry,
                     footer_hints: Vec::new(),
                 },
@@ -206,12 +218,13 @@ pub fn build_subsystem(defaults: Config) -> (LuaSubsystem, Config, KeybindingOve
         })
         .collect();
 
-    let handle = LuaHandle::new(bus.clone(), vec![host_handles], ops, shared);
+    let handle = LuaHandle::new(ticks.clone(), vec![host_handles], ops, shared);
 
     (
         LuaSubsystem {
             handle,
             bus,
+            ticks,
             registry,
             footer_hints,
         },
@@ -259,8 +272,8 @@ mod tests {
 
     /// Helper for inspection tests. Drives the host API install (so
     /// `ttymap.register_*` etc. exist), runs the source as a plain
-    /// Lua chunk, and returns the live `(lua, registry, bus)` tuple
-    /// so callers can read what landed in the registry / bus
+    /// Lua chunk, and returns the live `(lua, registry, bus, ticks)`
+    /// tuple so callers can read what landed in the registries
     /// directly. No deferred capture — registrations apply
     /// immediately as the chunk runs.
     fn run_in_fresh_vm(
@@ -269,26 +282,29 @@ mod tests {
         mlua::Lua,
         LuaRegistryHandle,
         std::rc::Rc<crate::event::EventBus>,
+        std::rc::Rc<crate::lua::tick::TickRegistry>,
     ) {
         let lua = new_lua();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
+        let ticks = std::rc::Rc::new(crate::lua::tick::TickRegistry::default());
         let registry = new_lua_registry();
         api::install(
             &lua,
             host::LuaHostShared::empty(),
             op::new_ops_buffer(),
             bus.clone(),
+            ticks.clone(),
             registry.clone(),
         )
         .expect("install ttymap");
         lua.load(source).exec().expect("exec source");
-        (lua, registry, bus)
+        (lua, registry, bus, ticks)
     }
 
     /// Build a Lua VM with `package.path` extended for a custom
-    /// runtime layer. Returns `(lua, registry, shared, bus)` so tests
-    /// can drive `lua.load(r#"require 'plugin.<name>'"#).exec()` and
-    /// assert what landed in the registry / shared snapshot.
+    /// runtime layer. Returns `(lua, registry, shared, bus, ticks)`
+    /// so tests can drive `lua.load(r#"require 'plugin.<name>'"#).exec()`
+    /// and assert what landed in the registry / shared snapshot.
     ///
     /// Plugins resolve as standard Lua modules under
     /// `<layer>/lua/plugin/<name>.lua` via the prepended
@@ -301,6 +317,7 @@ mod tests {
         LuaRegistryHandle,
         Arc<host::LuaHostShared>,
         std::rc::Rc<crate::event::EventBus>,
+        std::rc::Rc<crate::lua::tick::TickRegistry>,
     ) {
         runtimepath::ensure_runtime_path_for_tests();
         let lua = new_lua();
@@ -310,17 +327,19 @@ mod tests {
         vm::prepend_package_path(&lua, &layer.join("lua"));
         let shared = host::LuaHostShared::empty();
         let bus = std::rc::Rc::new(crate::event::EventBus::default());
+        let ticks = std::rc::Rc::new(crate::lua::tick::TickRegistry::default());
         let registry = new_lua_registry();
         api::install(
             &lua,
             shared.clone(),
             op::new_ops_buffer(),
             bus.clone(),
+            ticks.clone(),
             registry.clone(),
         )
         .expect("install ttymap");
 
-        (lua, registry, shared, bus)
+        (lua, registry, shared, bus, ticks)
     }
 
     /// Build a private temp directory rooted at the OS's temp dir.
@@ -358,7 +377,7 @@ mod tests {
         // push directly into the live `LuaRegistry`. No deferred
         // capture — the entries are visible the moment the chunk
         // returns.
-        let (_lua, registry, _bus) = run_in_fresh_vm(
+        let (_lua, registry, _bus, _ticks) = run_in_fresh_vm(
             r#"
             ttymap.register_palette_command({ label = "Toggle x", invoke = function() return true end })
             ttymap.register_keybind("i", function() return true end)
@@ -383,16 +402,18 @@ mod tests {
     }
 
     #[test]
-    fn on_tick_subscriptions_land_on_the_bus() {
+    fn on_tick_subscriptions_land_in_the_tick_registry() {
         // Each `ttymap.api.frame.on_tick(fn)` call subscribes
-        // directly against the bus.
-        let (_lua, _registry, bus) = run_in_fresh_vm(
+        // directly against the per-frame `TickRegistry` (not the
+        // typed-event bus — the tick payload is a borrowed
+        // `MapApi`, see `lua/tick.rs`).
+        let (_lua, _registry, _bus, ticks) = run_in_fresh_vm(
             r#"
             ttymap.api.frame.on_tick(function(_map) end)
             ttymap.api.frame.on_tick(function(_map) end)
             "#,
         );
-        assert_eq!(bus.count("tick"), 2);
+        assert_eq!(ticks.len(), 2);
     }
 
     #[test]
@@ -412,7 +433,7 @@ mod tests {
             "#,
         );
 
-        let (lua, registry, shared, _bus) = fresh_lua_layer_state(&layer);
+        let (lua, registry, shared, _bus, _ticks) = fresh_lua_layer_state(&layer);
         lua.load(r#"require "plugin.demo""#)
             .exec()
             .expect("require plugin.demo");
@@ -450,7 +471,7 @@ mod tests {
             r#"ttymap.register_palette_command({ label = "biggie", invoke = function() return true end })"#,
         );
 
-        let (lua, registry, _shared, _bus) = fresh_lua_layer_state(&layer);
+        let (lua, registry, _shared, _bus, _ticks) = fresh_lua_layer_state(&layer);
         lua.load(r#"require "plugin.biggie""#)
             .exec()
             .expect("require plugin.biggie");
@@ -477,7 +498,7 @@ mod tests {
         )
         .expect("write lib");
 
-        let (lua, registry, _shared, _bus) = fresh_lua_layer_state(&layer);
+        let (lua, registry, _shared, _bus, _ticks) = fresh_lua_layer_state(&layer);
         let v: i64 = lua
             .load(r#"return require("ttymap.foo").value"#)
             .eval()
@@ -500,7 +521,7 @@ mod tests {
             r#"ttymap.register_palette_command({ label = "demo", invoke = function() return true end })"#,
         );
 
-        let (lua, registry, _shared, _bus) = fresh_lua_layer_state(&layer);
+        let (lua, registry, _shared, _bus, _ticks) = fresh_lua_layer_state(&layer);
         lua.load(r#"require "plugin.demo"; require "plugin.demo""#)
             .exec()
             .expect("double require");
@@ -540,7 +561,7 @@ mod tests {
         )
         .expect("write travel/init.lua");
 
-        let (lua, registry, _shared, _bus) = fresh_lua_layer_state(&layer);
+        let (lua, registry, _shared, _bus, _ticks) = fresh_lua_layer_state(&layer);
         lua.load(r#"require "plugin.travel""#)
             .exec()
             .expect("require plugin.travel");
@@ -648,7 +669,7 @@ mod tests {
             "#,
         );
 
-        let (lua, registry, _shared, _bus) = fresh_lua_layer_state(&layer);
+        let (lua, registry, _shared, _bus, _ticks) = fresh_lua_layer_state(&layer);
         // init.lua-style pre-pass: mutate the lib's table BEFORE the
         // plugin requires it. Lua's module cache makes the plugin's
         // `require "ttymap.myplug"` return the same table.
@@ -756,7 +777,7 @@ mod tests {
         )
         .expect("write bundled init.lua");
 
-        let (lua, registry, _shared, _bus) = fresh_lua_layer_state(&layer);
+        let (lua, registry, _shared, _bus, _ticks) = fresh_lua_layer_state(&layer);
 
         // Stub `ttymap.user_config.load()`: simulates a user
         // init.lua. At the point it runs, the bundled plugin's

--- a/ttymap-app/src/lua/tick.rs
+++ b/ttymap-app/src/lua/tick.rs
@@ -1,39 +1,124 @@
 //! Per-frame `tick` dispatcher.
 //!
-//! `tick` is the only event whose payload (a borrowed `MapApi`) can't
-//! be expressed as an [`Event`](crate::event::Event) variant — the
-//! Lua-facing `map` table has to be built inside `Lua::scope` against
-//! the live ratatui buffer for that frame. That shape needs `mlua` +
-//! `MapApi` from `lua/`, so it lives here rather than in `event/`
-//! (which deliberately stays free of `crate::lua::*` imports).
+//! `tick` is the only "event" whose payload (a borrowed `MapApi`)
+//! can't be expressed as an [`Event`](crate::event::Event) variant —
+//! the Lua-facing `map` table has to be built inside `Lua::scope`
+//! against the live ratatui buffer for that frame. That shape needs
+//! `mlua` + `MapApi` from `lua/`, so the tick subscribers live in a
+//! **separate** registry here (not on the [`EventBus`], which is
+//! deliberately free of any `mlua` import).
 //!
-//! Called once per draw from `app::ui::draw` after composing the map
-//! frame.
+//! `dispatch` is called once per draw from `app::ui::draw` after
+//! composing the map frame.
+//!
+//! # Identity, removal, reentrancy
+//!
+//! Each `subscribe` call returns a monotonic `u64`. The Lua surface
+//! (`EventHandle`) wraps that ID so a plugin can `:remove()` itself
+//! later. Dispatch is **ID snapshot + per-call lookup** — the same
+//! pattern the [`EventBus`] uses — so a callback may call
+//! [`Self::remove`] (or `subscribe` a new entry) from inside without
+//! disturbing the in-flight dispatch.
+//!
+//! [`EventBus`]: crate::event::EventBus
 
 use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::event::EventBus;
+use mlua::{Lua, RegistryKey};
+
 use crate::lua::MapApi;
 use crate::lua::api::map;
 
-/// Fire the per-frame `"tick"` bucket against a live `MapApi`. Each
-/// Lua subscriber sees the per-frame map table; Rust subscribers in
-/// the bucket are skipped (a Rust thing wanting per-frame work
-/// should subscribe to `frame_ready` instead).
+/// One subscriber to the per-frame `tick` — a Lua callback paired
+/// with the Lua VM it was registered from.
+struct TickSubscriber {
+    id: u64,
+    lua: Lua,
+    callback: RegistryKey,
+}
+
+/// Lua-only registry of per-frame `tick` callbacks.
 ///
-/// Errors are logged + swallowed per callback so a single broken
-/// plugin can't freeze the loop.
-pub fn dispatch_tick(bus: &EventBus, map: &mut MapApi<'_>) {
-    let cell = RefCell::new(map);
-    bus.for_each_lua_subscriber("tick", |lua, f| {
-        let result: mlua::Result<()> = lua.scope(|scope| {
-            let map_table = map::make_map_table(lua, scope, &cell)?;
-            f.call::<()>(map_table)
-        });
-        if let Err(e) = result {
-            log::warn!("lua: tick subscriber failed: {}", e);
+/// Held by [`crate::lua::LuaHandle`] (which calls [`Self::dispatch`]
+/// once per draw) and by the `ttymap.api.frame.on_tick` /
+/// `ttymap.on_event("tick", …)` install sites (which call
+/// [`Self::subscribe`]). The Lua-facing handle returned to plugins
+/// targets [`Self::remove`].
+#[derive(Default)]
+pub struct TickRegistry {
+    subscribers: RefCell<Vec<TickSubscriber>>,
+    next_id: AtomicU64,
+}
+
+impl TickRegistry {
+    /// Register a Lua callback. Returns a monotonic ID
+    /// that can be passed to [`Self::remove`].
+    pub fn subscribe(&self, lua: Lua, callback: RegistryKey) -> u64 {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        self.subscribers
+            .borrow_mut()
+            .push(TickSubscriber { id, lua, callback });
+        id
+    }
+
+    /// Remove one subscriber by ID. Returns true if a matching entry
+    /// was found and removed. Safe to call from inside a dispatched
+    /// callback — the snapshot-then-lookup pattern in [`Self::dispatch`]
+    /// drops its borrow before invoking the Lua function.
+    pub fn remove(&self, id: u64) -> bool {
+        let mut subs = self.subscribers.borrow_mut();
+        let before = subs.len();
+        subs.retain(|s| s.id != id);
+        before != subs.len()
+    }
+
+    /// Total subscriber count.
+    pub fn len(&self) -> usize {
+        self.subscribers.borrow().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.subscribers.borrow().is_empty()
+    }
+
+    /// Fire every registered callback against a live `MapApi`.
+    ///
+    /// Errors are logged + swallowed per callback so a single broken
+    /// plugin can't freeze the loop.
+    pub fn dispatch(&self, map: &mut MapApi<'_>) {
+        let cell = RefCell::new(map);
+        let ids: Vec<u64> = self.subscribers.borrow().iter().map(|s| s.id).collect();
+
+        for id in ids {
+            // Resolve under a short borrow that drops before the Lua
+            // callback runs, so the callback can call `:remove()` (or
+            // `:subscribe()` a new entry) on the registry without
+            // panicking on a re-borrow.
+            let extracted = {
+                let subs = self.subscribers.borrow();
+                subs.iter().find(|s| s.id == id).and_then(|s| {
+                    match s.lua.registry_value::<mlua::Function>(&s.callback) {
+                        Ok(f) => Some((s.lua.clone(), f)),
+                        Err(e) => {
+                            log::warn!("lua: tick subscriber registry lookup failed: {}", e);
+                            None
+                        }
+                    }
+                })
+            };
+
+            if let Some((lua, f)) = extracted {
+                let result: mlua::Result<()> = lua.scope(|scope| {
+                    let map_table = map::make_map_table(&lua, scope, &cell)?;
+                    f.call::<()>(map_table)
+                });
+                if let Err(e) = result {
+                    log::warn!("lua: tick subscriber failed: {}", e);
+                }
+            }
         }
-    });
+    }
 }
 
 #[cfg(test)]
@@ -83,14 +168,14 @@ mod tests {
         let (lua_a, key_a) = lua_with_counter("a");
         let (lua_b, key_b) = lua_with_counter("b");
 
-        let bus = EventBus::default();
-        bus.subscribe_lua("tick", lua_a.clone(), key_a);
-        bus.subscribe_lua("tick", lua_b.clone(), key_b);
+        let ticks = TickRegistry::default();
+        ticks.subscribe(lua_a.clone(), key_a);
+        ticks.subscribe(lua_b.clone(), key_b);
 
         let (mut buf, area, frame, theme) = fixture(20, 5);
         let mut sink: Vec<UserPolyline> = Vec::new();
         let mut api = MapApi::new(&mut buf, area, &frame, &theme, None, &mut sink);
-        dispatch_tick(&bus, &mut api);
+        ticks.dispatch(&mut api);
 
         let a: i64 = lua_a.globals().get("a").expect("read a");
         let b: i64 = lua_b.globals().get("b").expect("read b");
@@ -110,16 +195,35 @@ mod tests {
 
         let (lua_good, good_key) = lua_with_counter("good");
 
-        let bus = EventBus::default();
-        bus.subscribe_lua("tick", lua_bad, bad_key);
-        bus.subscribe_lua("tick", lua_good.clone(), good_key);
+        let ticks = TickRegistry::default();
+        ticks.subscribe(lua_bad, bad_key);
+        ticks.subscribe(lua_good.clone(), good_key);
 
         let (mut buf, area, frame, theme) = fixture(20, 5);
         let mut sink: Vec<UserPolyline> = Vec::new();
         let mut api = MapApi::new(&mut buf, area, &frame, &theme, None, &mut sink);
-        dispatch_tick(&bus, &mut api);
+        ticks.dispatch(&mut api);
 
         let good: i64 = lua_good.globals().get("good").unwrap();
         assert_eq!(good, 1);
+    }
+
+    #[test]
+    fn remove_drops_the_subscriber() {
+        let (lua, key) = lua_with_counter("c");
+        let ticks = TickRegistry::default();
+        let id = ticks.subscribe(lua.clone(), key);
+
+        let (mut buf, area, frame, theme) = fixture(20, 5);
+        let mut sink: Vec<UserPolyline> = Vec::new();
+        let mut api = MapApi::new(&mut buf, area, &frame, &theme, None, &mut sink);
+        ticks.dispatch(&mut api);
+
+        assert!(ticks.remove(id));
+        ticks.dispatch(&mut api);
+
+        let c: i64 = lua.globals().get("c").expect("read c");
+        assert_eq!(c, 1, "removed subscriber must not fire on next dispatch");
+        assert!(!ticks.remove(id), "second remove returns false");
     }
 }


### PR DESCRIPTION
## Summary

Step 1 of the 5-step workspace split planned in #351. Makes `event/`
Lua-agnostic so a future `ttymap-lua` carve-out can pick its
dependencies cleanly.

Two coupled changes:

1. **`Subscriber::Lua` gone.** `Subscriber::Lua { lua: Lua, callback:
   RegistryKey }` is replaced by the underlying
   `Rc<dyn Fn(&Event)>` — the `Subscriber` enum itself is gone.
   `ttymap.on_event(name, fn)` now wraps the Lua callback in a Rust
   closure that captures `mlua::Lua` + `RegistryKey` and handles the
   Lua call site (typed arg conversion, error logging). `event/bus.rs`
   no longer imports `mlua`.

2. **`tick` pulled out of the bus.** The `tick` payload is a borrowed
   `MapApi` (per-frame ratatui buffer + frame + theme) which can't fit
   `&Event`. New `lua/tick.rs::TickRegistry` owns its own
   `(Lua, RegistryKey)` subscribers; `LuaHandle::tick` calls
   `dispatch` once per draw from `ui::draw`. Both
   `ttymap.api.frame.on_tick(fn)` and `ttymap.on_event("tick", fn)`
   route here — no behavioural change for plugins.

`EventHandle` (returned to Lua by `on_event` / `on_tick`) is
generalised to a `Rc<dyn Fn()>` remove closure so the same handle
type works for both bus and tick subscriptions. Idempotent — the
second `:remove()` is a no-op.

## Why tick had to move

The issue body's option (a) (\"replace `Subscriber::Lua` with
`Subscriber::Boxed`\") looked like a one-liner, but `for_each_lua_subscriber`
on the bus exists specifically because tick can't ride a typed
`&Event` — the bus would still need to expose `&Lua` + `&mlua::Function`
to the tick dispatcher. Routing tick through its own `mlua`-aware
registry (in `lua/`, where `mlua` belongs anyway) leaves the bus
genuinely Lua-free.

## Reentrancy

Snapshot-then-lookup contract preserved for both registries — a
callback may `:remove()` itself (or `subscribe` a new entry) during
dispatch without panicking on a re-borrow. Covered by:

- bus: new `callback_can_remove_itself_during_dispatch`,
  `re_subscribe_during_dispatch_does_not_panic`
- tick: new `remove_drops_the_subscriber`,
  `one_failing_subscriber_does_not_stop_the_others` (existing)

## Test plan

- [x] `cargo test --workspace` — 212 unit + 2 ipc handshake + 1 ignored doctest, all pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] grep confirms `event/` no longer imports `mlua` (doc-comment mentions only)

## Related

- #351 — full 5-step plan
- Next: Step 2 (compositor / palette ↔ `LuaRegistryHandle` decoupling)