### PR TITLE
feat(app): surface unexpected engine death as a notify

### DIFF
--- a/ttymap-app/src/app/mod.rs
+++ b/ttymap-app/src/app/mod.rs
@@ -258,6 +258,14 @@ impl App {
             // publish lands in the same accumulator dispatch-produced
             // events do — preserving the single-publish-site invariant.
             AppEvent::Bus(bus_event) => self.forward_external_event(bus_event),
+            // The engine subprocess died unexpectedly (panic / OOM /
+            // broken pipe). Frames have stopped; surface it so the user
+            // isn't staring at a silently frozen map. Recovery is the
+            // `RestartEngine` command.
+            AppEvent::EngineDied => self.pending_events.push(Event::Notify {
+                message: "Engine died — run \"Restart engine\" to recover".into(),
+                level: Level::Error,
+            }),
         }
     }
 

--- a/ttymap-app/src/engine_handle.rs
+++ b/ttymap-app/src/engine_handle.rs
@@ -21,7 +21,8 @@
 
 use std::io::{self, BufReader, BufWriter, Read, Write};
 use std::process::{Child, Command, Stdio};
-use std::sync::mpsc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -74,6 +75,11 @@ struct Connection {
     child: Child,
     writer: JoinHandle<()>,
     reader: JoinHandle<()>,
+    /// Set by [`EngineHandle::teardown`] to tell the reader thread its
+    /// stream end is an intentional shutdown, not a crash. The reader
+    /// holds a clone; on stream end it emits [`AppEvent::EngineDied`]
+    /// only when this is still `false`.
+    shutting_down: Arc<AtomicBool>,
 }
 
 pub struct EngineHandle {
@@ -86,6 +92,10 @@ pub struct EngineHandle {
     child: Option<Child>,
     writer: Option<JoinHandle<()>>,
     reader: Option<JoinHandle<()>>,
+    /// Current connection's shutdown flag (see [`Connection`]). `teardown`
+    /// sets it before tearing the child down so the reader stays silent
+    /// on an intentional exit.
+    shutting_down: Option<Arc<AtomicBool>>,
     // ── Respawn inputs ──────────────────────────────────────────────
     // Kept so `restart` can build a fresh child without the caller
     // re-supplying what doesn't change across a restart. The view
@@ -121,6 +131,7 @@ impl EngineHandle {
             child: Some(conn.child),
             writer: Some(conn.writer),
             reader: Some(conn.reader),
+            shutting_down: Some(conn.shutting_down),
             config: config.clone(),
             cache_dir,
             event_tx,
@@ -154,6 +165,7 @@ impl EngineHandle {
         self.child = Some(conn.child);
         self.writer = Some(conn.writer);
         self.reader = Some(conn.reader);
+        self.shutting_down = Some(conn.shutting_down);
         Ok(())
     }
 
@@ -165,6 +177,12 @@ impl EngineHandle {
     /// the way out, so a second call is a no-op. Shared by `Drop` and
     /// `restart`.
     fn teardown(&mut self) {
+        // Mark this an intentional exit *before* the child can close
+        // its stream, so the reader thread stays silent instead of
+        // reporting `EngineDied`.
+        if let Some(flag) = self.shutting_down.take() {
+            flag.store(true, Ordering::Relaxed);
+        }
         if let Some(tx) = self.command_tx.take() {
             let _ = tx.send(EngineCommand::Shutdown);
             drop(tx);
@@ -322,9 +340,11 @@ fn connect(
         .spawn(move || writer_loop(child_stdin, command_rx))
         .map_err(|e| EngineHandleError::Spawn(io::Error::other(e.to_string())))?;
 
+    let shutting_down = Arc::new(AtomicBool::new(false));
+    let reader_flag = shutting_down.clone();
     let reader = thread::Builder::new()
         .name("ttymap-engine-reader".into())
-        .spawn(move || reader_loop(child_stdout, event_tx))
+        .spawn(move || reader_loop(child_stdout, event_tx, reader_flag))
         .map_err(|e| EngineHandleError::Spawn(io::Error::other(e.to_string())))?;
 
     Ok(Connection {
@@ -333,6 +353,7 @@ fn connect(
         child,
         writer,
         reader,
+        shutting_down,
     })
 }
 
@@ -348,7 +369,11 @@ fn writer_loop(mut stdin: BufWriter<impl Write>, rx: mpsc::Receiver<EngineComman
     let _ = stdin.flush();
 }
 
-fn reader_loop(mut stdout: BufReader<impl Read>, event_tx: mpsc::Sender<AppEvent>) {
+fn reader_loop(
+    mut stdout: BufReader<impl Read>,
+    event_tx: mpsc::Sender<AppEvent>,
+    shutting_down: Arc<AtomicBool>,
+) {
     while let Ok(ev) = read_message::<EngineEvent, _>(&mut stdout) {
         match ev {
             EngineEvent::FrameReady(frame) => {
@@ -363,5 +388,12 @@ fn reader_loop(mut stdout: BufReader<impl Read>, event_tx: mpsc::Sender<AppEvent
                 log::error!("engine-worker error: {msg}");
             }
         }
+    }
+    // Stream ended: child stdout closed (child exited) or a read
+    // error. If we didn't initiate the teardown, the child died
+    // unexpectedly — surface it once so the App can notify the user.
+    if !shutting_down.load(Ordering::Relaxed) {
+        log::error!("engine-worker stream ended unexpectedly; engine died");
+        let _ = event_tx.send(AppEvent::EngineDied);
     }
 }

--- a/ttymap-tui/src/app_event.rs
+++ b/ttymap-tui/src/app_event.rs
@@ -73,6 +73,12 @@ pub enum AppEvent {
     /// instead of going through this variant — the queue round-trip
     /// would just add a one-iteration latency for no benefit.
     Bus(BusEvent),
+    /// The engine-worker subprocess exited unexpectedly (panic, OOM,
+    /// broken pipe) — *not* an intentional teardown. Emitted once by
+    /// the engine-reader thread when its stream ends without the
+    /// shutdown flag set. The main loop surfaces it to the user;
+    /// recovery is the `RestartEngine` command.
+    EngineDied,
 }
 
 impl From<UserCommand> for AppEvent {


### PR DESCRIPTION
## Summary

When the engine-worker child closed its stream, the engine-reader thread exited silently — the UI kept running but frames stopped, leaving the map **silently frozen** with only a log line. Now an unexpected engine death is surfaced to the user.

## Changes

- `AppEvent::EngineDied` — emitted once by the engine-reader thread when its stream ends.
- A per-connection `Arc<AtomicBool> shutting_down` flag distinguishes an **intentional** teardown (set by `EngineHandle::teardown` before the child can close its stream) from a **crash**. The reader only emits `EngineDied` when the flag is unset, so normal Drop / `RestartEngine` stay silent.
- App handles `EngineDied` with an error `Notify`: *"Engine died — run \"Restart engine\" to recover"*.

No auto-restart — runaway detection / crash recovery are separate follow-ups (#384 and parked auto-restart work).

## Verification

- `cargo build / test / clippy / fmt --all-targets` green (pre-commit hook enforced).
- No automated test: `EngineHandle` spawns via `std::env::current_exe()`, which under an integration test is the test harness, not the `ttymap` binary (same constraint as `ipc_handshake.rs`). The flag logic is the composition of the already-exercised teardown (Drop) and reader paths.
- Manual: run ttymap, `kill <engine-worker pid>`, observe the "Engine died" notify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)