### PR TITLE
refactor: decouple compositor and palette from LuaRegistryHandle (#351 Step 2)

### DIFF
--- a/ttymap-app/src/app/mod.rs
+++ b/ttymap-app/src/app/mod.rs
@@ -115,16 +115,22 @@ impl App {
 
         // Compositor bootstraps with the BaseLayer (keymap +
         // activation dispatch) at index 0. Every subsequent modal is
-        // pushed on top. BaseLayer borrows the live `LuaRegistry`
-        // so plugin `KeybindHandle:remove()` updates are visible on
-        // the next keypress; built-in activations (today: just `:`
+        // pushed on top. BaseLayer takes an `ActivationIndex` trait
+        // object — today backed by the Lua-side registry through
+        // `LuaActivationIndex`, but the compositor itself stays
+        // unaware that Lua is the source. Plugin
+        // `KeybindHandle:remove()` updates are visible on the next
+        // keypress because the wrapper holds a clone of the same
+        // `LuaRegistryHandle`. Built-in activations (today: just `:`
         // for the palette) are kept in their own Vec so plugins
         // can't accidentally shadow host shortcuts.
+        let activation_index: std::rc::Rc<dyn crate::compositor::ActivationIndex> =
+            std::rc::Rc::new(crate::lua::LuaActivationIndex::new(registry));
         let mut compositor = Compositor::new();
         compositor.push(Box::new(BaseLayer::new(
             keymap,
             builtin_activations,
-            registry,
+            activation_index,
             footer_hints,
         )));
 

--- a/ttymap-app/src/compositor/activation.rs
+++ b/ttymap-app/src/compositor/activation.rs
@@ -52,8 +52,42 @@ pub struct Activation {
 /// `"w"`); empty string when the entry is palette-only. Used by the
 /// help cheatsheet and the footer-hint slot to surface the binding
 /// alongside the label.
+///
+/// `Clone` is a cheap `Rc` bump on `spawn` plus two `String` clones,
+/// taken when a [`PaletteIndex`] hands a snapshot to the palette.
+#[derive(Clone)]
 pub struct PaletteEntry {
     pub label: String,
     pub hint: String,
     pub spawn: SpawnComponent,
+}
+
+/// Read-only lookup of keybind activations. Implemented by whatever
+/// store actually owns the activation list (today the Lua-side
+/// registry; trivially extensible to in-Rust built-ins or future
+/// runtime sources). [`super::BaseLayer`] depends only on this
+/// trait, so the compositor stays unaware of the Lua subsystem.
+pub trait ActivationIndex {
+    /// Spawn factory for a `(code, modifiers)` press, if any plugin
+    /// has registered an activation against it. `&self` because
+    /// dispatch is read-only — internal interior mutability (e.g.
+    /// `RefCell`) is the implementor's concern.
+    fn find_spawn(&self, code: KeyCode, modifiers: KeyModifiers) -> Option<SpawnComponent>;
+}
+
+/// Read-only view of the palette command list. Implemented by
+/// whatever store owns the entries; [`super::PaletteEntry`] is the
+/// transfer shape. The palette's `CommandProvider` depends only on
+/// this trait so the palette UI stays unaware of the Lua subsystem.
+pub trait PaletteIndex {
+    /// Snapshot of `(id, entry)` pairs in registration order. Taken
+    /// once per palette open; mutations after the snapshot land in
+    /// later opens.
+    fn entries(&self) -> Vec<(u64, PaletteEntry)>;
+    /// Spawn factory for a palette entry by its handle ID. Returns
+    /// `None` when the entry has been removed since the snapshot was
+    /// built — `CommandProvider::execute` treats that as a silent
+    /// no-op so a stale selection can't dispatch against a phantom
+    /// factory.
+    fn entry_spawn(&self, id: u64) -> Option<SpawnComponent>;
 }

--- a/ttymap-app/src/compositor/base.rs
+++ b/ttymap-app/src/compositor/base.rs
@@ -25,13 +25,14 @@
 //! thread's `MapFrame`, drawn by `App` separately from the
 //! compositor).
 
+use std::rc::Rc;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::window::{RenderWindow, Window};
-use super::{Activation, Component, SpawnComponent};
+use super::{Activation, ActivationIndex, Component, SpawnComponent};
 use crate::UserCommand;
 use crate::input::keymap::KeyMap;
-use crate::lua::LuaRegistryHandle;
 use ttymap_engine::map::MapAction;
 
 pub struct BaseLayer {
@@ -41,11 +42,11 @@ pub struct BaseLayer {
     /// pushed by [`crate::palette::install`]. Walked first on
     /// keypress, so a plugin can't accidentally shadow `:`.
     builtin_activations: Vec<Activation>,
-    /// Live registry of Lua-registered activations. Cloned from
-    /// `LuaSubsystem` at startup. Keypress dispatch borrows it
-    /// per-event; Lua `:remove()` mutably borrows it from a
-    /// `KeybindHandle` to drop the matching entry.
-    registry: LuaRegistryHandle,
+    /// Read-only view onto whatever store holds plugin activations.
+    /// Today backed by the Lua-side registry through
+    /// [`crate::lua::LuaActivationIndex`]; BaseLayer itself stays
+    /// unaware that Lua is involved.
+    activations: Rc<dyn ActivationIndex>,
     /// Lua-supplied footer hints harvested at startup. Static for
     /// the program lifetime — adding / removing entries does not
     /// refresh this list.
@@ -60,23 +61,23 @@ impl BaseLayer {
     pub fn new(
         keymap: KeyMap,
         builtin_activations: Vec<Activation>,
-        registry: LuaRegistryHandle,
+        activations: Rc<dyn ActivationIndex>,
         footer_hints: Vec<(&'static str, &'static str)>,
     ) -> Self {
         Self {
             keymap,
             builtin_activations,
-            registry,
+            activations,
             footer_hints,
             pending_g: false,
         }
     }
 
-    /// Look up the spawn factory for a key, cloning it out so the
-    /// caller can invoke it without holding a borrow on the
-    /// registry. Built-ins win over plugin entries (so `:` always
-    /// opens the palette regardless of what plugins did). Cloning
-    /// is cheap (Rc reference-count bump).
+    /// Look up the spawn factory for a key. Built-ins win over plugin
+    /// entries (so `:` always opens the palette regardless of what
+    /// plugins did). The trait returns an already-cloned
+    /// `SpawnComponent` (cheap `Rc` bump), so invoking it cannot
+    /// re-enter whatever borrow the index implementation took.
     fn lookup_spawn(&self, code: KeyCode, modifiers: KeyModifiers) -> Option<SpawnComponent> {
         let clean = modifiers & !KeyModifiers::SHIFT;
         for a in &self.builtin_activations {
@@ -84,10 +85,7 @@ impl BaseLayer {
                 return Some(a.spawn.clone());
             }
         }
-        self.registry
-            .borrow()
-            .find_activation(code, clean)
-            .map(|a| a.spawn.clone())
+        self.activations.find_spawn(code, clean)
     }
 
     /// Advance the `gg` state machine and resolve via the keymap.
@@ -168,6 +166,8 @@ impl Component for BaseLayer {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
     use super::super::window::WindowOps;
     use super::super::{CardId, Context};
     use super::*;
@@ -179,11 +179,45 @@ mod tests {
         cursor: None,
     };
 
+    /// In-test [`ActivationIndex`] backed by a `Vec`. Keeps the
+    /// compositor's tests free of any Lua dependency — the registry
+    /// remove/round-trip exercise here is structural (does the trait
+    /// surface it?), not Lua-specific.
+    #[derive(Default)]
+    struct MockIndex {
+        activations: RefCell<Vec<(u64, Activation)>>,
+    }
+
+    impl MockIndex {
+        fn add(&self, id: u64, a: Activation) {
+            self.activations.borrow_mut().push((id, a));
+        }
+
+        fn remove(&self, id: u64) -> bool {
+            let mut subs = self.activations.borrow_mut();
+            let before = subs.len();
+            subs.retain(|(i, _)| *i != id);
+            before != subs.len()
+        }
+    }
+
+    impl ActivationIndex for MockIndex {
+        fn find_spawn(&self, code: KeyCode, modifiers: KeyModifiers) -> Option<SpawnComponent> {
+            self.activations.borrow().iter().find_map(|(_, a)| {
+                if a.code == code && a.modifiers == modifiers {
+                    Some(Rc::clone(&a.spawn))
+                } else {
+                    None
+                }
+            })
+        }
+    }
+
     fn bg() -> BaseLayer {
         BaseLayer::new(
             KeyMap::default(),
             Vec::new(),
-            crate::lua::new_lua_registry(),
+            Rc::new(MockIndex::default()),
             Vec::new(),
         )
     }
@@ -227,16 +261,17 @@ mod tests {
     }
 
     #[test]
-    fn keybind_removed_from_registry_no_longer_dispatches() {
-        // Registry-driven dispatch round-trip: register an activation
+    fn keybind_removed_from_index_no_longer_dispatches() {
+        // Index-driven dispatch round-trip: register an activation
         // for `Z`, confirm the dispatch fires (factory returns Some
         // so a component would be pushed), then remove the activation
-        // by id and confirm the next `Z` press is a no-op.
+        // by id and confirm the next `Z` press is a no-op. Uses the
+        // in-test `MockIndex` rather than the Lua-backed wrapper —
+        // the compositor sees only the trait surface.
         use super::super::Component;
         use std::cell::Cell;
-        use std::rc::Rc;
 
-        let registry = crate::lua::new_lua_registry();
+        let index = Rc::new(MockIndex::default());
         let fired = Rc::new(Cell::new(0_u32));
 
         struct DummyComponent;
@@ -250,32 +285,37 @@ mod tests {
 
         let id = 42;
         let fired_for_factory = fired.clone();
-        registry.borrow_mut().add_activation(
+        index.add(
             id,
             Activation {
                 code: KeyCode::Char('Z'),
                 modifiers: KeyModifiers::NONE,
-                spawn: std::rc::Rc::new(move |_| -> Option<Box<dyn Component>> {
+                spawn: Rc::new(move |_| -> Option<Box<dyn Component>> {
                     fired_for_factory.set(fired_for_factory.get() + 1);
                     Some(Box::new(DummyComponent))
                 }),
             },
         );
 
-        let mut bg = BaseLayer::new(KeyMap::default(), Vec::new(), registry.clone(), Vec::new());
+        let mut bg = BaseLayer::new(
+            KeyMap::default(),
+            Vec::new(),
+            index.clone() as Rc<dyn ActivationIndex>,
+            Vec::new(),
+        );
 
         let ops = dispatch(&mut bg, KeyCode::Char('Z'));
         assert!(ops.pushed(), "registered keybind should push a component");
         assert_eq!(fired.get(), 1);
 
         // Drop the activation by id — simulating
-        // KeybindHandle:remove() from Lua.
-        assert!(registry.borrow_mut().remove_activation(id));
+        // KeybindHandle:remove() from Lua via the index trait.
+        assert!(index.remove(id));
 
         let ops = dispatch(&mut bg, KeyCode::Char('Z'));
         assert!(
             !ops.pushed(),
-            "removed keybind must not dispatch (factory must not fire)"
+            "removed keybind must not dispatch (factory must not fire)",
         );
         assert_eq!(fired.get(), 1, "factory must not have fired again");
     }

--- a/ttymap-app/src/compositor/mod.rs
+++ b/ttymap-app/src/compositor/mod.rs
@@ -32,7 +32,7 @@ pub mod render;
 mod sidebar;
 pub mod window;
 
-pub use activation::{Activation, PaletteEntry, SpawnComponent};
+pub use activation::{Activation, ActivationIndex, PaletteEntry, PaletteIndex, SpawnComponent};
 pub use base::BaseLayer;
 pub use component::{Component, Context, Placement};
 

--- a/ttymap-app/src/lua/mod.rs
+++ b/ttymap-app/src/lua/mod.rs
@@ -30,7 +30,7 @@ pub use handle::LuaHandle;
 pub use host::LuaHostShared;
 pub use init_lua::read_init_lua_config_only;
 pub use map_api::MapApi;
-pub use registrar::{LuaRegistry, LuaRegistryHandle, new_lua_registry};
+pub use registrar::{LuaActivationIndex, LuaRegistry, LuaRegistryHandle, new_lua_registry};
 pub use runtimepath::{resolve_runtime_path, runtime_path, set_runtime_path};
 pub use vm::new_lua;
 

--- a/ttymap-app/src/lua/registrar.rs
+++ b/ttymap-app/src/lua/registrar.rs
@@ -29,7 +29,7 @@ use std::rc::Rc;
 
 use crossterm::event::{KeyCode, KeyModifiers};
 
-use crate::compositor::{Activation, PaletteEntry};
+use crate::compositor::{Activation, ActivationIndex, PaletteEntry, PaletteIndex, SpawnComponent};
 
 /// Live registry of Lua-registered activations + palette entries.
 /// Each entry is paired with the handle ID Lua holds, so a
@@ -114,6 +114,49 @@ impl LuaRegistry {
 
     pub fn activation_count(&self) -> usize {
         self.activations.len()
+    }
+}
+
+/// Read-only view of a [`LuaRegistryHandle`] that implements both
+/// UI-facing index traits. Lets [`crate::compositor::BaseLayer`] and
+/// `palette::CommandProvider` consume the registry through
+/// `Rc<dyn ActivationIndex>` / `Rc<dyn PaletteIndex>` without
+/// knowing it's Lua-backed — every layer outside `lua/` sees just
+/// the trait surface.
+///
+/// Holds a clone of the same `Rc<RefCell<LuaRegistry>>` the Lua
+/// `:remove()` handles mutably borrow, so removals on the Lua side
+/// are visible to the UI on the very next dispatch / palette open
+/// (the wrapper's read methods take a short read borrow each call).
+pub struct LuaActivationIndex {
+    inner: LuaRegistryHandle,
+}
+
+impl LuaActivationIndex {
+    pub fn new(inner: LuaRegistryHandle) -> Self {
+        Self { inner }
+    }
+}
+
+impl ActivationIndex for LuaActivationIndex {
+    fn find_spawn(&self, code: KeyCode, modifiers: KeyModifiers) -> Option<SpawnComponent> {
+        self.inner
+            .borrow()
+            .find_activation(code, modifiers)
+            .map(|a| Rc::clone(&a.spawn))
+    }
+}
+
+impl PaletteIndex for LuaActivationIndex {
+    fn entries(&self) -> Vec<(u64, PaletteEntry)> {
+        self.inner.borrow().palette_entries().to_vec()
+    }
+
+    fn entry_spawn(&self, id: u64) -> Option<SpawnComponent> {
+        self.inner
+            .borrow()
+            .palette_entry(id)
+            .map(|e| Rc::clone(&e.spawn))
     }
 }
 

--- a/ttymap-app/src/main.rs
+++ b/ttymap-app/src/main.rs
@@ -165,12 +165,16 @@ fn run_event_loop(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let lua = lua_subsystem;
     lua.handle.set_attribution(map.attribution.clone());
 
-    // Palette is a built-in (not a plugin): build a CommandSeed
-    // around the live LuaRegistry and append the `:` activation
-    // to a fresh built-ins Vec. Must run after every plugin's
-    // register call so the seed sees them.
+    // Palette is a built-in (not a plugin): wrap the live Lua
+    // registry as a `PaletteIndex` and let `palette::install`
+    // build a `CommandSeed` around it, then append the `:`
+    // activation to a fresh built-ins Vec. Must run after every
+    // plugin's register call so the seed sees them.
     let mut builtin_activations: Vec<ttymap_app::compositor::Activation> = Vec::new();
-    ttymap_app::palette::install(&keymap, &mut builtin_activations, lua.registry.clone());
+    let palette_index: std::rc::Rc<dyn ttymap_app::compositor::PaletteIndex> = std::rc::Rc::new(
+        ttymap_app::lua::LuaActivationIndex::new(lua.registry.clone()),
+    );
+    ttymap_app::palette::install(&keymap, &mut builtin_activations, palette_index);
 
     let mut app = App::new(config, keymap, theme_id, map, builtin_activations, lua);
 

--- a/ttymap-app/src/palette/mod.rs
+++ b/ttymap-app/src/palette/mod.rs
@@ -27,7 +27,7 @@ use std::time::Instant;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::compositor::window::{RenderWindow, Window};
-use crate::compositor::{Activation, Component, Context};
+use crate::compositor::{Activation, Component, Context, PaletteIndex};
 use crate::input::keymap::KeyMap;
 use crate::theme::ThemeId;
 
@@ -213,18 +213,18 @@ impl Component for PaletteComponent {
 
 /// Install the palette as a built-in. Unlike a plugin's `register`,
 /// this is a **sink**: prebuild a [`CommandSeed`] that holds the
-/// static map-action half plus a clone of the live
-/// [`LuaRegistryHandle`](crate::lua::LuaRegistryHandle), and
-/// append a single `:` activation. Each open snapshots the registry
-/// freshly so plugins can `:remove()` (or, in a future PR, register
-/// at runtime) and the next open reflects it. Must be called
-/// **after** every plugin's `register`.
+/// static map-action half plus a clone of the [`PaletteIndex`] view
+/// onto wherever plugin entries are stored, and append a single `:`
+/// activation. Each open snapshots the index freshly so plugins can
+/// `:remove()` (or register more at runtime) and the next open
+/// reflects it. Must be called **after** every plugin's `register`
+/// at startup.
 pub fn install(
     keymap: &KeyMap,
     activations: &mut Vec<Activation>,
-    registry: crate::lua::LuaRegistryHandle,
+    palette_index: Rc<dyn PaletteIndex>,
 ) {
-    let seed = Rc::new(CommandSeed::build(keymap, registry));
+    let seed = Rc::new(CommandSeed::build(keymap, palette_index));
     let seed_for_spawn = seed;
     activations.push(Activation {
         code: KeyCode::Char(':'),

--- a/ttymap-app/src/palette/provider/command.rs
+++ b/ttymap-app/src/palette/provider/command.rs
@@ -20,9 +20,8 @@
 use std::rc::Rc;
 
 use crate::UserCommand;
-use crate::compositor::Context;
+use crate::compositor::{Context, PaletteIndex};
 use crate::input::keymap::KeyMap;
-use crate::lua::LuaRegistryHandle;
 use crate::theme::ThemeId;
 use ttymap_engine::map::MapAction;
 
@@ -30,15 +29,15 @@ use super::{PaletteAction, PaletteItem, PaletteProvider, ThemeProvider};
 
 /// Cached static-half of the palette source. Held as `Rc` so the
 /// `:` activation closure can clone cheaply for each push. The
-/// dynamic plugin half is read from `registry` at
+/// dynamic plugin half is read from `palette_index` at
 /// [`CommandProvider::build`] time per open.
 pub struct CommandSeed {
     map_actions: Vec<(MapAction, String)>, // (action, key hint)
-    registry: LuaRegistryHandle,
+    palette_index: Rc<dyn PaletteIndex>,
 }
 
 impl CommandSeed {
-    pub fn build(keymap: &KeyMap, registry: LuaRegistryHandle) -> Self {
+    pub fn build(keymap: &KeyMap, palette_index: Rc<dyn PaletteIndex>) -> Self {
         let map_actions = MapAction::all_listed()
             .iter()
             .map(|a| {
@@ -48,7 +47,7 @@ impl CommandSeed {
             .collect();
         Self {
             map_actions,
-            registry,
+            palette_index,
         }
     }
 }
@@ -95,16 +94,17 @@ impl CommandProvider {
             });
         }
 
-        // Snapshot the plugin entries from the live registry. We
-        // keep label / hint locally so the palette can render
-        // without re-borrowing during paint; the factory itself
-        // stays in the registry and we look it up by id at execute
-        // time.
-        for (id, entry) in seed.registry.borrow().palette_entries() {
+        // Snapshot the plugin entries from the live index. We keep
+        // label / hint locally so the palette can render without
+        // re-touching the index during paint; the factory itself
+        // stays in the index and we look it up by id at execute
+        // time. `entries()` returns an owned `Vec` — the snapshot
+        // for *this* open, independent of subsequent removals.
+        for (id, entry) in seed.palette_index.entries() {
             all.push(Entry {
-                label: entry.label.clone(),
-                hint: entry.hint.clone(),
-                kind: Kind::PluginEntry(*id),
+                label: entry.label,
+                hint: entry.hint,
+                kind: Kind::PluginEntry(id),
             });
         }
 
@@ -168,20 +168,12 @@ impl PaletteProvider for CommandProvider {
         match &self.all[entry_idx].kind {
             Kind::MapAction(a) => PaletteAction::Run(vec![UserCommand::Map(a.clone())]),
             Kind::PluginEntry(id) => {
-                // Live lookup against the registry — the entry may
-                // have been `:remove()`d between palette open and
-                // selection. Clone the factory out under a short
-                // borrow and drop the borrow before invoking, so
-                // the spawn callback is free to mutably borrow the
-                // registry (e.g. to call `:remove()` on its own
-                // handle).
-                let factory = self
-                    .seed
-                    .registry
-                    .borrow()
-                    .palette_entry(*id)
-                    .map(|e| e.spawn.clone());
-                let Some(spawn) = factory else {
+                // Live lookup against the palette index — the entry
+                // may have been `:remove()`d between palette open and
+                // selection. The trait returns an owned
+                // `SpawnComponent`, so invoking it cannot re-enter
+                // whatever borrow the index implementation took.
+                let Some(spawn) = self.seed.palette_index.entry_spawn(*id) else {
                     log::info!("palette: entry id={} no longer registered, ignoring", id);
                     return PaletteAction::Close;
                 };


### PR DESCRIPTION
## Summary

Step 2 of the 5-step workspace split planned in #351. Eliminates the
last layering violation between `compositor` / `palette` and the Lua
subsystem, so that when `ttymap-lua` is carved out (Step 3) the
future `ttymap-tui` crate (Step 5) can depend only on
`ttymap-engine` — not on `ttymap-lua`.

## What was wrong

`compositor::BaseLayer` and `palette::CommandSeed` used to hold a
\`Rc<RefCell<LuaRegistry>>\` directly. UI primitives knew their
plugin source was Lua-specific. Once \`ttymap-lua\` becomes its own
crate, this would force the real \`ttymap-tui\` crate to import
\`ttymap-lua\`, inverting the intended dependency direction.

## Approach

Two read-only trait objects on \`compositor::activation\`:

\`\`\`rust
pub trait ActivationIndex {
    fn find_spawn(&self, code: KeyCode, modifiers: KeyModifiers) -> Option<SpawnComponent>;
}

pub trait PaletteIndex {
    fn entries(&self) -> Vec<(u64, PaletteEntry)>;
    fn entry_spawn(&self, id: u64) -> Option<SpawnComponent>;
}
\`\`\`

- \`BaseLayer\` now holds \`Rc<dyn ActivationIndex>\`
- \`palette::CommandSeed\` now holds \`Rc<dyn PaletteIndex>\`

Neither imports \`crate::lua::*\` in production code.

The Lua side stays the single source of truth. A new
\`lua::LuaActivationIndex\` wraps \`LuaRegistryHandle\` and
implements both traits, sharing the same
\`Rc<RefCell<LuaRegistry>>\` that
\`KeybindHandle:remove()\` / \`PaletteCommandHandle:remove()\`
mutably borrow. \`App::new\` and \`main\` wrap the registry once and
pass the trait objects down.

\`PaletteEntry\` gets \`#[derive(Clone)]\` so \`entries()\` can
return an owned snapshot (cheap \`Rc\` bump on the \`spawn\` factory
plus two \`String\` clones; counts stay in the dozens per program).

## Why a trait, not \`Box<dyn Fn>\`

The original issue body suggested \`Box<dyn Fn(KeyEvent) -> Option<UserCommand>>\`,
but the audit found that's insufficient — UI primitives need
**two orthogonal queries**: (1) keybind dispatch and (2) palette
snapshot + per-id lookup. A small trait (2–3 methods) is the right
shape.

## Tests

- Compositor's existing
  \`keybind_removed_from_registry_no_longer_dispatches\` (renamed
  \`..._from_index_...\`) now uses an in-test \`MockIndex\`
  (Vec-backed \`ActivationIndex\` impl), so \`compositor/\` is free
  of any \`crate::lua::*\` import — including in tests.
- 212 unit + 2 ipc handshake + 1 ignored doctest, all pass.

## Test plan

- [x] \`cargo test --workspace\` — all PASS
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] grep confirms \`compositor/\` and \`palette/\` no longer import
  \`crate::lua::LuaRegistryHandle\` / \`new_lua_registry\` in code
  (only docstring \`[name](crate::lua::...)\` references remain)

## Related

- #351 — full 5-step plan
- Next: Step 3 (extract \`ttymap-lua\`) — mechanical move now that
  the dependency direction is straight \`ttymap-app → ttymap-lua\`