### PR TITLE
feat(lua): per-layer visibility toggle — map:set_layer_visible(layer, bool)

### DIFF
--- a/ttymap-app/src/app/mod.rs
+++ b/ttymap-app/src/app/mod.rs
@@ -406,6 +406,10 @@ impl App {
                 self.map.set_labels_visible(visible);
                 self.request_map_redraw();
             }
+            UserCommand::SetLayerVisible { layer, visible } => {
+                self.map.set_layer_visible(&layer, visible);
+                self.request_map_redraw();
+            }
         }
     }
 

--- a/ttymap-app/src/engine_handle.rs
+++ b/ttymap-app/src/engine_handle.rs
@@ -187,6 +187,13 @@ impl EngineHandle {
         self.send(EngineCommand::SetLabelsVisible(visible));
     }
 
+    pub fn set_layer_visible(&self, layer: &str, visible: bool) {
+        self.send(EngineCommand::SetLayerVisible {
+            layer: layer.to_string(),
+            visible,
+        });
+    }
+
     pub fn request_redraw(&self, overlays: Vec<UserPolyline>) {
         self.send(EngineCommand::Redraw { overlays });
     }

--- a/ttymap-engine/src/ipc.rs
+++ b/ttymap-engine/src/ipc.rs
@@ -56,6 +56,11 @@ pub enum EngineCommand {
     /// Toggle tile-rendered text labels. Caller is responsible for
     /// the follow-up [`EngineCommand::Redraw`].
     SetLabelsVisible(bool),
+    /// Show / hide one MVT source layer. Caller is responsible for
+    /// the follow-up [`EngineCommand::Redraw`]. Unknown layer names
+    /// are accepted silently so the API stays forward-compatible
+    /// with schemas added later.
+    SetLayerVisible { layer: String, visible: bool },
     /// Mutate engine state (pan / zoom / jump / reset / …).
     ApplyAction(MapAction),
     /// Trigger a fresh frame using the current viewport. `overlays` is
@@ -267,6 +272,9 @@ fn command_loop<R: Read>(reader: &mut R, event_tx: mpsc::Sender<EngineEvent>) ->
             EngineCommand::SetLabelsVisible(visible) => {
                 map.set_labels_visible(visible);
             }
+            EngineCommand::SetLayerVisible { layer, visible } => {
+                map.set_layer_visible(&layer, visible);
+            }
             EngineCommand::ApplyAction(action) => {
                 let changed = map.apply_action(&action);
                 if changed {
@@ -365,6 +373,21 @@ mod tests {
         roundtrip(&EngineCommand::SetLabelsVisible(true), |d| match d {
             EngineCommand::SetLabelsVisible(v) => assert!(v),
             _ => panic!("expected SetLabelsVisible"),
+        });
+    }
+
+    #[test]
+    fn command_set_layer_visible_round_trips() {
+        let cmd = EngineCommand::SetLayerVisible {
+            layer: "water".to_string(),
+            visible: false,
+        };
+        roundtrip(&cmd, |d| match d {
+            EngineCommand::SetLayerVisible { layer, visible } => {
+                assert_eq!(layer, "water");
+                assert!(!visible);
+            }
+            _ => panic!("expected SetLayerVisible"),
         });
     }
 

--- a/ttymap-engine/src/map/mod.rs
+++ b/ttymap-engine/src/map/mod.rs
@@ -101,6 +101,13 @@ impl MapHandle {
         self.render_client.set_labels_visible(visible);
     }
 
+    /// Show / hide one MVT source layer on the render thread.
+    /// Caller is responsible for the follow-up [`Self::request_redraw`]
+    /// — updating the hidden set alone won't redraw the visible frame.
+    pub fn set_layer_visible(&self, layer: &str, visible: bool) {
+        self.render_client.set_layer_visible(layer, visible);
+    }
+
     /// Queue a fresh `RenderTask::Draw` against the current
     /// viewport, carrying any per-frame overlays the caller has
     /// collected (e.g. Lua-pushed polylines drained from

--- a/ttymap-engine/src/map/render/pipeline.rs
+++ b/ttymap-engine/src/map/render/pipeline.rs
@@ -164,6 +164,13 @@ impl RenderPipeline {
         self.renderer.set_labels_visible(visible);
     }
 
+    /// Show / hide one MVT source layer. Forwards to the underlying
+    /// `Renderer`. No tile cache flush — hiding only short-circuits
+    /// the per-layer draw branch; decoded features stay in cache.
+    pub fn set_layer_visible(&mut self, layer: &str, visible: bool) {
+        self.renderer.set_layer_visible(layer, visible);
+    }
+
     // ── Private ──────────────────────────────────────────────────────────
 
     /// Compute the set of visible tiles for a viewport against the

--- a/ttymap-engine/src/map/render/renderer.rs
+++ b/ttymap-engine/src/map/render/renderer.rs
@@ -7,6 +7,7 @@
 //! than baking it into `Feature` at decode time) means the tile cache does not
 //! need to be flushed when the palette or style preset changes.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use log::debug;
@@ -89,6 +90,12 @@ pub struct Renderer {
     /// it through `RenderHandle::set_labels_visible`. Default
     /// `true`.
     labels_visible: bool,
+    /// Source-layer names suppressed during the per-feature loop.
+    /// Checked once per `LayerData` at the outermost per-tile loop
+    /// so the inner feature loop never runs for hidden layers.
+    /// Plugins flip entries through `RenderHandle::set_layer_visible`.
+    /// Default: empty (every layer renders).
+    hidden_layers: HashSet<String>,
 }
 
 /// A symbol feature that survived the first pass. Holds the resolved
@@ -112,6 +119,7 @@ impl Renderer {
             height,
             scratches: Scratches::new(),
             labels_visible: true,
+            hidden_layers: HashSet::new(),
         }
     }
 
@@ -135,6 +143,21 @@ impl Renderer {
     /// to suppress city-name hints.
     pub fn set_labels_visible(&mut self, visible: bool) {
         self.labels_visible = visible;
+    }
+
+    /// Show / hide every feature whose MVT `source_layer` matches
+    /// `layer`. Checked at the outermost per-tile loop so the
+    /// inner feature loop never runs for hidden layers. Drives
+    /// the `ttymap.map:set_layer_visible(name, b)` Lua API — used
+    /// to express view modes like roads-only or no-buildings.
+    /// Orthogonal to `set_labels_visible`: a layer can be hidden
+    /// independently of whether label rendering is on.
+    pub fn set_layer_visible(&mut self, layer: &str, visible: bool) {
+        if visible {
+            self.hidden_layers.remove(layer);
+        } else {
+            self.hidden_layers.insert(layer.to_string());
+        }
     }
 
     pub fn width(&self) -> usize {
@@ -185,6 +208,9 @@ impl Renderer {
         'outer: for td in tile_data {
             let tile_size = td.vis.size;
             for layer in &td.layers {
+                if self.hidden_layers.contains(&layer.name) {
+                    continue;
+                }
                 let extent = layer.extent as f64;
                 for feature in &layer.features {
                     if std::time::Instant::now() > deadline {
@@ -685,6 +711,129 @@ mod tests {
 
         assert_eq!(baseline, cells(2048));
         assert_eq!(baseline, cells(8192));
+    }
+
+    /// `set_layer_visible(name, false)` must drop every feature whose
+    /// MVT `source_layer` matches `name` from the rendered frame.
+    /// Re-enabling restores the original painted-cell count exactly —
+    /// the toggle owns nothing besides the hidden set, no side effects
+    /// on the styler or canvas. Mirrors `set_labels_visible` but at
+    /// per-layer granularity.
+    #[test]
+    fn hidden_layer_disappears_from_rendered_frame() {
+        use std::collections::HashMap;
+
+        use crate::geo::LonLat;
+        use crate::map::render::view::VisibleTile;
+        use crate::map::tile::decode::{Feature, TilePoint};
+
+        // A single CW square covering the whole tile, decoded as the
+        // `water` source layer. Renders as a saturated fill at
+        // zoom=14 with the `Dark` palette's water colour.
+        let cw_square = |x0: i32, y0: i32, x1: i32, y1: i32| {
+            vec![
+                TilePoint { x: x0, y: y0 },
+                TilePoint { x: x1, y: y0 },
+                TilePoint { x: x1, y: y1 },
+                TilePoint { x: x0, y: y1 },
+            ]
+        };
+        let feature = Feature {
+            layer_name: Arc::from("water"),
+            properties: Arc::new(HashMap::new()),
+            points: Arc::new(vec![cw_square(0, 0, 4096, 4096)]),
+            min_x: 0.0,
+            max_x: 0.0,
+            min_y: 0.0,
+            max_y: 0.0,
+        };
+        let tile = TileData {
+            vis: VisibleTile {
+                x: 0,
+                y: 0,
+                z: 14,
+                pos_x: 0.0,
+                pos_y: 0.0,
+                size: 256.0,
+            },
+            layers: vec![LayerData {
+                name: "water".to_string(),
+                extent: 4096,
+                features: vec![feature],
+            }],
+        };
+        let center = LonLat { lon: 0.0, lat: 0.0 };
+
+        let styler = Arc::new(Styler::new(crate::theme::ThemeId::Dark));
+        let mut renderer = Renderer::new(styler, "en".to_string(), 320, 320);
+
+        const EMPTY: char = '⠀';
+        let painted = |r: &mut Renderer| -> usize {
+            let frame = r
+                .draw(std::slice::from_ref(&tile), 14.0, center, &[])
+                .expect("frame");
+            frame.cells.iter().filter(|c| c.ch != EMPTY).count()
+        };
+
+        // Sanity: with no hidden layers the water fill paints cells.
+        let baseline = painted(&mut renderer);
+        assert!(
+            baseline > 0,
+            "baseline must paint cells — otherwise the test geometry \
+             never reached the canvas and the hidden-case is vacuous"
+        );
+
+        // Hide water → zero painted cells.
+        renderer.set_layer_visible("water", false);
+        assert_eq!(
+            painted(&mut renderer),
+            0,
+            "hidden source layer must drop every feature it owns"
+        );
+
+        // Re-show → painted count returns to baseline exactly.
+        renderer.set_layer_visible("water", true);
+        assert_eq!(
+            painted(&mut renderer),
+            baseline,
+            "re-shown layer must restore the original painted-cell count"
+        );
+    }
+
+    /// `set_layer_visible(name, false)` on a layer that the rendered
+    /// tile doesn't contain must be a silent no-op — the rest of the
+    /// frame is unchanged. Forward-compatibility guarantee: future
+    /// schema additions won't break plugins that hide layers
+    /// optimistically (e.g. "hide every label layer regardless of
+    /// whether this schema has it").
+    #[test]
+    fn hiding_unknown_layer_is_a_silent_no_op() {
+        let styler = Arc::new(Styler::new(crate::theme::ThemeId::Dark));
+        let mut renderer = Renderer::new(styler, "en".to_string(), 80, 40);
+        let center = crate::geo::LonLat { lon: 0.0, lat: 0.0 };
+
+        let before = renderer
+            .draw(&[], 4.0, center, &[])
+            .expect("frame")
+            .cells
+            .iter()
+            .map(|c| c.ch)
+            .collect::<Vec<_>>();
+
+        renderer.set_layer_visible("totally_made_up_layer", false);
+
+        let after = renderer
+            .draw(&[], 4.0, center, &[])
+            .expect("frame")
+            .cells
+            .iter()
+            .map(|c| c.ch)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            before, after,
+            "hiding a non-existent layer must not change the rendered frame"
+        );
     }
 
     /// User overlay polylines must paint on the *same* BrailleBuffer as

--- a/ttymap-engine/src/map/render/thread.rs
+++ b/ttymap-engine/src/map/render/thread.rs
@@ -42,6 +42,15 @@ pub enum RenderTask {
     /// `SetLabelsVisible` issued *between* two Draws will only
     /// affect the second.
     SetLabelsVisible(bool),
+    /// Show / hide one MVT source layer. Same ordering rules as
+    /// `SetLabelsVisible`: a `SetLayerVisible` issued between two
+    /// Draws only affects the second. Per-call (not per-set) so
+    /// multiple layer toggles compose naturally through the
+    /// drain pass.
+    SetLayerVisible {
+        layer: String,
+        visible: bool,
+    },
     Shutdown,
 }
 
@@ -86,6 +95,19 @@ impl RenderClient {
     /// command alone only flips the flag.
     pub fn set_labels_visible(&self, visible: bool) {
         self.send(RenderTask::SetLabelsVisible(visible), "set_labels_visible");
+    }
+
+    /// Show / hide one MVT source layer on the render thread.
+    /// Caller must follow up with a `request_draw` to see the
+    /// change — this command alone only updates the hidden set.
+    pub fn set_layer_visible(&self, layer: &str, visible: bool) {
+        self.send(
+            RenderTask::SetLayerVisible {
+                layer: layer.to_string(),
+                visible,
+            },
+            "set_layer_visible",
+        );
     }
 }
 
@@ -198,6 +220,10 @@ fn apply_task(task: RenderTask, pipeline: &mut RenderPipeline) -> TaskOutcome {
         }
         RenderTask::SetLabelsVisible(visible) => {
             pipeline.set_labels_visible(visible);
+            TaskOutcome::Continue
+        }
+        RenderTask::SetLayerVisible { layer, visible } => {
+            pipeline.set_layer_visible(&layer, visible);
             TaskOutcome::Continue
         }
         RenderTask::Shutdown => TaskOutcome::Shutdown,

--- a/ttymap-lua/src/api/map.rs
+++ b/ttymap-lua/src/api/map.rs
@@ -131,6 +131,25 @@ impl UserData for HostMap {
                 .push(Op::Command(UserCommand::SetLabelsVisible(visible)));
             Ok(())
         });
+
+        // `ttymap.map:set_layer_visible(name, b)` — show / hide
+        // every feature whose MVT `source_layer` matches `name`
+        // (e.g. "water", "road", "building"). Skipped at the
+        // outermost per-tile loop on the render thread, so hidden
+        // layers cost nothing per feature. Orthogonal to
+        // `set_labels_visible`. The dispatcher pairs the command
+        // with `request_map_redraw`; unknown layer names are
+        // accepted silently for forward compatibility with
+        // schemas added later.
+        methods.add_method(
+            "set_layer_visible",
+            |_, this, (layer, visible): (String, bool)| {
+                this.ops
+                    .borrow_mut()
+                    .push(Op::Command(UserCommand::SetLayerVisible { layer, visible }));
+                Ok(())
+            },
+        );
     }
 }
 

--- a/ttymap-shared/src/command.rs
+++ b/ttymap-shared/src/command.rs
@@ -87,6 +87,14 @@ pub enum UserCommand {
     /// Plugin-driven — `ttymap.map:set_labels_visible(b)` is the
     /// canonical caller (e.g. geo_quiz hard mode hides hints).
     SetLabelsVisible(bool),
+    /// Show / hide every feature whose MVT `source_layer` matches
+    /// `layer` on the render thread. Geometry skipped at the
+    /// outermost per-tile loop, so hidden layers cost nothing per
+    /// feature. Plugin-driven — `ttymap.map:set_layer_visible(name, b)`
+    /// is the canonical caller (e.g. a roads-only or no-buildings
+    /// view mode). Unknown layer names are accepted silently so the
+    /// API stays forward-compatible with schemas added later.
+    SetLayerVisible { layer: String, visible: bool },
 }
 
 impl UserCommand {


### PR DESCRIPTION
Closes #376.

Adds `ttymap.map:set_layer_visible(layer, visible)` — extends the precedent set by `set_labels_visible` to per-layer granularity, so plugins can hide every feature whose MVT `source_layer` matches a given name. Enables view modes like roads-only or no-buildings without touching the styler or schema.

## API

```lua
ttymap.map:set_layer_visible("water", false)
ttymap.map:set_layer_visible("road",  true)
```

Layer identity = the MVT `source_layer` name keyed by the styler's `rules_by_layer` (e.g. `water`, `waterway`, `road`, `building`, `place_label`…). Unknown names are accepted silently for forward compatibility with schemas added later.

## Plumbing

Mirrors the four-touchpoint shape of `set_labels_visible` exactly, extended through every layer that handles its sibling:

| Layer | Change |
|---|---|
| `ttymap-shared/src/command.rs` | `UserCommand::SetLayerVisible { layer, visible }` |
| `ttymap-engine/src/map/render/renderer.rs` | `hidden_layers: HashSet<String>` field + `set_layer_visible` setter. Checked at the outermost per-tile loop so the inner feature loop never runs for hidden layers — no per-feature cost. |
| `ttymap-engine/src/map/render/pipeline.rs` | passthrough |
| `ttymap-engine/src/map/render/thread.rs` | `RenderTask::SetLayerVisible` variant + `RenderClient::set_layer_visible` + `apply_task` arm |
| `ttymap-engine/src/map/mod.rs` | `MapHandle::set_layer_visible` delegate |
| `ttymap-engine/src/ipc.rs` | `EngineCommand::SetLayerVisible` variant + dispatch arm + round-trip test |
| `ttymap-app/src/engine_handle.rs` | IPC client method |
| `ttymap-app/src/app/mod.rs` | `UserCommand` dispatch arm paired with `request_map_redraw` |
| `ttymap-lua/src/api/map.rs` | `HostMap::set_layer_visible` enqueuing the op buffer entry |

Orthogonality with `set_labels_visible`: the existing all-or-nothing labels flag gates `StyleType::Symbol` regardless of source layer; the per-layer toggle gates by source-layer name regardless of style type. Both compose on the render thread.

## Scope notes

- **Setter only.** No `is_layer_visible` / `hidden_layers` getters in this PR — plugins that need state can shadow the set Lua-side. Deferred for a follow-up if maintainers prefer to design the reader shape separately (would need shared `Arc<Mutex<HashSet<String>>>` between Lua and render thread, mirroring how `center` / `zoom` already work).
- **Source-layer granularity only.** Class-level filtering (`set_class_visible("motorway")` etc.) is explicitly out of scope; deserves its own design once this surface settles. See the open question in #376.
- **Session-local.** Toggles don't survive restart. Users wanting a "roads only" startup default call `set_layer_visible` from their own `init.lua`.

## Tests

- `command_set_layer_visible_round_trips` — IPC wire format round-trip, mirroring the existing `command_set_labels_visible_round_trips`.
- `hidden_layer_disappears_from_rendered_frame` — render-loop integration: baseline > 0 painted cells with a `water` fill tile; after `set_layer_visible("water", false)`, zero painted cells; after re-enable, exact baseline restored.
- `hiding_unknown_layer_is_a_silent_no_op` — forward-compat guarantee.

## Local verification

- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo build --workspace --all-targets` ✓
- `cargo test --workspace` ✓ (all existing tests + the 3 new ones pass)
- End-to-end smoke: `cargo install --path ttymap-app --force` then launched against a bare runtime layer with a small plugin that calls `set_layer_visible` from a keybind; hides and re-shows survive frame ticks, redraws fire on each toggle (the `request_map_redraw` pairing).


## Plugin example

Built a modal layers panel against this API for a local bare runtime — validates the surface composes well in practice.

**Group toggle** — flip multiple source layers atomically as one user-facing concept (e.g. "water" = `water` + `waterway`):

```lua
for _, l in ipairs({ "water", "waterway" }) do
    ttymap.map:set_layer_visible(l, visible)
end
```

**Orthogonal composition with `set_labels_visible`** — both flags live on the render thread, both apply independently. Hiding the `water` layer leaves roads / buildings / labels untouched; hiding labels via the master flip leaves geometry untouched. Plugins can do either or both.

**Modal binding via `KeybindHandle:remove`** — per-layer toggle keys bind on panel-open, drop on panel-close, so native ttymap controls (`hjkl`, `q`, `\`, `0`, `a`/`z`, …) stay unshadowed when the panel isn't visible:

```lua
local active = {}

local function open_panel()
    for _, e in ipairs(GROUPS) do
        table.insert(active,
            ttymap.register_keybind(e.key, function() toggle_group(e) end))
    end
end

local function close_panel()
    for _, h in ipairs(active) do h:remove() end
    active = {}
end
```

**Forward-compat confirmed**: `set_layer_visible("country_label", false)` worked without the plugin needing to know the engine had that layer — exactly the silent-no-op behaviour the PR claims.

Covers all 17 styled source layers in `mapscii.rs::rules()` plus the master labels toggle, behind a single `:` palette entry that opens the panel. Happy to share the full source if useful for the bundled-plugins reference set.
