### PR TITLE
fix(engine): de-flake earcut_worker timeout test

### DIFF
--- a/ttymap-engine/src/map/render/earcut_worker.rs
+++ b/ttymap-engine/src/map/render/earcut_worker.rs
@@ -104,10 +104,18 @@ mod tests {
     #[test]
     fn timeout_returns_typed_error() {
         let mut w = EarcutWorker::new();
-        // Zero-duration timeout will fire before the worker can respond
-        // even on trivial input — easy way to exercise the timeout path.
-        let verts = vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]];
-        let result = w.triangulate(verts, vec![], Duration::from_millis(0));
+        // Large polygon + microsecond deadline: the worker can't possibly
+        // run earcut over 200k vertices in 1µs no matter how fast the
+        // thread schedules, so the timeout path fires deterministically.
+        // The previous version used 3 verts + 0ms — that raced with the
+        // worker on hot/fast runners (Ubuntu CI flake history).
+        let verts: Vec<[f64; 2]> = (0..200_000)
+            .map(|i| {
+                let t = i as f64 * 0.001;
+                [t.cos(), t.sin()]
+            })
+            .collect();
+        let result = w.triangulate(verts, vec![], Duration::from_micros(1));
         assert!(matches!(result, Err(TriangulateError::TimedOut)));
     }
 


### PR DESCRIPTION
## Summary

`map::render::earcut_worker::tests::timeout_returns_typed_error` was intermittently failing on Ubuntu CI (cf. PR #367 の Ubuntu job)。

旧版は 3 vertex の triangle + 0ms timeout で「worker thread の schedule + earcut + send より、main thread の recv_timeout(0) が先に発火する」前提だった。hot/cached worker だとこの順序が逆転して `Ok(indices)` が返り `matches!(..., TimedOut)` が false になる。

200k vertex の polygon + 1µs deadline に変更。200k 頂点の earcut は plausible な worker latency より数桁遅いので、scheduling のタイミングに関わらず timeout path が deterministic に発火する。

## Test plan

- [x] `cargo test -p ttymap-engine timeout_returns_typed_error` 50 連続実行: 50 pass / 0 fail
- [x] `cargo test --workspace` 全 443 tests green
- [x] `cargo clippy --workspace --all-targets` no warnings
- [x] pre-commit hook (test + clippy + fmt) 通過