### PR TITLE
feat(app): restart-engine command — recycle the engine subprocess

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,6 +176,9 @@ Pathological MVT polygons can hang inside earcut. The render path
 guards against this with a 200 ms timeout that abandons the worker
 on miss (`ttymap-engine/src/map/render/earcut_worker.rs`). Abandoned
 threads cannot be cancelled in safe Rust, so each pathology leaks one
-zombie OS thread (#305). Accepted as a known issue against the
-multi-process engine work in #348 — Phase 3 makes the whole engine
-restartable, which cleans up accumulated zombies in one move.
+zombie OS thread (#305). The recovery is the `RestartEngine` command
+(`:` palette → "Restart engine", or the `restart_engine` keymap
+name): `EngineHandle::restart` recycles the engine subprocess, and
+killing the child frees every thread it leaked — reclaiming the
+accumulated zombies in one move. The App owns the camera `MapState`,
+so the view survives the restart.

--- a/ttymap-app/src/app/mod.rs
+++ b/ttymap-app/src/app/mod.rs
@@ -48,7 +48,7 @@ use ttymap_engine::map::render::frame::MapFrame;
 use ttymap_engine::map::state::MapState;
 use ttymap_lua::{LuaHandle, LuaSubsystem};
 use ttymap_shared::UserCommand;
-use ttymap_shared::event::{Event, EventBus};
+use ttymap_shared::event::{Event, EventBus, Level};
 use ttymap_tui::compositor::op::Op;
 use ttymap_tui::compositor::{BaseLayer, Compositor, Context};
 use ttymap_tui::input::{KeyMap, MouseAdapter};
@@ -408,6 +408,36 @@ impl App {
             UserCommand::SetLayerVisible { layer, visible } => {
                 self.map.set_layer_visible(&layer, visible);
                 self.request_map_redraw();
+            }
+            UserCommand::RestartEngine => self.restart_engine(),
+        }
+    }
+
+    /// Recycle the engine subprocess. The App keeps the camera
+    /// (`map_state`), so the view is preserved: after the child is
+    /// respawned at the current size/theme we resize the mirror to
+    /// match the fresh canvas and redraw, which ships the preserved
+    /// viewport. Label / layer-visibility toggles are engine-side
+    /// render settings the App doesn't mirror, so they reset to
+    /// default — acceptable for an explicit recovery action.
+    fn restart_engine(&mut self) {
+        let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+        let map_cols = self.sidebar.effective_map_cols(cols);
+        match self.map.restart(map_cols, rows, self.theme_id) {
+            Ok(()) => {
+                self.map_state.resize(map_cols, rows);
+                self.request_map_redraw();
+                self.pending_events.push(Event::Notify {
+                    message: "Engine restarted".into(),
+                    level: Level::Info,
+                });
+            }
+            Err(e) => {
+                log::error!("engine restart failed: {e}");
+                self.pending_events.push(Event::Notify {
+                    message: format!("Engine restart failed: {e}"),
+                    level: Level::Error,
+                });
             }
         }
     }

--- a/ttymap-app/src/engine_handle.rs
+++ b/ttymap-app/src/engine_handle.rs
@@ -7,12 +7,13 @@
 //! stdin/stdout, and exposes thin `send_*` methods that the App
 //! calls after mutating its own state.
 //!
-//! The UI-side mirror of [`MapState`] lives on `App` (see
-//! `ttymap-app/src/app/mod.rs`'s `map_state` field) — the App
-//! mutates it synchronously in `dispatch`, then forwards the same
-//! `MapAction` to the child here. Both sides run the identical
-//! transitions on the same inputs, so they stay coherent by
-//! construction without round-trip RPCs.
+//! The sole [`MapState`] (the camera) lives on `App` (see
+//! `ttymap-app/src/app/mod.rs`'s `map_state` field) — the App mutates
+//! it synchronously in `dispatch` and ships the resulting `Viewport`
+//! to the child inside `EngineCommand::Draw`. The engine holds no
+//! camera state of its own, so [`EngineHandle::restart`] can recycle
+//! the child without any state replay: the App's next redraw carries
+//! the preserved viewport.
 //!
 //! `snap` keeps using `ttymap_engine::map::build` in-process; only
 //! the long-lived TUI takes the subprocess path. See #348 for the
@@ -32,10 +33,10 @@ use ttymap_engine::theme::ThemeId;
 
 use crate::app::AppEvent;
 
-/// Errors surfaced from [`EngineHandle::spawn`]. Anything that
-/// happens after spawn (writer / reader thread failures, child
-/// exit) is logged and surfaces as a dead-engine state — Phase 3
-/// will add restart logic.
+/// Errors surfaced from [`EngineHandle::spawn`] / [`EngineHandle::restart`].
+/// Anything that happens after a successful connect (writer / reader
+/// thread failures, child exit) is logged and surfaces as a
+/// dead-engine state; [`EngineHandle::restart`] is the recovery path.
 #[derive(Debug)]
 pub enum EngineHandleError {
     /// Couldn't resolve the parent binary path to spawn the child.
@@ -64,15 +65,34 @@ impl std::fmt::Display for EngineHandleError {
 
 impl std::error::Error for EngineHandleError {}
 
+/// The live half of an [`EngineHandle`] — everything tied to one
+/// running child process. Produced by [`connect`] and swapped in
+/// wholesale on [`EngineHandle::restart`].
+struct Connection {
+    command_tx: mpsc::Sender<EngineCommand>,
+    attribution: Option<String>,
+    child: Child,
+    writer: JoinHandle<()>,
+    reader: JoinHandle<()>,
+}
+
 pub struct EngineHandle {
-    /// Command stream. Cleared in [`Drop`] to signal the writer
-    /// thread to exit (which closes child stdin → child exits).
+    /// Command stream. Cleared in [`Drop`] / [`Self::restart`] to
+    /// signal the writer thread to exit (which closes child stdin →
+    /// child exits).
     command_tx: Option<mpsc::Sender<EngineCommand>>,
     /// Tile-backend attribution string, captured from the Ready event.
     pub attribution: Option<String>,
     child: Option<Child>,
     writer: Option<JoinHandle<()>>,
     reader: Option<JoinHandle<()>>,
+    // ── Respawn inputs ──────────────────────────────────────────────
+    // Kept so `restart` can build a fresh child without the caller
+    // re-supplying what doesn't change across a restart. The view
+    // (cols / rows / theme) *does* change, so `restart` takes those.
+    config: EngineConfig,
+    cache_dir: Option<std::path::PathBuf>,
+    event_tx: mpsc::Sender<AppEvent>,
 }
 
 impl EngineHandle {
@@ -87,80 +107,95 @@ impl EngineHandle {
         theme: ThemeId,
         event_tx: mpsc::Sender<AppEvent>,
     ) -> Result<Self, EngineHandleError> {
-        let exe = std::env::current_exe().map_err(EngineHandleError::CurrentExe)?;
-        let mut child = Command::new(exe)
-            .arg("engine-worker")
-            // child stderr → parent stderr so engine-side panics or
-            // log messages are visible in the user's terminal session.
-            .stderr(Stdio::inherit())
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn()
-            .map_err(EngineHandleError::Spawn)?;
+        let conn = connect(
+            config,
+            cache_dir.clone(),
+            cols,
+            rows,
+            theme,
+            event_tx.clone(),
+        )?;
+        Ok(Self {
+            command_tx: Some(conn.command_tx),
+            attribution: conn.attribution,
+            child: Some(conn.child),
+            writer: Some(conn.writer),
+            reader: Some(conn.reader),
+            config: config.clone(),
+            cache_dir,
+            event_tx,
+        })
+    }
 
-        let mut child_stdin = BufWriter::new(
-            child
-                .stdin
-                .take()
-                .ok_or_else(|| EngineHandleError::Spawn(io::Error::other("missing stdin")))?,
-        );
-        let mut child_stdout = BufReader::new(
-            child
-                .stdout
-                .take()
-                .ok_or_else(|| EngineHandleError::Spawn(io::Error::other("missing stdout")))?,
-        );
+    /// Recycle the engine subprocess: tear down the current child and
+    /// its IPC threads, then spawn a fresh one at the supplied view
+    /// (`cols` / `rows` are the *map area* size, `theme` the active
+    /// theme). The App owns the camera `MapState`, so the caller
+    /// follows up with a redraw to repaint the preserved view. On
+    /// error the handle is left with no live child — `send` degrades
+    /// to a logged no-op until the next successful (re)connect.
+    pub fn restart(
+        &mut self,
+        cols: u16,
+        rows: u16,
+        theme: ThemeId,
+    ) -> Result<(), EngineHandleError> {
+        self.teardown();
+        let conn = connect(
+            &self.config,
+            self.cache_dir.clone(),
+            cols,
+            rows,
+            theme,
+            self.event_tx.clone(),
+        )?;
+        self.command_tx = Some(conn.command_tx);
+        self.attribution = conn.attribution;
+        self.child = Some(conn.child);
+        self.writer = Some(conn.writer);
+        self.reader = Some(conn.reader);
+        Ok(())
+    }
 
-        // Init handshake. Send Init synchronously, then drain events
-        // until Ready arrives. Anything before Ready is unexpected
-        // (the worker only emits Ready / Error / FrameReady — and
-        // FrameReady can't fire before render thread starts, which
-        // is after Ready).
-        write_message(
-            &mut child_stdin,
-            &EngineCommand::Init {
-                config: config.clone(),
-                cache_dir,
-                cols,
-                rows,
-                theme,
-            },
-        )
-        .and_then(|()| child_stdin.flush())
-        .map_err(EngineHandleError::Handshake)?;
-
-        let attribution = loop {
-            let ev: EngineEvent = read_message(&mut child_stdout).map_err(|e| match e.kind() {
-                io::ErrorKind::UnexpectedEof => EngineHandleError::UnexpectedEof,
-                _ => EngineHandleError::Handshake(e),
-            })?;
-            match ev {
-                EngineEvent::Ready { attribution } => break attribution,
-                EngineEvent::Error(msg) => return Err(EngineHandleError::Subprocess(msg)),
-                _ => {
-                    // Tolerate spurious events; loop back.
+    /// Cooperative teardown of the live connection: send Shutdown,
+    /// drop the command tx so the writer thread exits (closes child
+    /// stdin → child breaks its read loop → exits → stdout EOF →
+    /// reader returns), join both threads, reap the child with a
+    /// bounded wait. Idempotent — every field is an `Option` taken on
+    /// the way out, so a second call is a no-op. Shared by `Drop` and
+    /// `restart`.
+    fn teardown(&mut self) {
+        if let Some(tx) = self.command_tx.take() {
+            let _ = tx.send(EngineCommand::Shutdown);
+            drop(tx);
+        }
+        if let Some(w) = self.writer.take() {
+            let _ = w.join();
+        }
+        if let Some(r) = self.reader.take() {
+            let _ = r.join();
+        }
+        if let Some(mut child) = self.child.take() {
+            // Bounded wait — if the child hangs we shouldn't block
+            // forever. 1 s is generous: cooperative exit should take
+            // milliseconds. A runaway engine (the reason to restart)
+            // still exits here because the command loop is responsive;
+            // process exit then frees every thread it leaked.
+            let deadline = std::time::Instant::now() + Duration::from_secs(1);
+            loop {
+                match child.try_wait() {
+                    Ok(Some(_)) => break,
+                    Ok(None) if std::time::Instant::now() >= deadline => {
+                        log::warn!("engine-worker did not exit within 1s; killing");
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        break;
+                    }
+                    Ok(None) => thread::sleep(Duration::from_millis(20)),
+                    Err(_) => break,
                 }
             }
-        };
-
-        let (command_tx, command_rx) = mpsc::channel::<EngineCommand>();
-        let writer = thread::Builder::new()
-            .name("ttymap-engine-writer".into())
-            .spawn(move || writer_loop(child_stdin, command_rx))
-            .map_err(|e| EngineHandleError::Spawn(io::Error::other(e.to_string())))?;
-
-        let reader = thread::Builder::new()
-            .name("ttymap-engine-reader".into())
-            .spawn(move || reader_loop(child_stdout, event_tx))
-            .map_err(|e| EngineHandleError::Spawn(io::Error::other(e.to_string())))?;
-
-        Ok(Self {
-            command_tx: Some(command_tx),
-            attribution,
-            child: Some(child),
-            writer: Some(writer),
-            reader: Some(reader),
-        })
+        }
     }
 
     // ── Wire-format senders ─────────────────────────────────────────────
@@ -198,10 +233,10 @@ impl EngineHandle {
         if let Some(tx) = &self.command_tx
             && tx.send(cmd).is_err()
         {
-            // Writer thread is gone — engine has died. Phase 3 will
-            // notice this and respawn; today, just log and let the
-            // App keep running without redraws (frames stop arriving
-            // but the UI doesn't crash).
+            // Writer thread is gone — engine has died. We don't
+            // auto-respawn; just log and let the App keep running
+            // without redraws (frames stop arriving but the UI doesn't
+            // crash). The user can recover with `RestartEngine`.
             log::warn!("engine-worker writer is gone; command dropped");
         }
     }
@@ -209,40 +244,96 @@ impl EngineHandle {
 
 impl Drop for EngineHandle {
     fn drop(&mut self) {
-        // Cooperative teardown: send Shutdown, drop the command tx so
-        // the writer thread exits (which closes child stdin → child
-        // breaks its read loop → exits → stdout EOF → reader thread
-        // returns). Then join everything and reap the child.
-        if let Some(tx) = self.command_tx.take() {
-            let _ = tx.send(EngineCommand::Shutdown);
-            drop(tx);
-        }
-        if let Some(w) = self.writer.take() {
-            let _ = w.join();
-        }
-        if let Some(r) = self.reader.take() {
-            let _ = r.join();
-        }
-        if let Some(mut child) = self.child.take() {
-            // Bounded wait — if the child hangs we shouldn't block
-            // shutdown forever. 1 s is generous: cooperative exit
-            // should take milliseconds.
-            let deadline = std::time::Instant::now() + Duration::from_secs(1);
-            loop {
-                match child.try_wait() {
-                    Ok(Some(_)) => break,
-                    Ok(None) if std::time::Instant::now() >= deadline => {
-                        log::warn!("engine-worker did not exit within 1s; killing");
-                        let _ = child.kill();
-                        let _ = child.wait();
-                        break;
-                    }
-                    Ok(None) => thread::sleep(Duration::from_millis(20)),
-                    Err(_) => break,
-                }
+        self.teardown();
+    }
+}
+
+/// Spawn an engine-worker child, run the Init → Ready handshake
+/// synchronously (so the returned `attribution` is populated), and
+/// start the writer / reader IPC threads. Shared by
+/// [`EngineHandle::spawn`] and [`EngineHandle::restart`].
+fn connect(
+    config: &EngineConfig,
+    cache_dir: Option<std::path::PathBuf>,
+    cols: u16,
+    rows: u16,
+    theme: ThemeId,
+    event_tx: mpsc::Sender<AppEvent>,
+) -> Result<Connection, EngineHandleError> {
+    let exe = std::env::current_exe().map_err(EngineHandleError::CurrentExe)?;
+    let mut child = Command::new(exe)
+        .arg("engine-worker")
+        // child stderr → parent stderr so engine-side panics or
+        // log messages are visible in the user's terminal session.
+        .stderr(Stdio::inherit())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(EngineHandleError::Spawn)?;
+
+    let mut child_stdin = BufWriter::new(
+        child
+            .stdin
+            .take()
+            .ok_or_else(|| EngineHandleError::Spawn(io::Error::other("missing stdin")))?,
+    );
+    let mut child_stdout = BufReader::new(
+        child
+            .stdout
+            .take()
+            .ok_or_else(|| EngineHandleError::Spawn(io::Error::other("missing stdout")))?,
+    );
+
+    // Init handshake. Send Init synchronously, then drain events
+    // until Ready arrives. Anything before Ready is unexpected
+    // (the worker only emits Ready / Error / FrameReady — and
+    // FrameReady can't fire before render thread starts, which
+    // is after Ready).
+    write_message(
+        &mut child_stdin,
+        &EngineCommand::Init {
+            config: config.clone(),
+            cache_dir,
+            cols,
+            rows,
+            theme,
+        },
+    )
+    .and_then(|()| child_stdin.flush())
+    .map_err(EngineHandleError::Handshake)?;
+
+    let attribution = loop {
+        let ev: EngineEvent = read_message(&mut child_stdout).map_err(|e| match e.kind() {
+            io::ErrorKind::UnexpectedEof => EngineHandleError::UnexpectedEof,
+            _ => EngineHandleError::Handshake(e),
+        })?;
+        match ev {
+            EngineEvent::Ready { attribution } => break attribution,
+            EngineEvent::Error(msg) => return Err(EngineHandleError::Subprocess(msg)),
+            _ => {
+                // Tolerate spurious events; loop back.
             }
         }
-    }
+    };
+
+    let (command_tx, command_rx) = mpsc::channel::<EngineCommand>();
+    let writer = thread::Builder::new()
+        .name("ttymap-engine-writer".into())
+        .spawn(move || writer_loop(child_stdin, command_rx))
+        .map_err(|e| EngineHandleError::Spawn(io::Error::other(e.to_string())))?;
+
+    let reader = thread::Builder::new()
+        .name("ttymap-engine-reader".into())
+        .spawn(move || reader_loop(child_stdout, event_tx))
+        .map_err(|e| EngineHandleError::Spawn(io::Error::other(e.to_string())))?;
+
+    Ok(Connection {
+        command_tx,
+        attribution,
+        child,
+        writer,
+        reader,
+    })
 }
 
 fn writer_loop(mut stdin: BufWriter<impl Write>, rx: mpsc::Receiver<EngineCommand>) {

--- a/ttymap-shared/src/command.rs
+++ b/ttymap-shared/src/command.rs
@@ -95,6 +95,13 @@ pub enum UserCommand {
     /// view mode). Unknown layer names are accepted silently so the
     /// API stays forward-compatible with schemas added later.
     SetLayerVisible { layer: String, visible: bool },
+    /// Tear down and respawn the engine-worker subprocess. An
+    /// app-lifetime concern (peer to [`Self::Quit`]), not a map-data
+    /// one: the App's `MapState` survives, so the view is preserved;
+    /// only the child process is recycled. Reclaims any CPU/memory a
+    /// runaway engine has leaked (e.g. abandoned earcut workers,
+    /// #305) since killing the process frees all its threads.
+    RestartEngine,
 }
 
 impl UserCommand {
@@ -106,6 +113,7 @@ impl UserCommand {
         match name {
             "quit" => Some(UserCommand::Quit),
             "toggle_sidebar" => Some(UserCommand::ToggleSidebar),
+            "restart_engine" => Some(UserCommand::RestartEngine),
             _ => MapAction::from_config_name(name).map(UserCommand::Map),
         }
     }
@@ -120,6 +128,7 @@ impl UserCommand {
             .collect();
         out.push((UserCommand::Quit, "Quit"));
         out.push((UserCommand::ToggleSidebar, "Toggle sidebar"));
+        out.push((UserCommand::RestartEngine, "Restart engine"));
         out
     }
 }

--- a/ttymap-tui/src/palette/provider/command.rs
+++ b/ttymap-tui/src/palette/provider/command.rs
@@ -65,6 +65,10 @@ enum Kind {
     PluginEntry(u64),
     /// "Theme" entry — swaps provider to [`ThemeProvider`].
     OpenThemeProvider(ThemeId),
+    /// "Restart engine" entry — runs [`UserCommand::RestartEngine`],
+    /// recycling the engine subprocess (reclaims a runaway engine's
+    /// leaked CPU/memory; the view is preserved).
+    RestartEngine,
 }
 
 #[derive(Clone)]
@@ -112,6 +116,12 @@ impl CommandProvider {
             label: "Theme".to_string(),
             hint: current_theme.name().to_string(),
             kind: Kind::OpenThemeProvider(current_theme),
+        });
+
+        all.push(Entry {
+            label: "Restart engine".to_string(),
+            hint: String::new(),
+            kind: Kind::RestartEngine,
         });
 
         let mut provider = Self {
@@ -187,6 +197,7 @@ impl PaletteProvider for CommandProvider {
             Kind::OpenThemeProvider(current) => {
                 PaletteAction::SwitchProvider(Box::new(ThemeProvider::new(*current)))
             }
+            Kind::RestartEngine => PaletteAction::Run(vec![UserCommand::RestartEngine]),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a user-triggered command to recycle the engine-worker subprocess: kill the current child and spawn a fresh one. The motivating case is reclaiming resources a runaway engine has leaked — most concretely the abandoned earcut worker threads of #305, which keep burning CPU forever; killing the child process frees every thread it leaked.

Because the App now owns the sole camera `MapState` (the recent engine-stateless-viewport refactor), restart needs **no state replay**: only the child process is recycled, so the view is preserved, and the App's next redraw ships the current viewport to the fresh child.

## Changes

- `UserCommand::RestartEngine` — surfaced as a built-in command-palette entry (`:` → **"Restart engine"**) and bindable via the `restart_engine` keymap name.
- `EngineHandle`: `spawn` factored into a shared `connect()` helper + stored respawn inputs (`config` / `cache_dir` / `event_tx`); `Drop`'s cooperative teardown factored into `teardown()`. `restart()` = `teardown()` + `connect()`, swapping the live child/threads in place.
- App `dispatch` arm → `restart_engine()`: respawn at the current size/theme, redraw the preserved view, post a "Engine restarted" notify (error notify + log on failure).
- Docs: rewrote the #305 known-issue note to point at `RestartEngine` as the recovery; refreshed stale `engine_handle.rs` module docs left over from the stateless-viewport refactor.

**Preserved across restart:** viewport (App owns it), theme, terminal size.
**Reset to default:** label / layer-visibility toggles — engine-side render settings the App doesn't mirror. Acceptable for an explicit recovery action; can be plumbed later if wanted.

## Verification

- `cargo build / test / clippy / fmt --all-targets` green (pre-commit hook enforced).
- **Live-exercised in the real TUI:** triggered "Restart engine" repeatedly while monitoring processes. Each restart flipped the engine-worker PID (`520645 -> 522317 -> 523485`), kept the worker count at exactly **1** (old child reaped — no zombie/leak accumulation), and left the parent TUI PID unchanged (view preserved). No orphaned engine-worker after quit.
- No automated test for `restart()` itself: `EngineHandle` spawns via `std::env::current_exe()`, which under an integration test resolves to the test harness rather than the `ttymap` binary (same constraint that makes `ipc_handshake.rs` drive the raw protocol against `CARGO_BIN_EXE_ttymap`). `restart()` is the composition of the already-exercised `connect()` (spawn) and `teardown()` (Drop) paths.

## Relationship to #305

**Mitigates, does not fix #305.** This is an on-demand reclaim: the underlying earcut hang (an uncancellable infinite loop on pathological polygons) is unchanged, so a long session can still accumulate zombie threads — the user just now has a way to reclaim them without losing their session. A real fix (subprocess-per-triangulation, a cancellable triangulator, or pre-validation) is still open. #305 should stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)