### PR TITLE
refactor(lua): unify MapApi color accessor naming on *_xterm

### DIFF
--- a/ttymap-lua/src/api/map.rs
+++ b/ttymap-lua/src/api/map.rs
@@ -237,23 +237,16 @@ fn resolve_color_arg(p: &MapApi<'_>, arg: Option<&mlua::Value>) -> u8 {
     match arg {
         Some(mlua::Value::Integer(n)) => (*n).clamp(0, 255) as u8,
         Some(mlua::Value::String(s)) => resolve_keyword(p, s),
-        _ => xterm_index(p.accent_color()),
+        _ => p.accent_color_xterm(),
     }
 }
 
 fn resolve_keyword(p: &MapApi<'_>, keyword: &mlua::String) -> u8 {
     match keyword.to_str().as_deref() {
         Ok("road") => p.road_color_xterm(),
-        Ok("accent_alt") => xterm_index(p.accent_alt_color()),
-        Ok("muted") => xterm_index(p.muted_color()),
-        _ => xterm_index(p.accent_color()),
-    }
-}
-
-fn xterm_index(color: ratatui::style::Color) -> u8 {
-    match color {
-        ratatui::style::Color::Indexed(i) => i,
-        _ => 7,
+        Ok("accent_alt") => p.accent_alt_color_xterm(),
+        Ok("muted") => p.muted_color_xterm(),
+        _ => p.accent_color_xterm(),
     }
 }
 

--- a/ttymap-lua/src/map_api.rs
+++ b/ttymap-lua/src/map_api.rs
@@ -110,25 +110,11 @@ impl<'a> MapApi<'a> {
     }
 
     // ── Theme accessors ──────────────────────────────────────────────
-
-    /// Primary accent colour — used by plugins to highlight features
-    /// (wiki markers, search pins, ...). Semantic accessor; the
-    /// underlying theme is hidden from plugins.
-    pub fn accent_color(&self) -> Color {
-        self.theme.accent
-    }
-
-    /// Secondary accent colour — typically used to distinguish the
-    /// selected / focused feature from the rest.
-    pub fn accent_alt_color(&self) -> Color {
-        self.theme.accent_alt
-    }
-
-    /// Muted foreground for chrome that should fade into the
-    /// background — attribution text, less-important readouts.
-    pub fn muted_color(&self) -> Color {
-        self.theme.muted_color
-    }
+    //
+    // All palette colours are surfaced uniformly as xterm-256 indices
+    // (`u8`) — the same shape `map:polyline` / `map:point` take. Lua
+    // plugins never see a `ratatui::Color`, so exposing only the
+    // `*_xterm` form keeps the surface single-typed.
 
     /// Active palette's "motorway" road colour as an xterm-256 index.
     /// Surfaced for the Lua bridge so plugins can request the same
@@ -143,26 +129,17 @@ impl<'a> MapApi<'a> {
     /// for plugins that want to feed the same colour into `map:polyline`
     /// or other APIs that take xterm indices.
     pub fn accent_color_xterm(&self) -> u8 {
-        match self.accent_color() {
-            ratatui::style::Color::Indexed(i) => i,
-            _ => 7,
-        }
+        color_to_xterm(self.theme.accent)
     }
 
     /// Active palette's `accent_alt` colour as an xterm-256 index.
     pub fn accent_alt_color_xterm(&self) -> u8 {
-        match self.accent_alt_color() {
-            ratatui::style::Color::Indexed(i) => i,
-            _ => 7,
-        }
+        color_to_xterm(self.theme.accent_alt)
     }
 
     /// Active palette's `muted` colour as an xterm-256 index.
     pub fn muted_color_xterm(&self) -> u8 {
-        match self.muted_color() {
-            ratatui::style::Color::Indexed(i) => i,
-            _ => 7,
-        }
+        color_to_xterm(self.theme.muted_color)
     }
 
     // ── Drawing primitives ──────────────────────────────────────────
@@ -314,6 +291,17 @@ impl<'a> MapApi<'a> {
             return None;
         }
         Some((self.map_area.x + col, self.map_area.y + row))
+    }
+}
+
+/// Unwrap an indexed terminal colour to its xterm-256 byte. The
+/// theme is authored against an indexed palette, so the non-Indexed
+/// arm is unreachable in practice — `7` (light grey) is the
+/// defensive fallback if a future theme ever surfaces an RGB colour.
+fn color_to_xterm(color: Color) -> u8 {
+    match color {
+        Color::Indexed(i) => i,
+        _ => 7,
     }
 }
 


### PR DESCRIPTION
## Summary
- `MapApi` had two parallel accessor families for the same palette data — `accent_color()` / `accent_alt_color()` / `muted_color()` returning `ratatui::Color`, plus `*_color_xterm()` returning the xterm-256 byte. `road_color_xterm()` only ever had the `_xterm` form. `resolve_keyword` in `api/map.rs` mixed the shapes: `road` used `road_color_xterm()` directly while `accent_alt` / `muted` / `accent` went through a free `xterm_index` helper wrapping the `Color`-returning accessors.
- Plugins only ever see the xterm byte (the Lua bridge already exposes `*_color_xterm()`), so the `Color` flavour was dead indirection — its only callers were the `_xterm` wrappers themselves and `resolve_keyword`.
- Dropped the three `Color`-returning accessors, folded the conversion into a private `color_to_xterm` helper in `map_api.rs`, and collapsed `resolve_keyword` to a 1:1 keyword → `p.*_color_xterm()` lookup. `xterm_index` (the free helper in `api/map.rs`) is no longer referenced and is deleted.

Closes #327.

## Test plan
- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (443 tests, 0 fail — color-arg tests for `polyline` / `point` / `label` still pass through the same `resolve_color_arg` entry point)