### PR TITLE
refactor(engine): inline RenderHandle::shutdown into Drop

### DIFF
--- a/ttymap-engine/src/map/render/thread.rs
+++ b/ttymap-engine/src/map/render/thread.rs
@@ -150,8 +150,15 @@ impl RenderHandle {
     pub fn client(&self) -> RenderClient {
         self.client.clone()
     }
+}
 
-    pub fn shutdown(&mut self) {
+impl Drop for RenderHandle {
+    /// Cooperative shutdown is the *only* way to wind a
+    /// `RenderHandle` down — no public `shutdown()` exists to call
+    /// manually. CLAUDE.md / docs/design.md state "Cleanup via
+    /// Drop, not manual"; making it the sole path enforces that at
+    /// the type level.
+    fn drop(&mut self) {
         self.should_quit.store(true, Ordering::Relaxed);
         let _ = self.client.task_tx.send(RenderTask::Shutdown);
         // `Option::take` alone only **drops** the JoinHandle — that's
@@ -160,12 +167,6 @@ impl RenderHandle {
         if let Some(handle) = self.thread.take() {
             let _ = handle.join();
         }
-    }
-}
-
-impl Drop for RenderHandle {
-    fn drop(&mut self) {
-        self.shutdown();
     }
 }
 
@@ -321,7 +322,7 @@ mod tests {
 
     use super::*;
 
-    /// Regression for issue #107. `shutdown` previously did
+    /// Regression for issue #107. The cleanup code previously did
     /// `self.thread.take()` which only **drops** the `JoinHandle` —
     /// `Drop for JoinHandle` is detach, not join. So control returned
     /// to the caller while the render thread was still running,
@@ -329,10 +330,10 @@ mod tests {
     /// shutdown is handled by its Drop impl".
     ///
     /// Probe: a thread that does a brief wind-down sleep before
-    /// flipping a flag. After shutdown, the flag must be set —
-    /// otherwise the join didn't actually wait.
+    /// flipping a flag. After the handle drops, the flag must be set
+    /// — otherwise the join didn't actually wait.
     #[test]
-    fn shutdown_joins_the_render_thread() {
+    fn dropping_handle_joins_the_render_thread() {
         let exited = Arc::new(Mutex::new(false));
         let exited_clone = Arc::clone(&exited);
 
@@ -358,17 +359,17 @@ mod tests {
             *exited_clone.lock().unwrap() = true;
         });
 
-        let mut handle = RenderHandle {
+        let handle = RenderHandle {
             client: RenderClient { task_tx },
             should_quit,
             thread: Some(thread),
         };
 
-        handle.shutdown();
+        drop(handle);
 
         assert!(
             *exited.lock().unwrap(),
-            "shutdown must wait for the render thread to finish (join), \
+            "Drop must wait for the render thread to finish (join), \
              not detach (drop the JoinHandle)"
         );
     }


### PR DESCRIPTION
## Summary
- The `pub fn shutdown` on `RenderHandle` had no external callers — `Drop::drop` was the only production caller, and one in-module test the only other.
- Going one step beyond #312's "make it private": inline the body into `Drop::drop` and remove the method entirely. CLAUDE.md / docs/design.md already state *"Cleanup via Drop, not manual"*; removing the method enforces that at the type level — there's no `shutdown()` left to call by hand.
- The issue-#107 regression comment (`Option::take` detaches, not joins) moves with the body and stays at the join site.
- The test `shutdown_joins_the_render_thread` is renamed to `dropping_handle_joins_the_render_thread` and switches from `handle.shutdown()` to `drop(handle)`. The probe is unchanged — `Drop` fires synchronously, so the same flag-after-drop assertion proves the join still waits.

Closes #312.

## Test plan
- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (`dropping_handle_joins_the_render_thread` passes — the issue-#107 regression check still triggers on drop)