### PR TITLE
refactor: drop MapAction::None (#351 follow-up)

### DIFF
--- a/ttymap-engine/src/map/action.rs
+++ b/ttymap-engine/src/map/action.rs
@@ -12,7 +12,6 @@ use crate::geo::LonLat;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum MapAction {
-    None,
     PanUp,
     PanDown,
     PanLeft,
@@ -58,13 +57,12 @@ pub enum MapAction {
 
 impl MapAction {
     /// Human-readable label used by the command palette and the help
-    /// overlay. Mouse-only variants (`PanCells`, `ZoomAt`) and the
-    /// no-op `None` return `""` since they are not exposed in UI
-    /// listings. `label()` is the single source of truth; keep
-    /// exhaustive so adding a variant triggers a compile error here.
+    /// overlay. Mouse-only variants (`PanCells`, `ZoomAt`) return
+    /// `""` since they are not exposed in UI listings. `label()` is
+    /// the single source of truth; keep exhaustive so adding a
+    /// variant triggers a compile error here.
     pub fn label(&self) -> &'static str {
         match self {
-            MapAction::None => "",
             MapAction::PanUp => "Pan up",
             MapAction::PanDown => "Pan down",
             MapAction::PanLeft => "Pan left",
@@ -87,9 +85,8 @@ impl MapAction {
     }
 
     /// Every `MapAction` variant surfaced in UI listings (command palette,
-    /// help overlay). Excludes mouse-only variants and the no-op
-    /// `None`. Adding a new keymap-bindable variant means adding it
-    /// here.
+    /// help overlay). Excludes mouse-only variants. Adding a new
+    /// keymap-bindable variant means adding it here.
     pub fn all_listed() -> &'static [MapAction] {
         &[
             MapAction::PanLeft,
@@ -110,11 +107,10 @@ impl MapAction {
 
     /// Stable, snake_case name used as the TOML key in `[keymap]`
     /// (e.g. `pan_left = ["h", "Left"]`). Mouse-only variants and
-    /// `None` / `Jump` return `""` since they cannot be rebound from
-    /// config. Exhaustive so adding a variant is a compile error.
+    /// `Jump` return `""` since they cannot be rebound from config.
+    /// Exhaustive so adding a variant is a compile error.
     pub fn config_name(&self) -> &'static str {
         match self {
-            MapAction::None => "",
             MapAction::PanUp => "pan_up",
             MapAction::PanDown => "pan_down",
             MapAction::PanLeft => "pan_left",

--- a/ttymap-engine/src/map/state.rs
+++ b/ttymap-engine/src/map/state.rs
@@ -86,7 +86,6 @@ impl MapState {
         let max_zoom = self.max_zoom;
 
         match action {
-            MapAction::None => false,
             MapAction::PanLeft => self.pan(step, -1.0, 0.0),
             MapAction::PanRight => self.pan(step, 1.0, 0.0),
             MapAction::PanUp => self.pan(step, 0.0, 0.75),

--- a/ttymap-tui/src/compositor/mod.rs
+++ b/ttymap-tui/src/compositor/mod.rs
@@ -493,7 +493,7 @@ mod tests {
         struct SwallowsAll;
         impl Component for SwallowsAll {
             fn handle_key(&mut self, _: KeyEvent, win: &mut Window) {
-                win.emit(UserCommand::Map(ttymap_engine::map::MapAction::None));
+                win.emit(UserCommand::Map(ttymap_engine::map::MapAction::Redraw));
             }
             fn render(&self, _: &mut window::RenderWindow) {}
         }

--- a/ttymap-tui/src/palette/mod.rs
+++ b/ttymap-tui/src/palette/mod.rs
@@ -303,7 +303,7 @@ mod tests {
             &self.items
         }
         fn execute(&mut self, _idx: usize, _ctx: &Context) -> PaletteAction {
-            PaletteAction::Run(vec![UserCommand::Map(MapAction::None)])
+            PaletteAction::Run(vec![UserCommand::Map(MapAction::Redraw)])
         }
     }
 
@@ -416,7 +416,7 @@ mod tests {
         expect_consumed(dispatch(&mut p, KeyCode::Down, NONE));
         let ops = dispatch(&mut p, KeyCode::Enter, NONE);
         assert!(ops.closed());
-        assert_eq!(ops.intents(), vec![UserCommand::Map(MapAction::None)]);
+        assert_eq!(ops.intents(), vec![UserCommand::Map(MapAction::Redraw)]);
         assert!(!ops.pushed());
     }
 


### PR DESCRIPTION
## Summary

\`MapAction::None\` was a no-op placeholder variant — \`process_action\`
returned \`false\` for it, \`label()\` and \`config_name()\` returned
\`\"\"\`, and **no production code ever emitted it**.

The only callers were three test helpers:

- \`palette::tests::FakeProvider::execute\` (returned a
  \`PaletteAction::Run(vec![UserCommand::Map(MapAction::None)])\`)
- \`palette::tests\` assert against that vec
- \`compositor::tests::tab_is_intercepted_before_components\` —
  \`SwallowsAll::handle_key\` emitted a no-op

The three test sites now use \`MapAction::Redraw\` as their
placeholder. Semantics are the same (\"emit something, check it
lands somewhere\") and \`Redraw\` is a real action with a
config-keymap binding, so we're not pretending dead code is alive.

Net: −8 lines, one fewer variant, six match arms shrink to five.

## Why

Null-object pattern (a no-op variant) is a code smell in Rust —
the type system already has \`Option<T>\` for \"absence\". The
\`None\` here was never selected by any producer, so it was a dead
arm sitting in three exhaustive matches.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace\` — 482 tests pass (no change)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] \`grep MapAction::None\` returns zero hits

## Related

- #351 — workspace split; this is a cleanup spotted while
  auditing command vocabulary across the new crates