### PR TITLE
refactor: drop MapAction::Redraw (#350 Tier 1)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -56,7 +56,6 @@ Current examples:
 | UserCommand                          | Source                                | Why it is a UserCommand                    |
 | ----------------------------------- | ------------------------------------- | ----------------------------------------- |
 | `Map(MapAction::Pan…)`              | keymap, mouse drag                    | User intent → map state change            |
-| `Map(MapAction::Redraw)`            | initial draw                          | Forces an unconditional fresh frame       |
 | `Map(MapAction::Jump(LonLat))`      | search provider result, geoip plugin  | Plugin async → map state change           |
 | `Quit`                              | keymap `q`, palette `:q`, Ctrl-C      | Same intent from 3 sources                |
 | `Resize(w, h)`                      | crossterm `Resize` event              | Cross-cutting: map state + render canvas  |

--- a/ttymap-app/src/app/mod.rs
+++ b/ttymap-app/src/app/mod.rs
@@ -177,7 +177,11 @@ impl App {
         event_rx: &std::sync::mpsc::Receiver<AppEvent>,
         event_tx: &std::sync::mpsc::Sender<AppEvent>,
     ) -> io::Result<()> {
-        self.dispatch_initial_redraw();
+        // Kick off the very first render task so the terminal isn't
+        // blank waiting for input. Goes direct to the render path
+        // rather than through `dispatch` — the engine has no state
+        // change to apply, just needs a frame.
+        self.request_map_redraw();
         self.publish_pending();
 
         while self.running {
@@ -224,13 +228,6 @@ impl App {
         }
 
         Ok(())
-    }
-
-    /// Initial dispatch fired right after entering the loop — kicks
-    /// off the very first render task so the terminal isn't blank
-    /// waiting for input.
-    fn dispatch_initial_redraw(&mut self) {
-        self.dispatch(UserCommand::Map(MapAction::Redraw));
     }
 
     /// Route one [`AppEvent`] into the right entry point. Each arm is

--- a/ttymap-engine/src/map/action.rs
+++ b/ttymap-engine/src/map/action.rs
@@ -24,7 +24,6 @@ pub enum MapAction {
     ZoomOut,
     ZoomToWorld,
     ResetPosition,
-    Redraw,
     /// Continuous pan by terminal-cell deltas — produced by mouse drag.
     /// `Pan*` above are discrete, keybinding-friendly steps; this is
     /// the arbitrary-delta version the mouse needs.
@@ -75,7 +74,6 @@ impl MapAction {
             MapAction::ZoomOut => "Zoom out",
             MapAction::ZoomToWorld => "Zoom to world",
             MapAction::ResetPosition => "Reset position",
-            MapAction::Redraw => "Redraw",
             MapAction::PanCells(..)
             | MapAction::ZoomAt { .. }
             | MapAction::Jump(_)
@@ -101,7 +99,6 @@ impl MapAction {
             MapAction::ZoomOut,
             MapAction::ZoomToWorld,
             MapAction::ResetPosition,
-            MapAction::Redraw,
         ]
     }
 
@@ -123,7 +120,6 @@ impl MapAction {
             MapAction::ZoomOut => "zoom_out",
             MapAction::ZoomToWorld => "zoom_to_world",
             MapAction::ResetPosition => "reset_position",
-            MapAction::Redraw => "redraw",
             MapAction::PanCells(..)
             | MapAction::ZoomAt { .. }
             | MapAction::Jump(_)

--- a/ttymap-engine/src/map/state.rs
+++ b/ttymap-engine/src/map/state.rs
@@ -119,7 +119,6 @@ impl MapState {
                 self.zoom = self.initial_zoom.unwrap_or(self.min_zoom);
                 self.center != old_center || self.zoom != old_zoom
             }
-            MapAction::Redraw => true,
             MapAction::PanCells(dx, dy) => {
                 let old = self.center;
                 self.pan_by_cells(*dx, *dy);

--- a/ttymap-tui/src/compositor/mod.rs
+++ b/ttymap-tui/src/compositor/mod.rs
@@ -493,7 +493,7 @@ mod tests {
         struct SwallowsAll;
         impl Component for SwallowsAll {
             fn handle_key(&mut self, _: KeyEvent, win: &mut Window) {
-                win.emit(UserCommand::Map(ttymap_engine::map::MapAction::Redraw));
+                win.emit(UserCommand::ToggleSidebar);
             }
             fn render(&self, _: &mut window::RenderWindow) {}
         }

--- a/ttymap-tui/src/palette/mod.rs
+++ b/ttymap-tui/src/palette/mod.rs
@@ -244,7 +244,6 @@ mod tests {
     use super::*;
     use crate::theme::ThemeId;
     use ttymap_core::UserCommand;
-    use ttymap_engine::map::MapAction;
 
     const NONE: KeyModifiers = KeyModifiers::NONE;
     const CTX: Context = Context {
@@ -303,7 +302,7 @@ mod tests {
             &self.items
         }
         fn execute(&mut self, _idx: usize, _ctx: &Context) -> PaletteAction {
-            PaletteAction::Run(vec![UserCommand::Map(MapAction::Redraw)])
+            PaletteAction::Run(vec![UserCommand::ToggleSidebar])
         }
     }
 
@@ -416,7 +415,7 @@ mod tests {
         expect_consumed(dispatch(&mut p, KeyCode::Down, NONE));
         let ops = dispatch(&mut p, KeyCode::Enter, NONE);
         assert!(ops.closed());
-        assert_eq!(ops.intents(), vec![UserCommand::Map(MapAction::Redraw)]);
+        assert_eq!(ops.intents(), vec![UserCommand::ToggleSidebar]);
         assert!(!ops.pushed());
     }
 


### PR DESCRIPTION
## Summary

`MapAction::Redraw` had a single production emitter (`App::dispatch_initial_redraw`) that routed through `dispatch(UserCommand::Map(MapAction::Redraw))`, causing **a redundant double IPC at startup**:

1. `EngineCommand::ApplyAction(Redraw)` (engine `MapState::process_action` is a no-op for `Redraw` — just returns `true` to signal "needs redraw")
2. `EngineCommand::Redraw { overlays }` (the actual draw)
3. … plus a spurious `EngineEvent::ViewportChanged { center, zoom }` round-trip back, which the parent's handler ignores as informational

Replace the dispatch with a direct `App::request_map_redraw()` call → 1 IPC instead of 2, no round-trip event.

After #358 dropped `MapAction::None`, `MapAction::Redraw` was incidentally serving as the no-op placeholder in two unit tests (`compositor/mod.rs`, `palette/mod.rs`). Those move to `UserCommand::ToggleSidebar`.

No default keymap binding referenced `redraw`, so user TOML configs are unaffected. The variant + its `label()` / `config_name()` / `all_listed()` / `process_action` arms, the `dispatch_initial_redraw` helper, the corresponding `docs/design.md` row, and a now-unused `MapAction` import in the palette tests all go.

This is **Tier 1** from #350 — safe deletes only, no compat breaks.

Diff: \`6 files changed, 8 insertions(+), 18 deletions(-)\`

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --all-targets\` (incl. \`ipc_handshake\` engine-subprocess round-trip)
- [x] \`cargo fmt --check\` (pre-commit)
- [x] Verified parent's \`ViewportChanged\` handler is a no-op (\`ttymap-app/src/engine_handle.rs:299\`), so removing the spurious round-trip is safe