### PR TITLE
refactor: collapse ttymap-app re-export shims (#351 follow-up)

### DIFF
--- a/ttymap-app/src/app/mod.rs
+++ b/ttymap-app/src/app/mod.rs
@@ -47,17 +47,17 @@ use log::{debug, info};
 
 use self::overlay::OverlayThrottle;
 use self::sidebar::SidebarPolicy;
-use crate::UserCommand;
-use crate::compositor::op::Op;
-use crate::compositor::{BaseLayer, Compositor, Context};
-use crate::config::Config;
-use crate::event::{Event, EventBus};
-pub use crate::input::KeybindingOverrides;
-use crate::input::{KeyMap, MouseAdapter};
-use crate::lua::{LuaHandle, LuaSubsystem};
-use crate::theme::{ThemeId, UiTheme};
+use ttymap_config::Config;
+use ttymap_core::UserCommand;
+use ttymap_core::event::{Event, EventBus};
+pub use ttymap_core::keymap::KeybindingOverrides;
 use ttymap_engine::map::MapAction;
 use ttymap_engine::map::render::frame::MapFrame;
+use ttymap_lua::{LuaHandle, LuaSubsystem};
+use ttymap_tui::compositor::op::Op;
+use ttymap_tui::compositor::{BaseLayer, Compositor, Context};
+use ttymap_tui::input::{KeyMap, MouseAdapter};
+use ttymap_tui::theme::{ThemeId, UiTheme};
 
 use crate::engine_handle::EngineHandle;
 
@@ -105,7 +105,7 @@ impl App {
         keymap: KeyMap,
         theme_id: ThemeId,
         map: EngineHandle,
-        builtin_activations: Vec<crate::compositor::Activation>,
+        builtin_activations: Vec<ttymap_tui::compositor::Activation>,
         lua: LuaSubsystem,
     ) -> Self {
         let LuaSubsystem {
@@ -127,8 +127,8 @@ impl App {
         // `LuaRegistryHandle`. Built-in activations (today: just `:`
         // for the palette) are kept in their own Vec so plugins
         // can't accidentally shadow host shortcuts.
-        let activation_index: std::rc::Rc<dyn crate::compositor::ActivationIndex> =
-            std::rc::Rc::new(crate::lua::LuaActivationIndex::new(registry));
+        let activation_index: std::rc::Rc<dyn ttymap_tui::compositor::ActivationIndex> =
+            std::rc::Rc::new(ttymap_lua::LuaActivationIndex::new(registry));
         let mut compositor = Compositor::new();
         compositor.push(Box::new(BaseLayer::new(
             keymap,

--- a/ttymap-app/src/app/ui.rs
+++ b/ttymap-app/src/app/ui.rs
@@ -12,11 +12,11 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use crate::compositor::{Compositor, Context};
-use crate::lua::{LuaHandle, MapApi};
-use crate::theme::UiTheme;
 use ttymap_engine::map::render::frame::MapFrame;
 use ttymap_engine::map::render::overlay::UserPolyline;
+use ttymap_lua::{LuaHandle, MapApi};
+use ttymap_tui::compositor::{Compositor, Context};
+use ttymap_tui::theme::UiTheme;
 
 /// Draw the full screen. Caller passes the latest map snapshot
 /// (or `None` if the render thread hasn't produced one yet) plus
@@ -115,7 +115,7 @@ pub fn draw(f: &mut Frame, inputs: DrawInputs<'_>) {
 
     // Modal panels on top of the map (bottom-up) + sidebar sections
     // laid out vertically in the side panel when it's open.
-    crate::compositor::render::paint(compositor, f, map_inner, sidebar_inner, theme, ctx);
+    ttymap_tui::compositor::render::paint(compositor, f, map_inner, sidebar_inner, theme, ctx);
 
     // Empty-sidebar placeholder so toggling on with no sections shows
     // SOMETHING — otherwise the user would just see an empty box and

--- a/ttymap-app/src/lib.rs
+++ b/ttymap-app/src/lib.rs
@@ -1,30 +1,14 @@
 //! ttymap — terminal map viewer.
 //!
-//! Renders Mapbox Vector Tiles as Unicode Braille characters in the terminal.
-//! Inspired by [mapscii](https://github.com/rastapasta/mapscii).
-
-// The crate is primarily a binary (see src/main.rs). The library exists so
-// tests can share a module tree; external consumers only need the handful
-// of items used by main.rs, so everything else is `pub(crate)`.
-
-// Module organization is **flat by feature**, Neovim-inspired
-// (cf. `src/nvim/`). The single concession to layering is `app/ui.rs`
-// — the only place ratatui's `terminal.draw(...)` is called — which
-// stays inside `app/` rather than getting its own `tui/` subdir.
-// Everything else (compositor / map / input / palette / theme / lua)
-// is a peer subsystem, named for what it does rather than for which
-// layer it's "supposed" to belong to. We tried a strict `core/front`
-// split (issue #212 Phase 4) and found it forced too many exceptional
-// cases — sidebar policy is "UI" but lived in core because dispatcher
-// owns it, theme_id leaked into core because every command tracked it,
-// etc. Flat sidesteps all that.
-
-// Crate-wide command vocabulary, event bus, configuration, and
-// keymap types live in `ttymap-core` so the TUI / Lua / CLI crates
-// can consume them without a circular dependency through `ttymap-app`.
-// Re-exported as `crate::{command, event, config, UserCommand}` so
-// existing call sites in this crate keep resolving.
-pub use ttymap_core::{UserCommand, command};
+//! Renders Mapbox Vector Tiles as Unicode Braille characters in the
+//! terminal. Inspired by [mapscii](https://github.com/rastapasta/mapscii).
+//!
+//! `ttymap-app` is the **composition root**: it owns `App` (the
+//! state hub + event-loop driver), `main` (CLI parse → subsystem
+//! bootstrap → loop run), `EngineHandle` (TUI-side handle to the
+//! `ttymap engine-worker` IPC subprocess), and XDG state logging.
+//! Every other concern lives in a peer crate of the workspace —
+//! see the top-level `CLAUDE.md` for the full layout.
 
 /// Application — central state hub + event loop driver. Holds every
 /// piece of mutable app-level state (map handle, lua handle,
@@ -34,42 +18,11 @@ pub use ttymap_core::{UserCommand, command};
 pub mod app;
 
 /// `EngineHandle` — TUI-side handle to the `ttymap engine-worker`
-/// subprocess. Wraps the parent end of the bincode-framed IPC stream
-/// and presents the same surface as the in-process `MapHandle` so
-/// [`app::App`] stays oblivious to the subprocess split.
+/// subprocess. Wraps the parent end of the bincode-framed IPC
+/// stream and presents the same surface as the in-process
+/// `MapHandle` so [`app::App`] stays oblivious to the subprocess
+/// split.
 pub mod engine_handle;
-
-// Compositor, palette, theme, and input subsystems live in
-// `ttymap-tui` so the Lua runtime and the future `ttymap-cli` crate
-// can consume them without depending on `ttymap-app`. Re-exported
-// here so existing `crate::compositor::*` / `crate::palette::*` /
-// `crate::input::*` / `crate::theme::*` imports keep resolving until
-// every consumer migrates to direct `ttymap_tui::*` use.
-pub use ttymap_tui::{AppEvent, compositor, input, palette, theme};
-
-// CLI subcommands live in `ttymap-cli` (`snap` + the
-// `engine-worker` subprocess entry). Re-exported as `crate::cli`
-// so `main.rs` keeps using `ttymap_app::cli::Command::run`.
-pub use ttymap_cli as cli;
-
-/// Settings populated from `~/.config/ttymap/init.lua` + CLI overrides.
-/// Lives in `ttymap-core` for use by `ttymap-lua` (Lua bootstrap
-/// reads `ttymap.opt.*` into this shape); re-exported here for
-/// existing `crate::config::*` imports.
-pub use ttymap_config as config;
-
-// theme + input now live in `ttymap-tui` (re-exported above).
 
 /// File-based logging to XDG state directory.
 pub mod logging;
-
-/// Pub/sub event subsystem — Lua-agnostic primitive at the
-/// integration point between Rust core and Lua plugin runtime.
-/// Lives in `ttymap-core`; re-exported here for existing
-/// `crate::event::*` imports.
-pub use ttymap_core::event;
-
-// Lua runtime + bundled `runtime/` tree live in `ttymap-lua`.
-// Re-exported as `crate::lua` so existing `crate::lua::*` call sites
-// in `app/`, `main.rs`, and `cli/` keep resolving.
-pub use ttymap_lua as lua;

--- a/ttymap-app/src/main.rs
+++ b/ttymap-app/src/main.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 use ttymap_app::app::App;
 use ttymap_app::app::frame_timer::FrameTimer;
-use ttymap_app::cli::Command as Subcommand;
-use ttymap_app::config::Config;
-use ttymap_app::input::thread::InputHandle;
+use ttymap_cli::Command as Subcommand;
+use ttymap_config::Config;
+use ttymap_tui::input::thread::InputHandle;
 
 #[derive(Parser)]
 #[command(
@@ -78,14 +78,14 @@ fn main() {
     // interactive app and the `snap` subcommand reach for it; doing
     // this once at the top means we fail fast with a single error
     // message rather than hitting the same wall in two places.
-    let runtime_path = match ttymap_app::lua::resolve_runtime_path() {
+    let runtime_path = match ttymap_lua::resolve_runtime_path() {
         Ok(p) => p,
         Err(e) => {
             eprintln!("ttymap: {}", e);
             std::process::exit(1);
         }
     };
-    ttymap_app::lua::set_runtime_path(runtime_path);
+    ttymap_lua::set_runtime_path(runtime_path);
 
     // Subcommands run a single task and exit without booting the full
     // interactive app.
@@ -114,7 +114,7 @@ fn run_event_loop(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     // via `set_attribution` so `ttymap.tile:attribution()` returns
     // the live value.
     let (lua_subsystem, mut config, _keymap_overrides, keymap) =
-        ttymap_app::lua::build_subsystem(Config::default());
+        ttymap_lua::build_subsystem(Config::default());
 
     if let Some(v) = cli.lat {
         config.engine.map.lat = v;
@@ -141,7 +141,7 @@ fn run_event_loop(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     // Active theme — owned by App, consumed by the map only at
     // construction (initial styler) and on theme switch.
-    let theme_id = ttymap_app::theme::ThemeId::from_name(&config.engine.render.style);
+    let theme_id = ttymap_tui::theme::ThemeId::from_name(&config.engine.render.style);
 
     // Engine doesn't depend on crossterm; the binary owns the
     // terminal-size probe and hands cols/rows to the engine
@@ -170,11 +170,10 @@ fn run_event_loop(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     // build a `CommandSeed` around it, then append the `:`
     // activation to a fresh built-ins Vec. Must run after every
     // plugin's register call so the seed sees them.
-    let mut builtin_activations: Vec<ttymap_app::compositor::Activation> = Vec::new();
-    let palette_index: std::rc::Rc<dyn ttymap_app::compositor::PaletteIndex> = std::rc::Rc::new(
-        ttymap_app::lua::LuaActivationIndex::new(lua.registry.clone()),
-    );
-    ttymap_app::palette::install(&keymap, &mut builtin_activations, palette_index);
+    let mut builtin_activations: Vec<ttymap_tui::compositor::Activation> = Vec::new();
+    let palette_index: std::rc::Rc<dyn ttymap_tui::compositor::PaletteIndex> =
+        std::rc::Rc::new(ttymap_lua::LuaActivationIndex::new(lua.registry.clone()));
+    ttymap_tui::palette::install(&keymap, &mut builtin_activations, palette_index);
 
     let mut app = App::new(config, keymap, theme_id, map, builtin_activations, lua);
 


### PR DESCRIPTION
## Summary

Follow-up to #356 (the 7-crate carve-out). That PR kept compatibility
shims in \`ttymap-app/src/lib.rs\`:

\`\`\`rust
pub use ttymap_tui::{compositor, palette, theme, input, AppEvent};
pub use ttymap_lua as lua;
pub use ttymap_cli as cli;
pub use ttymap_core::{UserCommand, command, event};
pub use ttymap_config as config;
\`\`\`

…so every existing \`crate::compositor::*\` / \`crate::lua::*\` /
\`crate::config::*\` call site in \`ttymap-app/\` kept resolving
without churn. Works, but obscures the actual dependency edge at
the import-site level — anyone reading \`app/mod.rs\` sees
\`crate::lua::*\` and has to know \`crate::lua\` is secretly
\`ttymap-lua\`.

This PR rewrites every call site in \`ttymap-app\` (3 files —
\`main.rs\`, \`app/mod.rs\`, \`app/ui.rs\`) to import directly from
the owning crate, then strips the shims and the
\`ttymap-app/src/input/keymap.rs\` shim file.

\`ttymap-app/src/lib.rs\` now declares only the three modules
\`ttymap-app\` actually owns:

\`\`\`rust
pub mod app;
pub mod engine_handle;
pub mod logging;
\`\`\`

\`ttymap-app/src/input/\` is removed entirely.

## Diff

4 files changed, 40 insertions(+), 88 deletions(-) — net 48 lines
gone. Most of the diff is import lines and the trimmed \`lib.rs\`
preamble.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace\` — 482 tests pass (no change from #356)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] grep confirms zero \`crate::{compositor, palette, theme, lua,
  cli, config, UserCommand, command, event, input, AppEvent}\`
  references remain in \`ttymap-app/\`

## Related

- #351 — full split plan
- #356 — the carve-out that introduced the shims