### PR TITLE
refactor(engine): drop Berlin lat/lon default from engine Config

### DIFF
--- a/ttymap-app/src/main.rs
+++ b/ttymap-app/src/main.rs
@@ -119,6 +119,9 @@ fn run_event_loop(cli: Cli, dirs: Option<AppDirs>) -> Result<(), Box<dyn std::er
     // `config.dirs` during `build_subsystem` sees the same values.
     // `read_back` clones `defaults` and overrides only `opt.*`
     // fields, so dirs flows through transparently.
+    //
+    // `Config::default()` is the app-side seed — it ships Berlin
+    // for the initial viewport (engine itself has no opinion).
     let defaults = Config {
         dirs: dirs.clone(),
         ..Default::default()
@@ -134,10 +137,10 @@ fn run_event_loop(cli: Cli, dirs: Option<AppDirs>) -> Result<(), Box<dyn std::er
         ttymap_lua::build_subsystem(defaults);
 
     if let Some(v) = cli.lat {
-        config.engine.map.lat = v;
+        config.engine.map.lat = Some(v);
     }
     if let Some(v) = cli.lon {
-        config.engine.map.lon = v;
+        config.engine.map.lon = Some(v);
     }
     if let Some(v) = cli.zoom {
         config.engine.map.zoom = Some(v);
@@ -149,7 +152,7 @@ fn run_event_loop(cli: Cli, dirs: Option<AppDirs>) -> Result<(), Box<dyn std::er
     }
 
     log::info!(
-        "starting ttymap: lat={}, lon={}",
+        "starting ttymap: lat={:?}, lon={:?}",
         config.engine.map.lat,
         config.engine.map.lon
     );
@@ -194,10 +197,14 @@ fn run_event_loop(cli: Cli, dirs: Option<AppDirs>) -> Result<(), Box<dyn std::er
     // engine subprocess gets via `Init`, so the two sides start in
     // lock-step.
     let (width, height) = ttymap_engine::map::render::canvas_size(cols, rows);
+    // `unwrap_or(0.0)` mirrors the engine's neutral fallback for
+    // the unseeded case — `Config::default()` already fills in
+    // Berlin, so this only matters if a future code path leaves
+    // `lat/lon` as `None`.
     let map_state = ttymap_engine::map::state::MapState::new(
         ttymap_engine::map::state::MapStateOptions {
-            initial_lon: config.engine.map.lon,
-            initial_lat: config.engine.map.lat,
+            initial_lon: config.engine.map.lon.unwrap_or(0.0),
+            initial_lat: config.engine.map.lat.unwrap_or(0.0),
             initial_zoom: config.engine.map.zoom,
             zoom_step: config.engine.map.zoom_step,
             max_zoom: config.engine.map.max_zoom,

--- a/ttymap-cli/src/snap.rs
+++ b/ttymap-cli/src/snap.rs
@@ -84,10 +84,10 @@ pub fn run(args: SnapArgs, dirs: Option<AppDirs>) -> Result<(), Box<dyn std::err
     let mut config = ttymap_lua::read_init_lua_config_only(defaults);
 
     if let Some(lat) = args.lat {
-        config.engine.map.lat = lat;
+        config.engine.map.lat = Some(lat);
     }
     if let Some(lon) = args.lon {
-        config.engine.map.lon = lon;
+        config.engine.map.lon = Some(lon);
     }
     if let Some(z) = args.zoom {
         config.engine.map.zoom = Some(z);
@@ -129,8 +129,8 @@ pub fn run(args: SnapArgs, dirs: Option<AppDirs>) -> Result<(), Box<dyn std::err
 
     let map = MapState::new(
         MapStateOptions {
-            initial_lon: config.engine.map.lon,
-            initial_lat: config.engine.map.lat,
+            initial_lon: config.engine.map.lon.unwrap_or(0.0),
+            initial_lat: config.engine.map.lat.unwrap_or(0.0),
             initial_zoom: config.engine.map.zoom,
             zoom_step: config.engine.map.zoom_step,
             max_zoom: config.engine.map.max_zoom,

--- a/ttymap-config/src/lib.rs
+++ b/ttymap-config/src/lib.rs
@@ -39,7 +39,7 @@ pub use ttymap_engine::config::{CacheConfig, MapConfig, RenderConfig};
 /// doesn't have to depend on this crate.
 pub type KeybindingOverrides = HashMap<String, Vec<String>>;
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct Config {
     /// Engine-side settings consumed by the map / render pipeline.
     pub engine: ttymap_engine::Config,
@@ -53,6 +53,25 @@ pub struct Config {
     /// so consumers (engine cache, lua http / storage, runtime path
     /// resolver, log file) read the same paths.
     pub dirs: Option<AppDirs>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        // Initial viewport is binary policy, not engine concern —
+        // `ttymap_engine::MapConfig::default()` ships `lat/lon: None`.
+        // We seed Berlin here so both `ttymap-app` and `ttymap-cli`
+        // (snap) inherit it via `Config::default()` without having
+        // to repeat the constant. Users override via `--lat/--lon`,
+        // `--here`, or `ttymap.opt.{lat,lon}` in init.lua.
+        let mut engine = ttymap_engine::Config::default();
+        engine.map.lat = Some(52.51298);
+        engine.map.lon = Some(13.42012);
+        Self {
+            engine,
+            runtime: RuntimeConfig::default(),
+            dirs: None,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -100,5 +119,17 @@ mod tests {
         assert_eq!(cfg.runtime.poll_timeout_ms, 50);
         assert_eq!(cfg.runtime.overlay_redraw_ms, 100);
         assert_eq!(cfg.runtime.sidebar_width, 56);
+    }
+
+    #[test]
+    fn default_seeds_berlin_viewport_at_config_layer() {
+        // Engine itself has no viewport opinion; the Berlin seed
+        // lives in this crate's `Config::default` so both
+        // `ttymap-app` and `ttymap-cli` (snap) inherit it.
+        let cfg = Config::default();
+        assert_eq!(cfg.engine.map.lat, Some(52.51298));
+        assert_eq!(cfg.engine.map.lon, Some(13.42012));
+        assert_eq!(ttymap_engine::Config::default().map.lat, None);
+        assert_eq!(ttymap_engine::Config::default().map.lon, None);
     }
 }

--- a/ttymap-engine/src/config.rs
+++ b/ttymap-engine/src/config.rs
@@ -19,8 +19,13 @@ pub struct Config {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MapConfig {
-    pub lat: f64,
-    pub lon: f64,
+    /// Initial camera latitude. `None` = engine has no opinion;
+    /// the binary picks a fallback (see `ttymap-app` / `ttymap-cli`
+    /// for the resolution chain: CLI flag → init.lua → binary
+    /// default). If both this and `lon` reach engine as `None`,
+    /// the engine falls back to `(0.0, 0.0)`.
+    pub lat: Option<f64>,
+    pub lon: Option<f64>,
     pub zoom: Option<f64>,
     pub max_zoom: f64,
     pub zoom_step: f64,
@@ -29,8 +34,8 @@ pub struct MapConfig {
 impl Default for MapConfig {
     fn default() -> Self {
         Self {
-            lat: 52.51298, // Berlin
-            lon: 13.42012,
+            lat: None,
+            lon: None,
             zoom: None,
             max_zoom: 18.0,
             zoom_step: 0.2,

--- a/ttymap-engine/src/map/mod.rs
+++ b/ttymap-engine/src/map/mod.rs
@@ -152,10 +152,15 @@ pub fn build(
     let render_handle = RenderHandle::spawn(pipeline, wake_rx, frame_sink);
     let render_client = render_handle.client();
 
+    // Engine has no built-in viewport opinion: if the binary
+    // didn't seed `config.map.lat/lon`, fall back to (0,0) so we
+    // still produce a frame. The binary is responsible for picking
+    // a meaningful starting view (CLI flag / init.lua / app
+    // default — see `ttymap-app` and `ttymap-cli`).
     let state = MapState::new(
         MapStateOptions {
-            initial_lon: config.map.lon,
-            initial_lat: config.map.lat,
+            initial_lon: config.map.lon.unwrap_or(0.0),
+            initial_lat: config.map.lat.unwrap_or(0.0),
             initial_zoom: config.map.zoom,
             zoom_step: config.map.zoom_step,
             max_zoom: config.map.max_zoom,

--- a/ttymap-lua/src/init_lua.rs
+++ b/ttymap-lua/src/init_lua.rs
@@ -162,8 +162,16 @@ fn build_opt_table(lua: &Lua, d: &Config) -> mlua::Result<Table> {
     let opt = lua.create_table()?;
 
     let map = lua.create_table()?;
-    map.set("lat", d.engine.map.lat)?;
-    map.set("lon", d.engine.map.lon)?;
+    // lat / lon mirror the `Option<f64>` shape: a binary that
+    // hasn't seeded a starting view leaves the field absent rather
+    // than guessing — `ttymap.opt.lat` in init.lua is then `nil`,
+    // and the user (or `ttymap.opt.lat = ...`) decides.
+    if let Some(lat) = d.engine.map.lat {
+        map.set("lat", lat)?;
+    }
+    if let Some(lon) = d.engine.map.lon {
+        map.set("lon", lon)?;
+    }
     if let Some(z) = d.engine.map.zoom {
         map.set("zoom", z)?;
     }
@@ -246,10 +254,10 @@ pub(crate) fn read_back(lua: &Lua, defaults: &Config) -> mlua::Result<Config> {
 
     if let Ok(t) = opt.get::<Table>("map") {
         if let Ok(v) = t.get::<f64>("lat") {
-            cfg.engine.map.lat = v;
+            cfg.engine.map.lat = Some(v);
         }
         if let Ok(v) = t.get::<f64>("lon") {
-            cfg.engine.map.lon = v;
+            cfg.engine.map.lon = Some(v);
         }
         if let Ok(v) = t.get::<Option<f64>>("zoom") {
             cfg.engine.map.zoom = v;


### PR DESCRIPTION
## Summary
- `ttymap-engine` no longer carries an opinion about where the camera starts — `MapConfig.lat/lon` become `Option<f64>`, default `None`.
- Berlin (52.51298, 13.42012) moves up one layer to `ttymap-config::Config::default()`, so both `ttymap-app` and `ttymap-cli` (snap) keep inheriting it via `Config::default()` with no restated constant. New non-TUI engine consumers (future headless tools) can go via `ttymap_engine::Config::default()` and get a no-opinion seed.
- Engine + binary seed sites unwrap to `(0.0, 0.0)` as a neutral fallback if `None` ever reaches `MapState::new`. `init.lua`'s `ttymap.opt.{lat,lon}` now mirror the Option shape (absent when `None`, same convention as `zoom`).

Closes #363.

## Test plan
- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (443 tests, 0 fail)
- [x] new `ttymap-config` test `default_seeds_berlin_viewport_at_config_layer` locks in Berlin-at-config / None-at-engine invariants
- [x] `ttymap snap` smoke test:
  - no args → Berlin output
  - `--lat 35.68 --lon 139.76` → Tokyo output (diff against Berlin verified)