### PR TITLE
refactor(app): move UI-side MapState mirror from EngineHandle to App

### DIFF
--- a/ttymap-app/src/app/mod.rs
+++ b/ttymap-app/src/app/mod.rs
@@ -53,6 +53,7 @@ use ttymap_core::event::{Event, EventBus};
 pub use ttymap_core::keymap::KeybindingOverrides;
 use ttymap_engine::map::MapAction;
 use ttymap_engine::map::render::frame::MapFrame;
+use ttymap_engine::map::state::MapState;
 use ttymap_lua::{LuaHandle, LuaSubsystem};
 use ttymap_tui::compositor::op::Op;
 use ttymap_tui::compositor::{BaseLayer, Compositor, Context};
@@ -62,6 +63,17 @@ use ttymap_tui::theme::{ThemeId, UiTheme};
 use crate::engine_handle::EngineHandle;
 
 pub struct App {
+    /// UI-side mirror of the engine's viewport state. `dispatch`
+    /// mutates this synchronously, then forwards the same
+    /// `MapAction` to the engine via `self.map.send_action`. The
+    /// child runs the identical transitions on the same inputs, so
+    /// the two stay coherent by construction — Lua's same-tick
+    /// getters (`ttymap.map:center()` etc.) read this mirror and
+    /// never block on IPC.
+    map_state: MapState,
+    /// Pure IPC transport to the `ttymap engine-worker` subprocess.
+    /// The App owns its own `MapState`; this handle just sends
+    /// commands and pipes back frames.
     map: EngineHandle,
     running: bool,
     theme_id: ThemeId,
@@ -104,6 +116,7 @@ impl App {
         config: Config,
         keymap: KeyMap,
         theme_id: ThemeId,
+        map_state: MapState,
         map: EngineHandle,
         builtin_activations: Vec<ttymap_tui::compositor::Activation>,
         lua: LuaSubsystem,
@@ -139,6 +152,7 @@ impl App {
 
         let ui_theme = UiTheme::from_palette(theme_id.palette());
         App {
+            map_state,
             map,
             running: true,
             theme_id,
@@ -372,7 +386,8 @@ impl App {
     fn dispatch(&mut self, msg: UserCommand) {
         match msg {
             UserCommand::Map(action) => {
-                if self.map.apply_action(&action) {
+                if self.map_state.process_action(&action) {
+                    self.map.send_action(&action);
                     self.request_map_redraw();
                 }
                 match &action {
@@ -420,7 +435,8 @@ impl App {
 
     fn handle_resize(&mut self, cols: u16, rows: u16) {
         let map_cols = self.sidebar.effective_map_cols(cols);
-        self.map.handle_resize(map_cols, rows);
+        self.map_state.resize(map_cols, rows);
+        self.map.send_resize(map_cols, rows);
         self.pending_events.push(Event::Resized(cols, rows));
         self.request_map_redraw();
     }
@@ -430,7 +446,8 @@ impl App {
         // queueing the next render task — Lua plugins read
         // `ttymap.map:center()` / `:zoom()` from these mirrors and
         // expect them to reflect the view about to be drawn.
-        self.lua.sync_view(self.map.center(), self.map.zoom());
+        self.lua
+            .sync_view(self.map_state.center(), self.map_state.zoom());
         let overlays = self.overlay.drain();
         self.map.request_redraw(overlays);
     }

--- a/ttymap-app/src/engine_handle.rs
+++ b/ttymap-app/src/engine_handle.rs
@@ -1,20 +1,18 @@
-//! `EngineHandle` — TUI-side handle to the `ttymap engine-worker`
-//! subprocess.
+//! `EngineHandle` — TUI-side IPC transport to the `ttymap
+//! engine-worker` subprocess.
 //!
-//! Replaces the in-process `MapHandle` for the long-lived TUI flow.
-//! Spawns the same binary as a child via `Command::new(current_exe)
-//! .arg("engine-worker")` (see [`crate::main`]), pipes a bincode-
+//! Pure transport: spawns the same binary as a child via
+//! `Command::new(current_exe).arg("engine-worker")`, pipes a bincode-
 //! framed [`EngineCommand`] / [`EngineEvent`] stream over
-//! stdin/stdout, and exposes the same surface as [`MapHandle`] so
-//! [`crate::app::App`] doesn't need to know the engine is now in
-//! another process.
+//! stdin/stdout, and exposes thin `send_*` methods that the App
+//! calls after mutating its own state.
 //!
-//! The viewport state ([`MapState`]) is mirrored UI-side and mutated
-//! synchronously on [`Self::apply_action`] / [`Self::handle_resize`].
-//! The child runs the exact same `MapState` transitions on its side
-//! so the two stay in lock-step without round-trip RPCs — Lua's
-//! synchronous getters (`ttymap.map:center()` etc.) read the mirror
-//! and never block on IPC.
+//! The UI-side mirror of [`MapState`] lives on `App` (see
+//! `ttymap-app/src/app/mod.rs`'s `map_state` field) — the App
+//! mutates it synchronously in `dispatch`, then forwards the same
+//! `MapAction` to the child here. Both sides run the identical
+//! transitions on the same inputs, so they stay coherent by
+//! construction without round-trip RPCs.
 //!
 //! `snap` keeps using `ttymap_engine::map::build` in-process; only
 //! the long-lived TUI takes the subprocess path. See #348 for the
@@ -29,9 +27,7 @@ use std::time::Duration;
 use ttymap_engine::Config as EngineConfig;
 use ttymap_engine::ipc::{EngineCommand, EngineEvent, read_message, write_message};
 use ttymap_engine::map::action::MapAction;
-use ttymap_engine::map::render::canvas_size;
 use ttymap_engine::map::render::overlay::UserPolyline;
-use ttymap_engine::map::state::{MapState, MapStateOptions};
 use ttymap_engine::theme::ThemeId;
 
 use crate::app::AppEvent;
@@ -69,12 +65,6 @@ impl std::fmt::Display for EngineHandleError {
 impl std::error::Error for EngineHandleError {}
 
 pub struct EngineHandle {
-    /// UI-side mirror of the engine's `MapState`. Updated synchronously
-    /// on every state-mutating method so Lua's same-tick getters see
-    /// the new value without waiting for IPC. The child runs the same
-    /// MapState transitions on its side; the two stay coherent by
-    /// construction (same code, same inputs).
-    state: MapState,
     /// Command stream. Cleared in [`Drop`] to signal the writer
     /// thread to exit (which closes child stdin → child exits).
     command_tx: Option<mpsc::Sender<EngineCommand>>,
@@ -153,19 +143,6 @@ impl EngineHandle {
             }
         };
 
-        let (width, height) = canvas_size(cols, rows);
-        let state = MapState::new(
-            MapStateOptions {
-                initial_lon: config.map.lon,
-                initial_lat: config.map.lat,
-                initial_zoom: config.map.zoom,
-                zoom_step: config.map.zoom_step,
-                max_zoom: config.map.max_zoom,
-            },
-            width,
-            height,
-        );
-
         let (command_tx, command_rx) = mpsc::channel::<EngineCommand>();
         let writer = thread::Builder::new()
             .name("ttymap-engine-writer".into())
@@ -178,7 +155,6 @@ impl EngineHandle {
             .map_err(|e| EngineHandleError::Spawn(io::Error::other(e.to_string())))?;
 
         Ok(Self {
-            state,
             command_tx: Some(command_tx),
             attribution,
             child: Some(child),
@@ -187,31 +163,19 @@ impl EngineHandle {
         })
     }
 
-    // ── Queries ────────────────────────────────────────────────────────
+    // ── Wire-format senders ─────────────────────────────────────────────
+    //
+    // Each `send_*` is a thin shim around the underlying `send` —
+    // the App mutates its own `MapState` mirror first, then calls
+    // these to forward the same intent to the child. The two sides
+    // run identical transitions on identical inputs and stay
+    // coherent by construction.
 
-    pub fn center(&self) -> ttymap_engine::geo::LonLat {
-        self.state.center()
+    pub fn send_action(&self, action: &MapAction) {
+        self.send(EngineCommand::ApplyAction(action.clone()));
     }
 
-    pub fn zoom(&self) -> f64 {
-        self.state.zoom()
-    }
-
-    // ── Mutations ──────────────────────────────────────────────────────
-
-    /// Apply a [`MapAction`] to the UI-side mirror **and** forward it
-    /// to the engine. Returns `true` if the mirror changed (matches
-    /// the in-process [`MapHandle::apply_action`] contract).
-    pub fn apply_action(&mut self, action: &MapAction) -> bool {
-        let changed = self.state.process_action(action);
-        if changed {
-            self.send(EngineCommand::ApplyAction(action.clone()));
-        }
-        changed
-    }
-
-    pub fn handle_resize(&mut self, cols: u16, rows: u16) {
-        self.state.resize(cols, rows);
+    pub fn send_resize(&self, cols: u16, rows: u16) {
         self.send(EngineCommand::Resize { cols, rows });
     }
 

--- a/ttymap-app/src/main.rs
+++ b/ttymap-app/src/main.rs
@@ -189,6 +189,23 @@ fn run_event_loop(cli: Cli, dirs: Option<AppDirs>) -> Result<(), Box<dyn std::er
         event_tx.clone(),
     )?;
 
+    // App owns its UI-side `MapState` mirror (see the field doc on
+    // `App::map_state`). Construct it with the same seed values the
+    // engine subprocess gets via `Init`, so the two sides start in
+    // lock-step.
+    let (width, height) = ttymap_engine::map::render::canvas_size(cols, rows);
+    let map_state = ttymap_engine::map::state::MapState::new(
+        ttymap_engine::map::state::MapStateOptions {
+            initial_lon: config.engine.map.lon,
+            initial_lat: config.engine.map.lat,
+            initial_zoom: config.engine.map.zoom,
+            zoom_step: config.engine.map.zoom_step,
+            max_zoom: config.engine.map.max_zoom,
+        },
+        width,
+        height,
+    );
+
     let lua = lua_subsystem;
     lua.handle.set_attribution(map.attribution.clone());
 
@@ -202,7 +219,15 @@ fn run_event_loop(cli: Cli, dirs: Option<AppDirs>) -> Result<(), Box<dyn std::er
         std::rc::Rc::new(ttymap_lua::LuaActivationIndex::new(lua.registry.clone()));
     ttymap_tui::palette::install(&keymap, &mut builtin_activations, palette_index);
 
-    let mut app = App::new(config, keymap, theme_id, map, builtin_activations, lua);
+    let mut app = App::new(
+        config,
+        keymap,
+        theme_id,
+        map_state,
+        map,
+        builtin_activations,
+        lua,
+    );
 
     let mut terminal = ratatui::init();
     crossterm::execute!(std::io::stdout(), crossterm::event::EnableMouseCapture)?;


### PR DESCRIPTION
## Summary

Follow-up cleanup to #348. \`EngineHandle\` (\`ttymap-app/src/engine_handle.rs\`) was carrying two unrelated concerns:

1. **IPC transport** to the \`ttymap engine-worker\` subprocess — child handle, writer/reader threads, command tx, attribution.
2. **UI-side \`MapState\` mirror** — \`apply_action\` / \`handle_resize\` mutated it so Lua's same-tick getters (\`ttymap.map:center()\` etc.) never block on IPC.

These have nothing to do with each other. Every other piece of app-level state already lives on \`App\` (compositor / theme_id / cursor / sidebar / lua / map_frame / ...). Mixing the mirror into the transport layer made mirror unit-testing require spawning the subprocess, and would entangle any future transport swap with state-replay code.

## Before / After

\`\`\`
                            As-Is                          To-Be
                       ──────────────                 ──────────────
App {                                            App {
    map: EngineHandle,                               map_state: MapState,    ← 昇格
    compositor, theme_id, ...                        engine: EngineHandle,
}                                                    compositor, theme_id, ...
                                                 }

EngineHandle {                                   EngineHandle {
    state: MapState,         ← 混在                  /* state 削除 */
    command_tx, attribution,                         command_tx, attribution,
    child, writer, reader,                           child, writer, reader,
}                                                }
   ※ IPC + mirror が同居                            ※ pure IPC transport
\`\`\`

### Dispatch path

\`\`\`
                    As-Is                                  To-Be
                ──────────────                         ──────────────
App::dispatch(UserCommand::Map(action))         App::dispatch(UserCommand::Map(action))
    │                                               │
    ▼                                               ▼
self.map.apply_action(&action)               let changed =
    │                                            self.map_state.process_action(&action);
    ├── self.state.process_action()  ①mirror    if changed {
    └── if changed {                                self.map.send_action(&action);   ②IPC
           self.send(ApplyAction(action)) ②IPC      self.request_map_redraw();
        }                                       }
    ↓ returns bool
if changed { self.request_map_redraw() }
\`\`\`

## What's preserved

- **IPC wire format** unchanged. \`EngineCommand::ApplyAction\` / \`Resize\` / \`Redraw\` payloads identical.
- **Determinism contract** unchanged. Same \`MapAction\` stream → same state on both sides.
- **Lua sync getters** unchanged. \`ttymap.map:center()\` / \`:zoom()\` still return same-tick values from a parent-side mirror; just from \`App.map_state\` instead of \`EngineHandle.state\`.
- **\`snap\` subcommand** unaffected — already in-process, doesn't touch \`EngineHandle\`.

## What changes for callers

- \`EngineHandle::apply_action(&MapAction) -> bool\` → **removed**. Caller does \`self.map_state.process_action(&action)\` + \`self.map.send_action(&action)\`.
- \`EngineHandle::handle_resize(cols, rows)\` → **removed**. Caller does \`self.map_state.resize(...)\` + \`self.map.send_resize(...)\`.
- \`EngineHandle::center()\` / \`zoom()\` → **removed**. Reach into \`App.map_state\` directly (used in 1 site: \`request_map_redraw\`'s \`lua.sync_view\` call).
- \`App::new\` takes one new positional arg: \`map_state: MapState\`. Constructed in \`main.rs\` from \`config.engine\` seed.

## Files

\`\`\`
ttymap-app/src/app/mod.rs       | 23 ++++++++++--
ttymap-app/src/engine_handle.rs | 80 ++++++++++++-----------------------------
ttymap-app/src/main.rs          | 27 +++++++++++++-
3 files changed, 68 insertions(+), 62 deletions(-)
\`\`\`

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --all-targets\` (incl. \`ipc_handshake\` engine-subprocess round-trip)
- [x] \`cargo fmt --check\` (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)