### PR TITLE
refactor(engine): unify antimeridian wrap math via shortest_modular_dx

### DIFF
--- a/ttymap-engine/src/geo.rs
+++ b/ttymap-engine/src/geo.rs
@@ -97,12 +97,7 @@ impl MapProjection {
         // antimeridian so a feature on the wrap side lands next to the
         // centre instead of way off-screen (issue #96). y is not.
         let grid = (1u64 << self.z) as f64;
-        let raw_dx = pt.x - self.center_tile.x;
-        let dx = if grid > 0.0 && raw_dx.abs() > grid / 2.0 {
-            raw_dx - raw_dx.signum() * grid
-        } else {
-            raw_dx
-        };
+        let dx = shortest_modular_dx(pt.x - self.center_tile.x, grid);
         let px = self.canvas_w / 2.0 + dx * self.tile_size;
         let py = self.canvas_h / 2.0 + (pt.y - self.center_tile.y) * self.tile_size;
         if !px.is_finite() || !py.is_finite() || px < 0.0 || py < 0.0 {
@@ -142,6 +137,18 @@ pub fn base_zoom(zoom: f64) -> u32 {
 /// story.
 pub fn tile_grid_size(z: u32) -> i32 {
     1i32.checked_shl(z).unwrap_or(i32::MAX)
+}
+
+/// Shortest signed delta on a wrapping axis (longitude / tile-x).
+/// When `|raw| > grid/2` the antimeridian is the shorter path, so
+/// wrap by one grid width; otherwise keep `raw`. A non-positive
+/// `grid` disables wrapping. See issue #96.
+pub fn shortest_modular_dx(raw: f64, grid: f64) -> f64 {
+    if grid > 0.0 && raw.abs() > grid / 2.0 {
+        raw - raw.signum() * grid
+    } else {
+        raw
+    }
 }
 
 /// Return the effective tile size (in screen pixels / units) at a fractional

--- a/ttymap-engine/src/map/render/overlay.rs
+++ b/ttymap-engine/src/map/render/overlay.rs
@@ -16,7 +16,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::geo::{LonLat, base_zoom, ll2tile, tile_size_at_zoom};
+use crate::geo::{LonLat, base_zoom, ll2tile, shortest_modular_dx, tile_size_at_zoom};
 
 /// One polyline submitted by a Lua plugin during a frame's `on_tick`
 /// pass. Re-pushed every frame ("ephemeral re-submit"); the App-side
@@ -56,12 +56,7 @@ pub fn ll_to_subpixel(
     // way off-screen. Mirrors the same fix in `MapProjection::ll_to_cell`
     // (issue #96).
     let grid = (1u64 << z) as f64;
-    let raw_dx = pt.x - center_t.x;
-    let dx = if grid > 0.0 && raw_dx.abs() > grid / 2.0 {
-        raw_dx - raw_dx.signum() * grid
-    } else {
-        raw_dx
-    };
+    let dx = shortest_modular_dx(pt.x - center_t.x, grid);
 
     let px = canvas_w as f64 / 2.0 + dx * tile_size;
     let py = canvas_h as f64 / 2.0 + (pt.y - center_t.y) * tile_size;
@@ -160,12 +155,7 @@ pub fn project_polyline_continuous(
     // First point: classic centre-aware shortest path.
     let first = coords[0];
     let pt0 = ll2tile(first.lon, first.lat, z);
-    let raw_dx0 = pt0.x - center_t.x;
-    let dx0 = if grid_tiles > 0.0 && raw_dx0.abs() > grid_tiles / 2.0 {
-        raw_dx0 - raw_dx0.signum() * grid_tiles
-    } else {
-        raw_dx0
-    };
+    let dx0 = shortest_modular_dx(pt0.x - center_t.x, grid_tiles);
     let mut prev_dx_pixels = dx0 * tile_size;
     let py0 = canvas_h_half + (pt0.y - center_t.y) * tile_size;
     out.push(((canvas_w_half + prev_dx_pixels) as i32, py0 as i32));

--- a/ttymap-engine/src/map/tile/cache.rs
+++ b/ttymap-engine/src/map/tile/cache.rs
@@ -186,12 +186,7 @@ impl TileCache {
 /// Y is **not** modular — slippy maps have no polar wrap.
 fn tile_distance_sq(key: &TileKey, center_x: f64, center_y: f64, grid_size: i32) -> f64 {
     let raw_dx = key.x as f64 + 0.5 - center_x;
-    let g = grid_size as f64;
-    let dx = if g > 0.0 && raw_dx.abs() > g / 2.0 {
-        raw_dx - raw_dx.signum() * g
-    } else {
-        raw_dx
-    };
+    let dx = crate::geo::shortest_modular_dx(raw_dx, grid_size as f64);
     let dy = key.y as f64 + 0.5 - center_y;
     dx * dx + dy * dy
 }


### PR DESCRIPTION
## What

The "wrap by one grid width when \`|raw_dx| > grid/2\`" pattern was duplicated across 4 sites:

- \`geo::MapProjection::ll_to_cell\`
- \`map::render::overlay\` (point projection + polyline first-point)
- \`map::tile::cache::tile_distance_sq\`

Issues #96 / #106 had to fix three of them separately; the fourth risked drift on the next antimeridian bug.

Extracted \`pub fn geo::shortest_modular_dx(raw, grid)\` and routed all four sites through it. Pure de-dup, no behavior change — existing antimeridian / distance_sq tests cover it.

Closes #308