### PR TITLE
refactor: centralise XDG path resolution as ttymap_config::AppDirs (#362, supersedes #323)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,7 +3011,6 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "crossterm",
- "directories",
  "log",
  "ratatui",
  "ttymap-cli",
@@ -3038,6 +3037,7 @@ dependencies = [
 name = "ttymap-config"
 version = "0.1.0"
 dependencies = [
+ "directories",
  "ttymap-core",
  "ttymap-engine",
 ]
@@ -3058,7 +3058,6 @@ dependencies = [
  "bincode",
  "criterion",
  "crossbeam-channel",
- "directories",
  "earcut",
  "flate2",
  "indexmap",
@@ -3081,7 +3080,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "crossterm",
- "directories",
  "log",
  "mlua",
  "ratatui",

--- a/ttymap-app/Cargo.toml
+++ b/ttymap-app/Cargo.toml
@@ -42,7 +42,6 @@ clap = { version = "4", features = ["derive"] }
 log = { version = "0.4", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 crossbeam-channel = "0.5"
-directories = "6"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/ttymap-app/src/engine_handle.rs
+++ b/ttymap-app/src/engine_handle.rs
@@ -91,6 +91,7 @@ impl EngineHandle {
     /// the child emits Ready or exits with an error.
     pub fn spawn(
         config: &EngineConfig,
+        cache_dir: Option<std::path::PathBuf>,
         cols: u16,
         rows: u16,
         theme: ThemeId,
@@ -129,6 +130,7 @@ impl EngineHandle {
             &mut child_stdin,
             &EngineCommand::Init {
                 config: config.clone(),
+                cache_dir,
                 cols,
                 rows,
                 theme,

--- a/ttymap-app/src/logging.rs
+++ b/ttymap-app/src/logging.rs
@@ -27,8 +27,8 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 
 use chrono::Local;
-use directories::ProjectDirs;
 use log::{LevelFilter, Log, Metadata, Record};
+use ttymap_config::AppDirs;
 
 struct FileLogger {
     file: Mutex<File>,
@@ -61,15 +61,6 @@ impl Log for FileLogger {
     }
 }
 
-fn log_path() -> Option<PathBuf> {
-    let dirs = ProjectDirs::from("", "", "ttymap")?;
-    let state_dir = dirs
-        .state_dir()
-        .unwrap_or_else(|| dirs.data_local_dir())
-        .to_path_buf();
-    Some(state_dir.join("ttymap.log"))
-}
-
 /// Parse a level name (`error` / `warn` / `info` / `debug` /
 /// `trace`) case-insensitively. Unknown strings fall back to
 /// `Debug` rather than erroring — the user is asking for logs,
@@ -86,18 +77,28 @@ fn parse_level(value: &str) -> LevelFilter {
 /// caller passes `"off"`). Truncates the file on startup so each
 /// `--log` invocation starts fresh.
 ///
+/// `dirs` carries the resolved XDG state directory (#362). `None`
+/// surfaces as "could not determine log directory" — the same
+/// failure mode the pre-#362 code had when `ProjectDirs::from`
+/// returned None.
+///
 /// Returns:
 /// - `Ok(Some(path))` when a logger was installed.
 /// - `Ok(None)` when `level == "off"`.
 /// - `Err(_)` for filesystem failures while creating the log dir
 ///   or opening the file.
-pub fn init(level: &str) -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
+pub fn init(
+    level: &str,
+    dirs: Option<&AppDirs>,
+) -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
     let level = parse_level(level);
     if level == LevelFilter::Off {
         return Ok(None);
     }
 
-    let path = log_path().ok_or("could not determine log directory")?;
+    let path = dirs
+        .map(|d| d.state.join("ttymap.log"))
+        .ok_or("could not determine log directory")?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }

--- a/ttymap-app/src/main.rs
+++ b/ttymap-app/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use ttymap_app::app::App;
 use ttymap_app::app::frame_timer::FrameTimer;
 use ttymap_cli::Command as Subcommand;
-use ttymap_config::Config;
+use ttymap_config::{AppDirs, Config};
 use ttymap_tui::input::thread::InputHandle;
 
 #[derive(Parser)]
@@ -52,6 +52,21 @@ struct Cli {
 fn main() {
     let cli = Cli::parse();
 
+    // Engine-worker is the headless subprocess role. It owns tile
+    // cache + render thread + MapState; it doesn't load Lua and
+    // doesn't need XDG paths (cache_dir comes via the parent's Init
+    // message). Dispatch early so a missing / unresolvable runtime
+    // never blocks the worker from booting.
+    if matches!(cli.command, Some(Subcommand::EngineWorker)) {
+        ttymap_engine::run_as_subprocess();
+    }
+
+    // Resolve XDG dirs once for the program (#362). All subsequent
+    // consumers (logging, runtime path, lua http / storage, tile
+    // cache) read from this single source rather than each calling
+    // `ProjectDirs::from("", "", "ttymap")` independently.
+    let dirs = AppDirs::resolve();
+
     // Logging is opt-in via `--log [LEVEL]`. Without the flag no
     // logger is registered and the `log::*!` macros are no-ops.
     // When set, logs land in ~/.local/state/ttymap/ttymap.log
@@ -61,24 +76,16 @@ fn main() {
     // surfaced on stderr — the alternative was silent failure where
     // `--log` had no observable effect and no error to grep for.
     if let Some(level) = cli.log.as_deref()
-        && let Err(e) = ttymap_app::logging::init(level)
+        && let Err(e) = ttymap_app::logging::init(level, dirs.as_ref())
     {
         eprintln!("ttymap: --log requested but logging init failed: {e}");
-    }
-
-    // Engine-worker is the headless subprocess role. It owns tile
-    // cache + render thread + MapState; it doesn't load Lua and
-    // doesn't need the runtime path. Dispatch early so a missing /
-    // unresolvable runtime never blocks the worker from booting.
-    if matches!(cli.command, Some(Subcommand::EngineWorker)) {
-        ttymap_engine::run_as_subprocess();
     }
 
     // Resolve runtime path before any Lua state spins up. Both the
     // interactive app and the `snap` subcommand reach for it; doing
     // this once at the top means we fail fast with a single error
     // message rather than hitting the same wall in two places.
-    let runtime_path = match ttymap_lua::resolve_runtime_path() {
+    let runtime_path = match ttymap_lua::resolve_runtime_path(dirs.as_ref()) {
         Ok(p) => p,
         Err(e) => {
             eprintln!("ttymap: {}", e);
@@ -90,14 +97,14 @@ fn main() {
     // Subcommands run a single task and exit without booting the full
     // interactive app.
     if let Some(cmd) = cli.command {
-        if let Err(e) = cmd.run() {
+        if let Err(e) = cmd.run(dirs) {
             eprintln!("error: {e}");
             std::process::exit(1);
         }
         return;
     }
 
-    if let Err(e) = run_event_loop(cli) {
+    if let Err(e) = run_event_loop(cli, dirs) {
         eprintln!("Error: {e}");
     }
 }
@@ -106,7 +113,17 @@ fn main() {
 /// (map / Lua), spawns the off-thread input / frame-timer peers,
 /// then hands control to `App::run`. Every thread handle joins
 /// in its `Drop` impl, so teardown is just RAII at end of scope.
-fn run_event_loop(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
+fn run_event_loop(cli: Cli, dirs: Option<AppDirs>) -> Result<(), Box<dyn std::error::Error>> {
+    // Pre-stamp resolved XDG dirs on the seed Config so every
+    // subsystem (lua storage / http, engine cache, ...) that reads
+    // `config.dirs` during `build_subsystem` sees the same values.
+    // `read_back` clones `defaults` and overrides only `opt.*`
+    // fields, so dirs flows through transparently.
+    let defaults = Config {
+        dirs: dirs.clone(),
+        ..Default::default()
+    };
+
     // Lua bootstrap runs first — `build_subsystem` creates the VM,
     // installs the API, and runs the init.lua chain (which `require`s
     // every bundled plugin). The tile cache spins up next; its
@@ -114,7 +131,7 @@ fn run_event_loop(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     // via `set_attribution` so `ttymap.tile:attribution()` returns
     // the live value.
     let (lua_subsystem, mut config, _keymap_overrides, keymap) =
-        ttymap_lua::build_subsystem(Config::default());
+        ttymap_lua::build_subsystem(defaults);
 
     if let Some(v) = cli.lat {
         config.engine.map.lat = v;
@@ -154,8 +171,18 @@ fn run_event_loop(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     // streams MapFrames back onto the AppEvent channel via
     // EngineHandle's reader thread. `EngineHandle::Drop` does the
     // cooperative shutdown + child reap at end of scope.
+    //
+    // `cache_dir` flows in via the Init handshake (#362) — engine
+    // itself never resolves XDG paths. `cache.tiles == false` and
+    // a missing AppDirs both surface as None here.
+    let cache_dir = config
+        .dirs
+        .as_ref()
+        .filter(|_| config.engine.cache.tiles)
+        .map(|d| d.cache.clone());
     let map = ttymap_app::engine_handle::EngineHandle::spawn(
         &config.engine,
+        cache_dir,
         cols,
         rows,
         theme_id,

--- a/ttymap-app/tests/ipc_handshake.rs
+++ b/ttymap-app/tests/ipc_handshake.rs
@@ -43,6 +43,9 @@ fn engine_worker_init_ready_shutdown_round_trip() {
         &mut stdin,
         &EngineCommand::Init {
             config: workerless_config(),
+            // `config.cache.tiles == false`, so a `None` cache_dir
+            // is semantically correct — engine never touches disk.
+            cache_dir: None,
             cols: 80,
             rows: 24,
             theme: ThemeId::Dark,

--- a/ttymap-cli/src/lib.rs
+++ b/ttymap-cli/src/lib.rs
@@ -8,6 +8,7 @@
 //!   3. Add the variant to [`Command`] and a match arm in [`Command::run`].
 
 use clap::Subcommand;
+use ttymap_config::AppDirs;
 
 pub mod snap;
 
@@ -25,9 +26,9 @@ pub enum Command {
 }
 
 impl Command {
-    pub fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn run(self, dirs: Option<AppDirs>) -> Result<(), Box<dyn std::error::Error>> {
         match self {
-            Self::Snap(args) => snap::run(args),
+            Self::Snap(args) => snap::run(args, dirs),
             Self::EngineWorker => ttymap_engine::run_as_subprocess(),
         }
     }

--- a/ttymap-cli/src/snap.rs
+++ b/ttymap-cli/src/snap.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 
 use clap::Args;
 
-use ttymap_config as config;
+use ttymap_config::{self as config, AppDirs};
 use ttymap_engine::map::Viewport;
 use ttymap_engine::map::render::frame::MapFrame;
 use ttymap_engine::map::render::pipeline::RenderPipeline;
@@ -72,12 +72,16 @@ pub struct SnapArgs {
     pub timeout_ms: u64,
 }
 
-pub fn run(args: SnapArgs) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(args: SnapArgs, dirs: Option<AppDirs>) -> Result<(), Box<dyn std::error::Error>> {
     // snap is headless and doesn't activate plugins, so we use the
     // config-only init.lua entry (no API install, no plugin requires).
     // `Config` carries every init.lua-tunable knob (cache / render);
     // plugins would just slow snap down.
-    let mut config = ttymap_lua::read_init_lua_config_only(config::Config::default());
+    let defaults = config::Config {
+        dirs: dirs.clone(),
+        ..Default::default()
+    };
+    let mut config = ttymap_lua::read_init_lua_config_only(defaults);
 
     if let Some(lat) = args.lat {
         config.engine.map.lat = lat;
@@ -110,7 +114,9 @@ pub fn run(args: SnapArgs) -> Result<(), Box<dyn std::error::Error>> {
     // tile::build spawns 6 worker threads fetching tiles in
     // parallel — they run independently of us, so we can drive the
     // pipeline synchronously and just poll for completed tiles.
-    let (tile_cache, _wake_rx) = ttymap_engine::map::tile::build(&config.engine)?;
+    let cache_dir = config.dirs.as_ref().map(|d| d.cache.clone());
+    let (tile_cache, _wake_rx) =
+        ttymap_engine::map::tile::build(&config.engine, cache_dir.as_deref())?;
     let theme_id = ThemeId::from_name(&config.engine.render.style);
     let styler = Arc::new(Styler::new(theme_id));
     let mut pipeline = RenderPipeline::new(

--- a/ttymap-config/Cargo.toml
+++ b/ttymap-config/Cargo.toml
@@ -10,3 +10,4 @@ repository.workspace = true
 [dependencies]
 ttymap-engine = { path = "../ttymap-engine", version = "0.1.0" }
 ttymap-core = { path = "../ttymap-core", version = "0.1.0" }
+directories = "6"

--- a/ttymap-config/src/dirs.rs
+++ b/ttymap-config/src/dirs.rs
@@ -1,0 +1,63 @@
+//! Resolved XDG directory paths for ttymap.
+//!
+//! Pre-#362, every crate (engine, app, lua, …) called
+//! `directories::ProjectDirs::from("", "", "ttymap")` independently
+//! — the brand string `"ttymap"` was hardcoded at 7 sites. This
+//! module centralises the resolution so the brand and the XDG
+//! fallback policy (state → data_local_dir) live in one place.
+//!
+//! `AppDirs::resolve()` is called once at process startup
+//! (`ttymap-app/src/main.rs` and `ttymap-cli/src/snap.rs`); the
+//! resulting struct is threaded into every consumer:
+//!
+//! - **engine tile cache** — `cache` flows via
+//!   `EngineCommand::Init.cache_dir` over the IPC pipe.
+//! - **app log file** — `state.join("ttymap.log")`.
+//! - **lua runtime path** — `config` and `data` feed the layered
+//!   resolver.
+//! - **lua HTTP cache** — `cache.join("lua-http/")`.
+//! - **lua storage lib** — `data.join("storage/")`.
+//! - **bundled init.lua** — `config` is used to skip the user tier
+//!   when walking the runtime path for the bundled file.
+//!
+//! `resolve()` returns `Option<Self>` to mirror the pre-existing
+//! "no $HOME / no per-user dirs" failure mode that every original
+//! call site already handled. Consumers gracefully degrade (no
+//! cache, no log) when `None`.
+
+use std::path::PathBuf;
+
+use directories::ProjectDirs;
+
+/// Resolved XDG directories, brand-stamped for ttymap.
+#[derive(Clone, Debug)]
+pub struct AppDirs {
+    pub config: PathBuf,
+    pub data: PathBuf,
+    pub cache: PathBuf,
+    /// `state_dir()` is Linux-only in the `directories` crate; on
+    /// macOS / Windows it returns `None`. The pre-#362 logging code
+    /// fell back to `data_local_dir()` in that case — that policy
+    /// lives here now so every consumer sees a single `state` path
+    /// regardless of platform.
+    pub state: PathBuf,
+}
+
+impl AppDirs {
+    /// Resolve the per-user XDG dirs for the `ttymap` brand. Returns
+    /// `None` when `directories::ProjectDirs::from` can't find a home
+    /// directory (rare: e.g. `HOME` unset in CI sandboxes).
+    pub fn resolve() -> Option<Self> {
+        let d = ProjectDirs::from("", "", "ttymap")?;
+        let state = d
+            .state_dir()
+            .unwrap_or_else(|| d.data_local_dir())
+            .to_path_buf();
+        Some(Self {
+            config: d.config_dir().to_path_buf(),
+            data: d.data_dir().to_path_buf(),
+            cache: d.cache_dir().to_path_buf(),
+            state,
+        })
+    }
+}

--- a/ttymap-config/src/lib.rs
+++ b/ttymap-config/src/lib.rs
@@ -17,6 +17,9 @@
 //! definitions and their `Default` impls (which act as the seed
 //! Lua starts from).
 
+pub mod dirs;
+
+pub use dirs::AppDirs;
 pub use ttymap_core::keymap::KeybindingOverrides;
 pub use ttymap_engine::config::{CacheConfig, MapConfig, RenderConfig};
 
@@ -25,6 +28,15 @@ pub struct Config {
     /// Engine-side settings consumed by the map / render pipeline.
     pub engine: ttymap_engine::Config,
     pub runtime: RuntimeConfig,
+    /// Resolved XDG directories for the `ttymap` brand. `None` only
+    /// in pathological environments where `directories::ProjectDirs`
+    /// can't find a home (CI sandboxes with `$HOME` unset, mostly).
+    /// The composition root (`ttymap-app/src/main.rs`,
+    /// `ttymap-cli/src/snap.rs`) calls `AppDirs::resolve()` once at
+    /// startup and pre-stamps this field before any subsystem boots,
+    /// so consumers (engine cache, lua http / storage, runtime path
+    /// resolver, log file) read the same paths.
+    pub dirs: Option<AppDirs>,
 }
 
 #[derive(Clone)]

--- a/ttymap-engine/Cargo.toml
+++ b/ttymap-engine/Cargo.toml
@@ -21,7 +21,6 @@ indexmap = "2.14.0"
 unicode-width = "0.2"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde_json = "1"
-directories = "6"
 thiserror = "2"
 
 [build-dependencies]

--- a/ttymap-engine/src/ipc.rs
+++ b/ttymap-engine/src/ipc.rs
@@ -15,6 +15,7 @@
 //! See `docs/architecture.md` and #348 for the multi-process design.
 
 use std::io::{self, Read, Write};
+use std::path::PathBuf;
 use std::sync::mpsc;
 
 use serde::de::DeserializeOwned;
@@ -34,8 +35,16 @@ use crate::theme::ThemeId;
 pub enum EngineCommand {
     /// One-shot boot. Builds the tile cache + render pipeline + render
     /// thread inside the child. Reply: [`EngineEvent::Ready`].
+    ///
+    /// `cache_dir` carries the parent-resolved tile-cache root (e.g.
+    /// `~/.cache/ttymap/`); engine itself never resolves XDG paths
+    /// (#362). `None` disables on-disk tile caching regardless of
+    /// `config.cache.tiles`. The parent forwards
+    /// `config.cache.tiles && AppDirs.cache` so the user-facing knob
+    /// still gates the directory's use.
     Init {
         config: Config,
+        cache_dir: Option<PathBuf>,
         cols: u16,
         rows: u16,
         theme: ThemeId,
@@ -196,13 +205,14 @@ fn command_loop<R: Read>(reader: &mut R, event_tx: mpsc::Sender<EngineEvent>) ->
         Ok(c) => c,
         Err(_) => return 0, // EOF before any command — clean exit
     };
-    let (config, cols, rows, theme) = match cmd {
+    let (config, cache_dir, cols, rows, theme) = match cmd {
         EngineCommand::Init {
             config,
+            cache_dir,
             cols,
             rows,
             theme,
-        } => (config, cols, rows, theme),
+        } => (config, cache_dir, cols, rows, theme),
         EngineCommand::Shutdown => return 0,
         _ => {
             let _ = event_tx.send(EngineEvent::Error(
@@ -216,14 +226,14 @@ fn command_loop<R: Read>(reader: &mut R, event_tx: mpsc::Sender<EngineEvent>) ->
     let frame_tx = event_tx.clone();
     let frame_sink: crate::map::render::thread::FrameSink =
         Box::new(move |frame| frame_tx.send(EngineEvent::FrameReady(frame)).is_ok());
-    let (_render_handle, mut map) = match crate::map::build(&config, cols, rows, frame_sink, theme)
-    {
-        Ok(pair) => pair,
-        Err(e) => {
-            let _ = event_tx.send(EngineEvent::Error(format!("engine build failed: {e}")));
-            return 1;
-        }
-    };
+    let (_render_handle, mut map) =
+        match crate::map::build(&config, cache_dir.as_deref(), cols, rows, frame_sink, theme) {
+            Ok(pair) => pair,
+            Err(e) => {
+                let _ = event_tx.send(EngineEvent::Error(format!("engine build failed: {e}")));
+                return 1;
+            }
+        };
 
     if event_tx
         .send(EngineEvent::Ready {
@@ -299,6 +309,7 @@ mod tests {
     fn command_init_round_trips() {
         let cmd = EngineCommand::Init {
             config: Config::default(),
+            cache_dir: Some(PathBuf::from("/tmp/ttymap-test-cache")),
             cols: 240,
             rows: 80,
             theme: ThemeId::Dark,
@@ -309,11 +320,16 @@ mod tests {
                 rows,
                 theme,
                 config,
+                cache_dir,
             } => {
                 assert_eq!(cols, 240);
                 assert_eq!(rows, 80);
                 assert_eq!(theme, ThemeId::Dark);
                 assert_eq!(config.map.lat, Config::default().map.lat);
+                assert_eq!(
+                    cache_dir.as_deref(),
+                    Some(std::path::Path::new("/tmp/ttymap-test-cache"))
+                );
             }
             _ => panic!("expected Init"),
         });

--- a/ttymap-engine/src/map/mod.rs
+++ b/ttymap-engine/src/map/mod.rs
@@ -121,6 +121,7 @@ impl MapHandle {
 /// `App` since it crosses both map rendering and UI chrome.
 pub fn build(
     config: &Config,
+    cache_dir: Option<&std::path::Path>,
     cols: u16,
     rows: u16,
     frame_sink: FrameSink,
@@ -136,7 +137,7 @@ pub fn build(
         height
     );
 
-    let (tile_cache, wake_rx) = tile::build(config)?;
+    let (tile_cache, wake_rx) = tile::build(config, cache_dir)?;
     let attribution = tile_cache.attribution();
 
     let styler = Arc::new(Styler::new(theme_id));

--- a/ttymap-engine/src/map/tile/mod.rs
+++ b/ttymap-engine/src/map/tile/mod.rs
@@ -57,8 +57,8 @@ use crate::config::Config;
 /// the cache are backend-agnostic.
 pub fn build(
     config: &Config,
+    cache_dir: Option<&std::path::Path>,
 ) -> Result<(TileCache, crossbeam_channel::Receiver<()>), crate::EngineError> {
-    use directories::ProjectDirs;
     use std::fs;
 
     use crate::map::tile::cache::DiskFastPath;
@@ -70,15 +70,19 @@ pub fn build(
     /// without saturating the upstream.
     const HTTP_WORKERS: usize = 6;
 
+    // Engine is IO-policy-free (#362): the caller resolves the XDG
+    // cache root and passes it in. `config.cache.tiles == false`
+    // means the caller passes `None`; we also tolerate
+    // `cache_dir == None` from a caller that couldn't resolve a home
+    // dir at all. Either way, no on-disk caching.
     let cache_dir = if config.cache.tiles {
-        match ProjectDirs::from("", "", "ttymap") {
-            Some(proj_dirs) => {
-                let dir = proj_dirs.cache_dir().to_path_buf();
-                fs::create_dir_all(&dir).map_err(|source| crate::EngineError::CacheDir {
-                    path: dir.clone(),
+        match cache_dir {
+            Some(dir) => {
+                fs::create_dir_all(dir).map_err(|source| crate::EngineError::CacheDir {
+                    path: dir.to_path_buf(),
                     source,
                 })?;
-                Some(dir)
+                Some(dir.to_path_buf())
             }
             None => None,
         }

--- a/ttymap-lua/Cargo.toml
+++ b/ttymap-lua/Cargo.toml
@@ -25,7 +25,6 @@ mlua = { version = "0.11", features = ["lua54", "vendored"] }
 log = { version = "0.4", features = ["std"] }
 serde = "1"
 serde_json = "1"
-directories = "6"
 unicode-width = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 sgp4 = { version = "2.4.0", default-features = false, features = ["std"] }

--- a/ttymap-lua/src/api/http.rs
+++ b/ttymap-lua/src/api/http.rs
@@ -33,15 +33,29 @@ use ttymap_engine::shared::http::HttpClient;
 
 pub struct HostHttp {
     pub http: HttpClient,
+    /// Resolved cache root passed in from `ttymap-config::AppDirs`
+    /// (#362). The `lua-http/` subdir is appended at write time.
+    /// `None` disables on-disk caching for `fetch_cached`.
+    pub cache_root: Option<std::path::PathBuf>,
 }
 
 impl UserData for HostHttp {
     fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
         methods.add_method("fetch", |_, this, url: String| {
-            Ok(LuaJob::spawn(&this.http, url, None))
+            Ok(LuaJob::spawn(
+                &this.http,
+                url,
+                None,
+                this.cache_root.clone(),
+            ))
         });
         methods.add_method("fetch_cached", |_, this, (url, ttl_secs): (String, u64)| {
-            Ok(LuaJob::spawn(&this.http, url, Some(ttl_secs)))
+            Ok(LuaJob::spawn(
+                &this.http,
+                url,
+                Some(ttl_secs),
+                this.cache_root.clone(),
+            ))
         });
         methods.add_method("url_encode", |_, _this, s: String| {
             Ok(ttymap_engine::shared::http::url::urlencoded(&s))
@@ -73,12 +87,17 @@ impl LuaJob {
     /// error so a rate-limiting upstream doesn't strand callers on
     /// "no body, no error"). Cache miss / stale rolls into the
     /// network path automatically.
-    fn spawn(http: &HttpClient, url: String, cache_ttl: Option<u64>) -> Self {
+    fn spawn(
+        http: &HttpClient,
+        url: String,
+        cache_ttl: Option<u64>,
+        cache_root: Option<std::path::PathBuf>,
+    ) -> Self {
         let (tx, rx) = mpsc::channel();
         let cancelled = Arc::new(AtomicBool::new(false));
         let cancelled_for_worker = cancelled.clone();
         let http = http.clone();
-        let path = cache_ttl.and_then(|_| http_cache_path(&url));
+        let path = cache_ttl.and_then(|_| http_cache_path(cache_root.as_deref(), &url));
         thread::spawn(move || {
             // Fresh cache hit → return immediately, skip the network.
             if let (Some(ttl), Some(p)) = (cache_ttl, path.as_ref())
@@ -152,18 +171,17 @@ impl UserData for LuaJob {
 /// Where we stash an HTTP response for `fetch_cached`. FNV-1a 64-bit
 /// keeps the cache key deterministic across runs (Rust's default
 /// hasher is not), and small enough to fit on every filesystem.
-/// `None` means we couldn't resolve a per-user cache dir — the
-/// caller treats it as a permanent miss + no write.
-fn http_cache_path(url: &str) -> Option<std::path::PathBuf> {
+/// `cache_root` comes from `ttymap-config::AppDirs.cache` (#362);
+/// `None` means the caller couldn't resolve a per-user cache dir
+/// and treats every read as a permanent miss + no write.
+fn http_cache_path(cache_root: Option<&std::path::Path>, url: &str) -> Option<std::path::PathBuf> {
     let mut hash: u64 = 0xcbf29ce484222325;
     for &b in url.as_bytes() {
         hash ^= b as u64;
         hash = hash.wrapping_mul(0x100000001b3);
     }
     let key = format!("{:016x}", hash);
-    let dir = directories::ProjectDirs::from("", "", "ttymap")?
-        .cache_dir()
-        .join("lua-http");
+    let dir = cache_root?.join("lua-http");
     Some(dir.join(format!("{}.txt", key)))
 }
 

--- a/ttymap-lua/src/api/mod.rs
+++ b/ttymap-lua/src/api/mod.rs
@@ -160,6 +160,7 @@ pub fn install(
     bus: std::rc::Rc<ttymap_core::event::EventBus>,
     ticks: std::rc::Rc<crate::tick::TickRegistry>,
     registry: crate::registrar::LuaRegistryHandle,
+    dirs: Option<&ttymap_config::AppDirs>,
 ) -> mlua::Result<LuaHostHandles> {
     // Fire-and-forget Lua intents (`map:jump`, `:zoom`, `:fly_to`,
     // `frame.export`) enqueue `Op::Command(UserCommand::...)` onto
@@ -184,6 +185,7 @@ pub fn install(
         "http",
         lua.create_userdata(http::HostHttp {
             http: HttpClient::new("lua").map_err(mlua::Error::external)?,
+            cache_root: dirs.map(|d| d.cache.clone()),
         })?,
     )?;
     ttymap.set(
@@ -199,7 +201,7 @@ pub fn install(
     )?;
     ttymap.set("help", lua.create_userdata(HostHelp::new(shared.clone()))?)?;
     ttymap.set("log", lua.create_userdata(HostLog::new("lua".to_string()))?)?;
-    if let Some(host_storage) = HostStorage::new() {
+    if let Some(host_storage) = HostStorage::new(dirs) {
         ttymap.set("storage", lua.create_userdata(host_storage)?)?;
     } else {
         // No per-user data dir resolved — `:open` would have nowhere
@@ -286,6 +288,11 @@ mod tests {
         let bus = std::rc::Rc::new(ttymap_core::event::EventBus::default());
         let ticks = std::rc::Rc::new(crate::tick::TickRegistry::default());
         let registry = crate::new_lua_registry();
+        // Resolve real XDG dirs so `ttymap.storage` wires up (it
+        // gates on `AppDirs.data` and silently skips when None).
+        // Matches pre-#362 behavior where every test relied on a
+        // real `$HOME` being present.
+        let dirs = ttymap_config::AppDirs::resolve();
         let handles = install(
             &lua,
             LuaHostShared::empty(),
@@ -293,6 +300,7 @@ mod tests {
             bus,
             ticks,
             registry,
+            dirs.as_ref(),
         )
         .expect("install ttymap table");
         (lua, handles, ops)
@@ -429,6 +437,7 @@ mod tests {
             bus,
             ticks,
             crate::new_lua_registry(),
+            None,
         )
         .expect("install ttymap table");
 
@@ -468,6 +477,7 @@ mod tests {
             bus,
             ticks.clone(),
             crate::new_lua_registry(),
+            None,
         )
         .expect("install ttymap table");
         lua.load(
@@ -500,6 +510,7 @@ mod tests {
             bus.clone(),
             ticks.clone(),
             crate::new_lua_registry(),
+            None,
         )
         .expect("install ttymap table");
         lua.load(
@@ -535,6 +546,7 @@ mod tests {
             bus.clone(),
             ticks,
             crate::new_lua_registry(),
+            None,
         )
         .expect("install ttymap table");
         lua.load(
@@ -570,6 +582,7 @@ mod tests {
             bus,
             ticks,
             crate::new_lua_registry(),
+            None,
         )
         .expect("install ttymap table");
         let result: mlua::Result<()> = lua.load(r#"ttymap.on_event("", function() end)"#).exec();

--- a/ttymap-lua/src/api/storage.rs
+++ b/ttymap-lua/src/api/storage.rs
@@ -42,17 +42,15 @@ pub(super) struct HostStorage {
 }
 
 impl HostStorage {
-    /// Production constructor. Resolves the storage root via
-    /// `directories::ProjectDirs` (same convention as the lua HTTP
-    /// cache and the host log file).
+    /// Production constructor. `dirs` carries the resolved XDG dirs
+    /// via `ttymap-config::AppDirs` (#362); the storage root is
+    /// `data_dir().join("storage")`.
     ///
     /// Returns `None` when no per-user data dir is available — the
     /// caller (api/mod.rs) treats that as "skip wiring storage in";
     /// plugins that try to open will get a clear error message.
-    pub(super) fn new() -> Option<Self> {
-        let dir = directories::ProjectDirs::from("", "", "ttymap")?
-            .data_dir()
-            .join("storage");
+    pub(super) fn new(dirs: Option<&ttymap_config::AppDirs>) -> Option<Self> {
+        let dir = dirs?.data.join("storage");
         Some(Self { root: dir })
     }
 

--- a/ttymap-lua/src/bridge/palette_provider.rs
+++ b/ttymap-lua/src/bridge/palette_provider.rs
@@ -250,6 +250,7 @@ mod tests {
             bus,
             ticks,
             crate::new_lua_registry(),
+            None,
         )
         .expect("install ttymap");
         let spec: Table = lua.load(script).eval().expect("eval spec");

--- a/ttymap-lua/src/init_lua.rs
+++ b/ttymap-lua/src/init_lua.rs
@@ -81,8 +81,8 @@ pub fn read_init_lua_config_only(defaults: Config) -> Config {
 ///
 /// IO / Lua errors are warn-logged and recovered — a broken bundled
 /// init.lua still lets the host boot with `Config::default()`.
-pub(crate) fn run_system_init_lua(lua: &Lua) {
-    let Some(path) = bundled_init_path() else {
+pub(crate) fn run_system_init_lua(lua: &Lua, dirs: Option<&ttymap_config::AppDirs>) {
+    let Some(path) = bundled_init_path(dirs) else {
         log::info!("init.lua: no bundled init found in runtime path");
         return;
     };
@@ -119,15 +119,14 @@ fn read_init_file(path: &Path) -> Option<String> {
 }
 
 /// Walk the runtime path looking for the bundled init.lua. Skips
-/// the user tier (xdg_config) — that file is the *user's* init.lua
-/// and is loaded by the `ttymap.user_config` Lua lib, not by Rust.
-/// Returns the first hit so dev manifest beats stale install
-/// (matches the runtime_path priority order).
-fn bundled_init_path() -> Option<PathBuf> {
-    use directories::ProjectDirs;
-    let user = ProjectDirs::from("", "", "ttymap").map(|d| d.config_dir().to_path_buf());
+/// the user tier (`AppDirs.config`) — that file is the *user's*
+/// init.lua and is loaded by the `ttymap.user_config` Lua lib, not
+/// by Rust. Returns the first hit so dev manifest beats stale
+/// install (matches the runtime_path priority order).
+fn bundled_init_path(dirs: Option<&ttymap_config::AppDirs>) -> Option<PathBuf> {
+    let user = dirs.map(|d| d.config.as_path());
     for layer in crate::runtime_path() {
-        if user.as_ref() == Some(layer) {
+        if user == Some(layer.as_path()) {
             continue;
         }
         let candidate = layer.join("init.lua");

--- a/ttymap-lua/src/lib.rs
+++ b/ttymap-lua/src/lib.rs
@@ -158,6 +158,7 @@ pub fn build_subsystem(defaults: Config) -> (LuaSubsystem, Config, KeybindingOve
         bus.clone(),
         ticks.clone(),
         registry.clone(),
+        defaults.dirs.as_ref(),
     ) {
         Ok(h) => h,
         Err(e) => {
@@ -183,8 +184,9 @@ pub fn build_subsystem(defaults: Config) -> (LuaSubsystem, Config, KeybindingOve
     // `package.path`), then pulls in user config via
     // `require("ttymap.user_config").load()`. The user-config
     // path lives entirely on the Lua side — Rust never names it.
-    // Errors are logged + recovered.
-    init_lua::run_system_init_lua(&lua);
+    // Errors are logged + recovered. `defaults.dirs.config` is
+    // skipped when walking the runtime path (#362).
+    init_lua::run_system_init_lua(&lua, defaults.dirs.as_ref());
 
     // Read `ttymap.opt.*` mutations back into `Config`. Type errors
     // silently fall back to the seeded value — a typo doesn't crash
@@ -295,6 +297,7 @@ mod tests {
             bus.clone(),
             ticks.clone(),
             registry.clone(),
+            None,
         )
         .expect("install ttymap");
         lua.load(source).exec().expect("exec source");
@@ -336,6 +339,7 @@ mod tests {
             bus.clone(),
             ticks.clone(),
             registry.clone(),
+            None,
         )
         .expect("install ttymap");
 

--- a/ttymap-lua/src/runtimepath.rs
+++ b/ttymap-lua/src/runtimepath.rs
@@ -36,6 +36,8 @@
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+use ttymap_config::AppDirs;
+
 /// Set once at startup by [`crate::app`] after [`resolve_runtime_path`]
 /// returns at least one valid layer. [`crate::new_lua`] reads this
 /// to wire the disk-based lib-script searcher and to extend
@@ -65,7 +67,7 @@ impl std::fmt::Display for RuntimePathError {
 /// exists and has a `lua/` subdir. Order matches the module top
 /// (env > user > bundled > dev). On full miss, returns the candidate
 /// list back so the caller can render a "we tried these" failure.
-pub fn resolve_runtime_path() -> Result<Vec<PathBuf>, RuntimePathError> {
+pub fn resolve_runtime_path(dirs: Option<&AppDirs>) -> Result<Vec<PathBuf>, RuntimePathError> {
     let mut found: Vec<PathBuf> = Vec::new();
     let mut tried: Vec<PathBuf> = Vec::new();
 
@@ -83,11 +85,13 @@ pub fn resolve_runtime_path() -> Result<Vec<PathBuf>, RuntimePathError> {
     if let Some(manifest) = option_env!("CARGO_MANIFEST_DIR") {
         visit(PathBuf::from(manifest).join("runtime"));
     }
-    if let Some(p) = xdg_config_runtime() {
-        visit(p);
-    }
-    if let Some(p) = xdg_data_runtime() {
-        visit(p);
+    // The user tier (`$XDG_CONFIG_HOME/ttymap`) holds the user's
+    // overrides; the bundled tier (`$XDG_DATA_HOME/ttymap`) is what
+    // `make install` populates. Both come from the centralised
+    // `AppDirs` resolver in `ttymap-config` (#362).
+    if let Some(d) = dirs {
+        visit(d.config.clone());
+        visit(d.data.clone());
     }
 
     if found.is_empty() {
@@ -128,23 +132,6 @@ pub fn ensure_runtime_path_for_tests() {
 /// doesn't exist there.
 fn is_valid(dir: &Path) -> bool {
     dir.is_dir()
-}
-
-/// `$XDG_CONFIG_HOME/ttymap` (default `~/.config/ttymap`). Holds
-/// `init.lua` and any user override `lua/*.lua` scripts. `directories`
-/// resolves the platform-specific equivalent on macOS / Windows.
-fn xdg_config_runtime() -> Option<PathBuf> {
-    use directories::ProjectDirs;
-    let dirs = ProjectDirs::from("", "", "ttymap")?;
-    Some(dirs.config_dir().to_path_buf())
-}
-
-/// `$XDG_DATA_HOME/ttymap` (default `~/.local/share/ttymap`). The
-/// bundled scripts dir placed by `make install`.
-fn xdg_data_runtime() -> Option<PathBuf> {
-    use directories::ProjectDirs;
-    let dirs = ProjectDirs::from("", "", "ttymap")?;
-    Some(dirs.data_dir().to_path_buf())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Pre-this-PR, 7 sites across 5 crates each called \`directories::ProjectDirs::from(\"\", \"\", \"ttymap\")\` independently. The brand string \`\"ttymap\"\` was hardcoded in every call site; the state-dir → data_local_dir fallback policy lived only inside \`logging.rs\` even though every other consumer would want the same shape.

This PR centralises XDG resolution as **\`ttymap_config::AppDirs\`** — \`{ config, data, cache, state }\` — resolved **once** at the composition root and threaded into every consumer.

## Single source of truth

\`ttymap-config/src/dirs.rs\` (new):

\`\`\`rust
pub struct AppDirs {
    pub config: PathBuf,
    pub data: PathBuf,
    pub cache: PathBuf,
    pub state: PathBuf,  // state_dir() fallback to data_local_dir baked in
}

impl AppDirs {
    pub fn resolve() -> Option<Self> { ... }
}
\`\`\`

Called once in \`ttymap-app/src/main.rs\` and \`ttymap-cli/src/snap.rs\`; \`config.dirs\` is pre-stamped on the seed Config before \`build_subsystem\` so \`read_back\` carries it through transparently.

## Engine stays IO-policy-free

- \`engine::map::tile::build(config, cache_dir: Option<&Path>)\` — was: resolved its own \`ProjectDirs\` inside.
- \`engine::map::build(config, cache_dir, cols, rows, frame_sink, theme)\` — adds \`cache_dir\` to thread through.
- \`EngineCommand::Init { config, cache_dir: Option<PathBuf>, cols, rows, theme }\` — IPC wire change. Parent forwards \`config.cache.tiles && AppDirs.cache\`; \`None\` disables on-disk caching unconditionally.

## Cargo.toml diff

| Crate | \`directories\` dep |
| --- | --- |
| \`ttymap-engine\` | **dropped** |
| \`ttymap-app\` | **dropped** |
| \`ttymap-lua\` | **dropped** |
| \`ttymap-config\` | **added** (only home) |

## Threading shape

- **engine subprocess** — receives \`cache_dir\` via Init handshake; never resolves XDG paths itself.
- **app logging** — \`logging::init(level, dirs: Option<&AppDirs>)\`.
- **lua HTTP cache** — \`HostHttp { cache_root: Option<PathBuf> }\` userdata field; the free \`http_cache_path\` fn takes \`Option<&Path>\` so it can be unit-tested without env access.
- **lua storage** — \`HostStorage::new(dirs: Option<&AppDirs>)\` returns None when no data dir is resolvable (matches pre-#362 behavior).
- **lua runtime path** — \`resolve_runtime_path(dirs: Option<&AppDirs>)\` reads \`config\` and \`data\` directly. The pre-\`build_subsystem\` resolution phase **can't** use a host-singleton (runtime path is set before the VM exists), so it takes the AppDirs ref as a function param.
- **bundled init.lua walker** — \`bundled_init_path(dirs: Option<&AppDirs>)\` skips the user tier (\`AppDirs.config\`) when finding the bundled file.

## Cache layout — unchanged

| What | Where |
| --- | --- |
| engine tile cache | \`~/.cache/ttymap/{z}/{x}-{y}.pbf\` |
| lua HTTP cache | \`~/.cache/ttymap/lua-http/{hash}.txt\` |
| lua storage | \`~/.local/share/ttymap/storage/...\` |
| log file | \`~/.local/state/ttymap/ttymap.log\` |

Existing user caches are preserved.

## Relationship to other issues

- **Subsumes #323** (engine-side slice of the same problem — \"move cache_dir resolution out of engine to binary\"). Closing this issue closes #323.
- Orthogonal to #322 (TTL/disk fallback caching consolidation) — same cross-crate dedup category, different surface.

Diff: \`23 files changed, 262 insertions(+), 110 deletions(-)\`. The line growth is plumbing — the new threading is one ref per consumer.

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --all-targets\` (incl. \`ipc_handshake\` engine-subprocess round-trip)
- [x] \`cargo fmt --check\` (pre-commit)
- [x] \`grep -rn 'ProjectDirs::from\\|directories::' --include='*.rs'\` → only \`ttymap-config/src/dirs.rs\` calls it
- [x] \`cargo run --release -- snap --lat 35.68 --lon 139.76 -z 10 --cols 40 --rows 12 -o /tmp/x.ansi\` smoke test
- [x] Verified \`~/.cache/ttymap/{z}/\` layout intact after smoke run (new tiles fetched into existing zoom-level dirs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)