### PR TITLE
ci: run tests with --all-targets for parity with build/clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: cargo build --workspace --all-targets
 
       - name: Test
-        run: cargo test --workspace
+        run: cargo test --workspace --all-targets
 
   # Supply-chain checks. Linux-only — output is platform-independent,
   # so the matrix in `check` doesn't apply here.


### PR DESCRIPTION
## What

The build and clippy steps use `--all-targets`, but the test step was `cargo test --workspace` only — so bench harnesses (criterion `harness = false` in the engine) and other non-default targets were never *compiled* in CI. Stale code there could land unnoticed (the memory note about the pre-commit hook only linting lib+bins is the same class of gap).

Switched the test step to `cargo test --workspace --all-targets`.

Verified locally: `cargo test --workspace --all-targets` passes clean with no warnings, and benches under `--all-targets` only build (they don't run), so the added CI cost is just compilation.

Note: `--all-targets` does **not** run doctests, but the workspace has zero executable doctests today (`cargo test --doc` → all 0, 1 ignored), so nothing is lost now. This PR's own CI run is the live check.

Closes #328