### PR TITLE
chore: add GitHub issue templates (feature / bug / refactor)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report incorrect, broken, or unexpected behavior
+title: 'fix: '
+labels: bug
+---
+
+## Summary
+
+<!-- What's broken, in a sentence or two. -->
+
+## Steps to reproduce
+
+1.
+2.
+
+## Expected
+
+<!-- What should happen. -->
+
+## Actual
+
+<!-- What actually happens. Paste relevant log output
+(`ttymap --log debug`, at `$XDG_STATE_HOME/ttymap/ttymap.log`) if any. -->
+
+## Environment
+
+- ttymap version / commit:
+- OS + terminal:
+
+## Relationship to other issues
+
+<!-- Link `#NN` if related. Omit if none. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# Keep free-form issues available alongside the templates — not every
+# report fits a template, and several existing issues predate them.
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Propose a new feature or behavior
+title: 'feat: '
+labels: feat
+---
+
+## Summary
+
+<!-- What's the feature and why, in a sentence or two. Name any
+related files / modules / issues (e.g. `#NN`). -->
+
+## Proposal
+
+<!-- Concrete description of the change. For user-facing features,
+describe the surface: command, keybind, palette entry, config key. -->
+
+## Acceptance
+
+<!-- Verifiable criteria — "the user can do X and observes Y". -->
+
+- [ ]
+
+## Out of scope
+
+<!-- What this explicitly does NOT cover. -->
+
+## Relationship to other issues
+
+<!-- Link `#NN`: depends on / pairs with / supersedes / touches. Omit
+if none. -->

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,31 @@
+---
+name: Refactor / chore
+about: Internal change with no user-facing behavior change (refactor, hygiene, deps, CI)
+title: 'refactor: '
+labels: refactor
+---
+
+## Summary
+
+<!-- The structural change, in a sentence or two. -->
+
+## Motivation
+
+<!-- Why now: what's awkward today, or what feature this unblocks. -->
+
+## Proposed change
+
+<!-- What moves / gets extracted / gets renamed. Name the files. -->
+
+## Acceptance
+
+- [ ] No user-facing behavior change (existing tests still green)
+- [ ]
+
+## Out of scope
+
+<!-- What this explicitly does NOT touch. -->
+
+## Relationship to other issues
+
+<!-- Link `#NN`: unblocks / pairs with / follows. Omit if none. -->


### PR DESCRIPTION
## Summary

The repo had no `.github/ISSUE_TEMPLATE/`. Adds three templates plus a config, matching the repo's existing conventions.

## Changes

- `feature_request.md` (`feat:` title, `feat` label), `bug_report.md` (`fix:` title, `bug` label), `refactor.md` (`refactor:` title, `refactor` label).
- Body shape follows the Summary-led 5-section spine used by recent issues (#305, #384): Summary / Proposal (or Motivation+Change) / Acceptance / Out of scope / Relationship to other issues.
- `config.yml` keeps `blank_issues_enabled: true` so free-form reports still work (several existing issues predate templates).

The filenames also match what the `nemawashi-issue` workflow looks for, so future issue-filing stays consistent.

## Verification

- Frontmatter (name / about / title / labels) is well-formed; labels (`feat` / `bug` / `refactor`) all exist in the repo.
- No code change; CI / hook pass trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)