### PR TITLE
refactor(engine): collapse ZoomIn/ZoomOut into ZoomBy(i8), unify ZoomAt direction

### DIFF
--- a/ttymap-engine/src/map/action.rs
+++ b/ttymap-engine/src/map/action.rs
@@ -20,8 +20,11 @@ pub enum MapAction {
     PanRightFast,
     PanUpHalf,
     PanDownHalf,
-    ZoomIn,
-    ZoomOut,
+    /// Zoom by `dir` steps. `+1` = `zoom_in`, `-1` = `zoom_out`; the
+    /// integer is `dir * zoom_step` when applied, so larger magnitudes
+    /// remain a free axis for future fast-zoom bindings without
+    /// adding new variants.
+    ZoomBy(i8),
     ZoomToWorld,
     ResetPosition,
     /// Continuous pan by terminal-cell deltas — produced by mouse drag.
@@ -30,11 +33,12 @@ pub enum MapAction {
     PanCells(i16, i16),
     /// Zoom toward a screen anchor — produced by mouse scroll wheel.
     /// The anchor is expressed in cells relative to screen center;
-    /// `zoom_in == true` zooms in by one step, else out.
+    /// `dir` follows the same convention as [`ZoomBy`] (`+1` zooms
+    /// in, `-1` zooms out).
     ZoomAt {
         anchor_dx: f64,
         anchor_dy: f64,
-        zoom_in: bool,
+        dir: i8,
     },
     /// Re-centre the map on a specific location. Produced by search,
     /// the here-plugin, and `ttymap.map:jump` from any Lua plugin — anything
@@ -70,8 +74,9 @@ impl MapAction {
             MapAction::PanRightFast => "Pan right (fast)",
             MapAction::PanUpHalf => "Pan up (half)",
             MapAction::PanDownHalf => "Pan down (half)",
-            MapAction::ZoomIn => "Zoom in",
-            MapAction::ZoomOut => "Zoom out",
+            MapAction::ZoomBy(1) => "Zoom in",
+            MapAction::ZoomBy(-1) => "Zoom out",
+            MapAction::ZoomBy(_) => "",
             MapAction::ZoomToWorld => "Zoom to world",
             MapAction::ResetPosition => "Reset position",
             MapAction::PanCells(..)
@@ -95,8 +100,8 @@ impl MapAction {
             MapAction::PanRightFast,
             MapAction::PanUpHalf,
             MapAction::PanDownHalf,
-            MapAction::ZoomIn,
-            MapAction::ZoomOut,
+            MapAction::ZoomBy(1),
+            MapAction::ZoomBy(-1),
             MapAction::ZoomToWorld,
             MapAction::ResetPosition,
         ]
@@ -116,8 +121,9 @@ impl MapAction {
             MapAction::PanRightFast => "pan_right_fast",
             MapAction::PanUpHalf => "pan_up_half",
             MapAction::PanDownHalf => "pan_down_half",
-            MapAction::ZoomIn => "zoom_in",
-            MapAction::ZoomOut => "zoom_out",
+            MapAction::ZoomBy(1) => "zoom_in",
+            MapAction::ZoomBy(-1) => "zoom_out",
+            MapAction::ZoomBy(_) => "",
             MapAction::ZoomToWorld => "zoom_to_world",
             MapAction::ResetPosition => "reset_position",
             MapAction::PanCells(..)

--- a/ttymap-engine/src/map/state.rs
+++ b/ttymap-engine/src/map/state.rs
@@ -94,14 +94,10 @@ impl MapState {
             MapAction::PanRightFast => self.pan(step, 10.0, 0.0),
             MapAction::PanUpHalf => self.pan(step, 0.0, 7.5),
             MapAction::PanDownHalf => self.pan(step, 0.0, -7.5),
-            MapAction::ZoomIn => {
+            MapAction::ZoomBy(dir) => {
                 let old = self.zoom;
-                self.zoom = (self.zoom + zoom_step).min(max_zoom);
-                self.zoom != old
-            }
-            MapAction::ZoomOut => {
-                let old = self.zoom;
-                self.zoom = (self.zoom - zoom_step).max(self.min_zoom);
+                let delta = f64::from(*dir) * zoom_step;
+                self.zoom = (self.zoom + delta).clamp(self.min_zoom, max_zoom);
                 self.zoom != old
             }
             MapAction::ZoomToWorld => {
@@ -127,9 +123,9 @@ impl MapState {
             MapAction::ZoomAt {
                 anchor_dx,
                 anchor_dy,
-                zoom_in,
+                dir,
             } => {
-                let delta = if *zoom_in { zoom_step } else { -zoom_step };
+                let delta = f64::from(*dir) * zoom_step;
                 let old_zoom = self.zoom;
                 let old_center = self.center;
                 self.zoom_towards(*anchor_dx, *anchor_dy, delta);
@@ -257,10 +253,10 @@ mod tests {
     fn test_zoom_in_out() {
         let mut map = default_core();
         for _ in 0..5 {
-            map.process_action(&MapAction::ZoomIn);
+            map.process_action(&MapAction::ZoomBy(1));
         }
         let after_in = map.zoom;
-        map.process_action(&MapAction::ZoomOut);
+        map.process_action(&MapAction::ZoomBy(-1));
         assert!(map.zoom < after_in);
     }
 
@@ -286,7 +282,7 @@ mod tests {
     #[test]
     fn set_zoom_clamps_into_allowed_range() {
         // SetZoom must obey the same `[min_zoom, max_zoom]` window that
-        // ZoomIn/ZoomOut land in; out-of-range Lua-side requests get
+        // `ZoomBy` lands in; out-of-range Lua-side requests get
         // clamped so a plugin author can pass `1e9` without the host
         // entering an undefined zoom state.
         let mut map = default_core();

--- a/ttymap-tui/src/input/keymap.rs
+++ b/ttymap-tui/src/input/keymap.rs
@@ -168,10 +168,10 @@ impl Default for KeyMap {
                 map("w", PanRightFast),
                 map("C-u", PanUpHalf),
                 map("C-d", PanDownHalf),
-                map("a", ZoomIn),
-                map("+", ZoomIn),
-                map("z", ZoomOut),
-                map("-", ZoomOut),
+                map("a", ZoomBy(1)),
+                map("+", ZoomBy(1)),
+                map("z", ZoomBy(-1)),
+                map("-", ZoomBy(-1)),
                 map("0", ResetPosition),
                 intent("q", UserCommand::Quit),
                 intent("\\", UserCommand::ToggleSidebar),
@@ -285,7 +285,7 @@ mod tests {
 
         assert_eq!(
             km.lookup(KeyCode::Char('i'), KeyModifiers::NONE),
-            Some(&map(MapAction::ZoomIn))
+            Some(&map(MapAction::ZoomBy(1)))
         );
         assert_eq!(
             km.lookup(KeyCode::Char('Q'), KeyModifiers::NONE),
@@ -347,11 +347,11 @@ mod tests {
         let km = KeyMap::default();
         assert_eq!(
             km.resolve(KeyCode::Char('a'), NONE),
-            Some(map(MapAction::ZoomIn))
+            Some(map(MapAction::ZoomBy(1)))
         );
         assert_eq!(
             km.resolve(KeyCode::Char('z'), NONE),
-            Some(map(MapAction::ZoomOut))
+            Some(map(MapAction::ZoomBy(-1)))
         );
     }
 

--- a/ttymap-tui/src/input/mouse.rs
+++ b/ttymap-tui/src/input/mouse.rs
@@ -81,12 +81,12 @@ impl MouseAdapter {
             MouseEventKind::ScrollUp => Some(UserCommand::Map(MapAction::ZoomAt {
                 anchor_dx,
                 anchor_dy,
-                zoom_in: true,
+                dir: 1,
             })),
             MouseEventKind::ScrollDown => Some(UserCommand::Map(MapAction::ZoomAt {
                 anchor_dx,
                 anchor_dy,
-                zoom_in: false,
+                dir: -1,
             })),
             _ => None,
         }


### PR DESCRIPTION
## Summary

`MapAction::ZoomIn` / `MapAction::ZoomOut` were a 2-variant constant
table — the only thing they encoded over `zoom_step` was the sign.
`ZoomAt { ..., zoom_in: bool }` did the same in bool form. Collapse
both to a shared `dir: i8` axis (`+1` zooms in, `-1` zooms out).

- `ZoomBy(i8)` replaces `ZoomIn` / `ZoomOut`
- `ZoomAt.zoom_in: bool` → `ZoomAt.dir: i8`
- `process_action` ZoomBy arm uses `.clamp(min, max)` for both
  directions instead of the asymmetric `.min(max)` / `.max(min)`
- `from_config_name("zoom_in")` still resolves (via `all_listed` →
  `config_name` round-trip), so TOML / Lua keymap names are
  unchanged — `ttymap.keymap.set("zoom_in", "i")` keeps working
- Frees future fast-zoom bindings (`ZoomBy(2)`) without adding new
  enum variants or match arms

## User-facing behaviour

Identical. Default keybindings (`a` / `+` → zoom in, `z` / `-` →
zoom out) and config names (`zoom_in` / `zoom_out`) preserved.

## Why not also collapse the 9 Pan variants (#359)

Considered. `Pan { dx, dy }` collapses 9 → 1, but the `all_listed`
literals (`Pan { dx: -1.0, dy: 0.0 }, …` × 8) make the after-shape
noisier than the before. The Zoom collapse here is cleaner because
the parameter has semantic meaning (sign = direction), only 2
constants need round-tripping, and the unification benefits `ZoomAt`
for free. Pan stays as-is.

## Test plan

- [x] `cargo test --workspace` — 444 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] pre-commit hook (test + clippy + fmt) — pass