### PR TITLE
feat(notify): surface runtime engine errors as an error notify (#253)

### DIFF
--- a/ttymap-app/src/app/mod.rs
+++ b/ttymap-app/src/app/mod.rs
@@ -266,6 +266,10 @@ impl App {
                 message: "Engine died — run \"Restart engine\" to recover".into(),
                 level: Level::Error,
             }),
+            // The engine reported a runtime error but is still alive.
+            // Surface it so the user gets feedback instead of a silent
+            // log line (#253).
+            AppEvent::EngineError(msg) => self.pending_events.push(engine_error_notify(msg)),
         }
     }
 
@@ -492,5 +496,27 @@ impl App {
         };
         terminal.draw(|f| ui::draw(f, inputs))?;
         Ok(())
+    }
+}
+
+/// Build the error notify surfaced when the engine reports a runtime
+/// error (`EngineEvent::Error`) while the loop is running (#253). Pure
+/// so it is unit-testable without standing up an `App`.
+fn engine_error_notify(msg: String) -> Event {
+    Event::Notify {
+        message: format!("Engine error: {msg}"),
+        level: Level::Error,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_error_notify_formats_with_error_level() {
+        let Event::Notify { message, level } = engine_error_notify("tile fetch failed".into());
+        assert_eq!(message, "Engine error: tile fetch failed");
+        assert_eq!(level, Level::Error);
     }
 }

--- a/ttymap-app/src/engine_handle.rs
+++ b/ttymap-app/src/engine_handle.rs
@@ -386,6 +386,9 @@ fn reader_loop(
             }
             EngineEvent::Error(msg) => {
                 log::error!("engine-worker error: {msg}");
+                if event_tx.send(AppEvent::EngineError(msg)).is_err() {
+                    return; // App is gone
+                }
             }
         }
     }

--- a/ttymap-tui/src/app_event.rs
+++ b/ttymap-tui/src/app_event.rs
@@ -79,6 +79,12 @@ pub enum AppEvent {
     /// shutdown flag set. The main loop surfaces it to the user;
     /// recovery is the `RestartEngine` command.
     EngineDied,
+    /// The engine-worker reported a runtime error (`EngineEvent::Error`)
+    /// while the loop is running — the child is still alive, but an op
+    /// failed. Emitted by the engine-reader thread; the main loop
+    /// surfaces it as an error notify so the user gets feedback without
+    /// tailing the log. The carried `String` is the engine-side message.
+    EngineError(String),
 }
 
 impl From<UserCommand> for AppEvent {


### PR DESCRIPTION
Closes #253.

## Problem

A runtime `EngineEvent::Error` (engine still alive, an op failed) was logged and dropped by the engine-reader thread — zero UI feedback unless the user tails the log.

## What changed

- **`AppEvent::EngineError(String)`** — new variant next to `EngineDied`.
- **engine-reader thread** (`engine_handle.rs`) — `EngineEvent::Error(msg)` now logs *and* forwards `AppEvent::EngineError(msg)` to the App (previously log-only).
- **App** (`app/mod.rs`) — handles it via `engine_error_notify(msg)`, pushing `Event::Notify { level: Error }`, mirroring the `EngineDied` handler. `notify.lua` renders the popup.

## Deviation from the issue

The issue predates the two-process split. Its proposed `notify::engine_error(handle, tag, &dyn Error)` helper is obsolete: runtime engine errors now arrive as a `String` over a single IPC funnel (the reader thread), not as an in-process `&dyn Error`. So this wires that one path instead of a generic error-formatting helper.

Per the issue's own note (\"this can wait if the codebase has no runtime engine error paths yet\"), there is **no runtime `EngineEvent::Error` emitter today** — the two existing emit sites are both handshake-time (caught by the spawn handshake, not the loop). This lands the wiring so the first future runtime failure (e.g. #81 offline UX) surfaces in the popup for free.

## Verification

- Unit test: `engine_error_notify` formats the message and tags `Level::Error`.
- `cargo test` (full workspace), `clippy --all-targets`, `fmt --check` pass.
- Not exercised end-to-end: no runtime emitter exists to trigger a live popup yet (by design).