### PR TITLE
refactor(keymap): move default keybindings from Rust to bundled init.lua

### DIFF
--- a/runtime/init.lua
+++ b/runtime/init.lua
@@ -44,7 +44,31 @@ ttymap.opt.runtime.poll_timeout_ms   = 50   -- Main loop wake interval (20 Hz).
 ttymap.opt.runtime.overlay_redraw_ms = 100  -- Min interval between overlay-driven redraws (10 Hz).
 
 ------------------------------------------------------------
--- 2. Bundled libs — infrastructure consumed by every plugin's
+-- 2. Default keybindings. nvim-style: the defaults are ordinary
+-- `ttymap.keymap.set(name, keys)` calls, not hardcoded in Rust, so
+-- user init.lua can rebind or `ttymap.keymap.del(name)` any of them.
+-- Set before libs / plugins so a later require error can't strip the
+-- bindings (the keymap is harvested after this whole file runs).
+-- `name` is a UserCommand config name; the action behaviour (pan
+-- deltas, zoom step, …) lives in Rust — only the key↔name mapping is
+-- configured here.
+------------------------------------------------------------
+ttymap.keymap.set("pan_left", { "h", "Left" })
+ttymap.keymap.set("pan_right", { "l", "Right" })
+ttymap.keymap.set("pan_up", { "k", "Up" })
+ttymap.keymap.set("pan_down", { "j", "Down" })
+ttymap.keymap.set("pan_left_fast", { "b" })
+ttymap.keymap.set("pan_right_fast", { "w" })
+ttymap.keymap.set("pan_up_half", { "C-u" })
+ttymap.keymap.set("pan_down_half", { "C-d" })
+ttymap.keymap.set("zoom_in", { "a", "+" })
+ttymap.keymap.set("zoom_out", { "z", "-" })
+ttymap.keymap.set("reset_position", { "0" })
+ttymap.keymap.set("quit", { "q" })
+ttymap.keymap.set("toggle_sidebar", { "\\" })
+
+------------------------------------------------------------
+-- 3. Bundled libs — infrastructure consumed by every plugin's
 -- `ttymap.notify(msg)` calls. A lib (not plugin) so users can
 -- pass `setup({ ttl_s = …, ring_cap = …, max_text_width = … })`
 -- to tweak the renderer; skipping the call disables it entirely.
@@ -52,7 +76,7 @@ ttymap.opt.runtime.overlay_redraw_ms = 100  -- Min interval between overlay-driv
 require("ttymap.notify").setup()
 
 ------------------------------------------------------------
--- 3. Bundled plugins — chrome first, then everything else
+-- 4. Bundled plugins — chrome first, then everything else
 -- (alphabetical). Adjust per file to taste. Each lives at
 -- `<layer>/lua/plugin/<name>.lua` (or `<name>/init.lua`) and is
 -- required as a standard Lua module via `package.path` — no
@@ -82,7 +106,7 @@ require "plugin.travel"
 require "plugin.wiki"
 
 ------------------------------------------------------------
--- 4. User init.lua — runs LAST so the user wins:
+-- 5. User init.lua — runs LAST so the user wins:
 --   * override any `ttymap.opt.*` set above
 --   * `ttymap.keymap.set/del`
 --   * `require` user plugins (their registrations stack on top of

--- a/ttymap-lua/src/lib.rs
+++ b/ttymap-lua/src/lib.rs
@@ -248,6 +248,30 @@ mod tests {
         assert_eq!(n, 4);
     }
 
+    /// The default keybindings live in the bundled `runtime/init.lua`
+    /// (`ttymap.keymap.set`), not in Rust. Boot the real subsystem and
+    /// confirm a representative map binding (`h` → pan_left) and the
+    /// non-map `quit` (`q`) land in the harvested `KeyMap`.
+    #[test]
+    fn bundled_init_lua_seeds_default_keymap() {
+        use ttymap_engine::map::MapAction;
+        use ttymap_shared::UserCommand;
+        runtimepath::ensure_runtime_path_for_tests();
+        let (_sub, _cfg, _ov, keymap) = build_subsystem(ttymap_config::Config::default());
+        assert!(
+            keymap
+                .keys_for(&UserCommand::Map(MapAction::PanLeft))
+                .contains(&"h".to_string()),
+            "bundled init.lua should bind h → pan_left"
+        );
+        assert!(
+            keymap
+                .keys_for(&UserCommand::Quit)
+                .contains(&"q".to_string()),
+            "bundled init.lua should bind q → quit"
+        );
+    }
+
     #[test]
     fn lua_can_call_a_rust_closure() {
         let lua = new_lua();

--- a/ttymap-tui/src/input/keymap.rs
+++ b/ttymap-tui/src/input/keymap.rs
@@ -24,7 +24,6 @@
 use crossterm::event::{KeyCode, KeyModifiers};
 
 use ttymap_config::KeybindingOverrides;
-use ttymap_engine::map::MapAction;
 use ttymap_shared::UserCommand;
 
 /// A key binding: a key code + optional modifiers.
@@ -146,36 +145,14 @@ impl KeyMap {
 }
 
 impl Default for KeyMap {
+    /// An empty table. Default bindings are *not* seeded in Rust —
+    /// the bundled `runtime/init.lua` declares them with
+    /// `ttymap.keymap.set(...)`, folded in by [`Self::with_overrides`]
+    /// (nvim-style: defaults are ordinary, user-overridable config).
+    /// This empty table is the base the override map layers onto.
     fn default() -> Self {
-        use MapAction::*;
-        let map = |key: &str, action: MapAction| -> (KeyBinding, UserCommand) {
-            (parse_key_binding(key).unwrap(), UserCommand::Map(action))
-        };
-        let intent = |key: &str, intent: UserCommand| -> (KeyBinding, UserCommand) {
-            (parse_key_binding(key).unwrap(), intent)
-        };
         Self {
-            bindings: vec![
-                map("h", PanLeft),
-                map("Left", PanLeft),
-                map("l", PanRight),
-                map("Right", PanRight),
-                map("k", PanUp),
-                map("Up", PanUp),
-                map("j", PanDown),
-                map("Down", PanDown),
-                map("b", PanLeftFast),
-                map("w", PanRightFast),
-                map("C-u", PanUpHalf),
-                map("C-d", PanDownHalf),
-                map("a", ZoomBy(1)),
-                map("+", ZoomBy(1)),
-                map("z", ZoomBy(-1)),
-                map("-", ZoomBy(-1)),
-                map("0", ResetPosition),
-                intent("q", UserCommand::Quit),
-                intent("\\", UserCommand::ToggleSidebar),
-            ],
+            bindings: Vec::new(),
         }
     }
 }
@@ -224,9 +201,25 @@ fn parse_key_code(s: &str) -> Option<KeyCode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ttymap_engine::map::MapAction;
 
     fn map(action: MapAction) -> UserCommand {
         UserCommand::Map(action)
+    }
+
+    /// Build a keymap from `(config_name, keys)` rows via the real
+    /// `with_overrides` path — the same mechanism the bundled
+    /// `init.lua` defaults flow through, but with explicit bindings so
+    /// the tests don't depend on the shipped default set.
+    fn km(rows: &[(&str, &[&str])]) -> KeyMap {
+        let mut o = KeybindingOverrides::new();
+        for (name, keys) in rows {
+            o.insert(
+                (*name).to_string(),
+                keys.iter().map(|s| (*s).to_string()).collect(),
+            );
+        }
+        KeyMap::with_overrides(&o)
     }
 
     #[test]
@@ -263,7 +256,7 @@ mod tests {
 
     #[test]
     fn test_lookup() {
-        let km = KeyMap::default();
+        let km = km(&[("pan_left", &["h"]), ("pan_down_half", &["C-d"])]);
         assert_eq!(
             km.lookup(KeyCode::Char('h'), KeyModifiers::NONE),
             Some(&map(MapAction::PanLeft))
@@ -298,21 +291,14 @@ mod tests {
     }
 
     #[test]
-    fn with_overrides_keeps_unoverridden_defaults() {
-        let km = KeyMap::with_overrides(&KeybindingOverrides::new());
-        assert_eq!(
-            km.lookup(KeyCode::Char('h'), KeyModifiers::NONE),
-            Some(&map(MapAction::PanLeft))
-        );
-    }
-
-    #[test]
     fn with_overrides_skips_unknown_entries() {
         let mut overrides = KeybindingOverrides::new();
         overrides.insert("not_an_action".to_string(), vec!["x".to_string()]);
-        // Defaults survive an unknown entry — it must not poison the
-        // rest of the table.
+        overrides.insert("pan_left".to_string(), vec!["h".to_string()]);
+        // An unknown name is logged and skipped; it must not poison the
+        // known entries in the same map.
         let km = KeyMap::with_overrides(&overrides);
+        assert_eq!(km.lookup(KeyCode::Char('x'), KeyModifiers::NONE), None);
         assert_eq!(
             km.lookup(KeyCode::Char('h'), KeyModifiers::NONE),
             Some(&map(MapAction::PanLeft))
@@ -321,43 +307,41 @@ mod tests {
 
     const NONE: KeyModifiers = KeyModifiers::NONE;
 
+    /// Representative names across the vocabulary (pan, fast/half pan,
+    /// zoom, reset, the non-map `quit`) resolve to the right command
+    /// through `with_overrides` → `from_config_name`. Exercises the
+    /// config-name → command mapping the bundled defaults rely on,
+    /// without asserting the shipped keys themselves.
     #[test]
-    fn resolve_basic_movement() {
-        let km = KeyMap::default();
+    fn resolve_across_vocabulary() {
+        let km = km(&[
+            ("pan_left", &["h"]),
+            ("pan_right_fast", &["w"]),
+            ("pan_down_half", &["C-d"]),
+            ("zoom_in", &["a"]),
+            ("reset_position", &["0"]),
+            ("quit", &["q"]),
+        ]);
         assert_eq!(
             km.resolve(KeyCode::Char('h'), NONE),
             Some(map(MapAction::PanLeft))
         );
         assert_eq!(
-            km.resolve(KeyCode::Char('j'), NONE),
-            Some(map(MapAction::PanDown))
+            km.resolve(KeyCode::Char('w'), NONE),
+            Some(map(MapAction::PanRightFast))
         );
         assert_eq!(
-            km.resolve(KeyCode::Char('k'), NONE),
-            Some(map(MapAction::PanUp))
+            km.resolve(KeyCode::Char('d'), KeyModifiers::CONTROL),
+            Some(map(MapAction::PanDownHalf))
         );
-        assert_eq!(
-            km.resolve(KeyCode::Char('l'), NONE),
-            Some(map(MapAction::PanRight))
-        );
-    }
-
-    #[test]
-    fn resolve_zoom() {
-        let km = KeyMap::default();
         assert_eq!(
             km.resolve(KeyCode::Char('a'), NONE),
             Some(map(MapAction::ZoomBy(1)))
         );
         assert_eq!(
-            km.resolve(KeyCode::Char('z'), NONE),
-            Some(map(MapAction::ZoomBy(-1)))
+            km.resolve(KeyCode::Char('0'), NONE),
+            Some(map(MapAction::ResetPosition))
         );
-    }
-
-    #[test]
-    fn resolve_quit() {
-        let km = KeyMap::default();
         assert_eq!(
             km.resolve(KeyCode::Char('q'), NONE),
             Some(UserCommand::Quit)
@@ -365,42 +349,13 @@ mod tests {
     }
 
     #[test]
-    fn resolve_big_pan() {
-        let km = KeyMap::default();
+    fn resolve_unbound_key_is_none() {
+        let km = km(&[("pan_left", &["h"])]);
         assert_eq!(
-            km.resolve(KeyCode::Char('w'), NONE),
-            Some(map(MapAction::PanRightFast))
+            km.resolve(KeyCode::Char('h'), NONE),
+            Some(map(MapAction::PanLeft))
         );
-        assert_eq!(
-            km.resolve(KeyCode::Char('b'), NONE),
-            Some(map(MapAction::PanLeftFast))
-        );
-        assert_eq!(
-            km.resolve(KeyCode::Char('d'), KeyModifiers::CONTROL),
-            Some(map(MapAction::PanDownHalf))
-        );
-        assert_eq!(
-            km.resolve(KeyCode::Char('u'), KeyModifiers::CONTROL),
-            Some(map(MapAction::PanUpHalf))
-        );
-    }
-
-    #[test]
-    fn resolve_reset_position() {
-        let km = KeyMap::default();
-        assert_eq!(
-            km.resolve(KeyCode::Char('0'), NONE),
-            Some(map(MapAction::ResetPosition))
-        );
-    }
-
-    #[test]
-    fn resolve_unknown_key_is_none() {
-        let km = KeyMap::default();
-        // `/`, `?`, `i` are widget activation triggers, not keymap
-        // entries — they fall through to `None`.
+        // An unbound key (e.g. a widget activation trigger) falls through.
         assert_eq!(km.resolve(KeyCode::Char('/'), NONE), None);
-        assert_eq!(km.resolve(KeyCode::Char('?'), NONE), None);
-        assert_eq!(km.resolve(KeyCode::Char('i'), NONE), None);
     }
 }


### PR DESCRIPTION
## What

Default keybindings move out of Rust's `KeyMap::default()` (now empty) into the bundled `runtime/init.lua`, declared as ordinary `ttymap.keymap.set(name, keys)` calls and folded in by `with_overrides`. nvim-style: defaults are config you can read and override, not a hardcoded Rust table.

## Why

- **Shrinks Rust** (the recurring goal): net ~-26 lines across `keymap.rs` + the new test (production `keymap.rs` shrinks more — the end-to-end test adds 22 back).
- **Fixes `ttymap.keymap.del`**: `del` only removes from the override map, so against the *old* Rust defaults it was effectively a no-op (you couldn't unbind a default from Lua). Now that defaults ARE override entries, `del("pan_left")` actually unbinds it.
- **Consistent with the architecture**: defaults already live in init.lua for `ttymap.opt.*`, plugins, attribution, etc. Keybindings were the odd one out.

## Robustness

The `keymap.set` block runs **before** any plugin require, so a later plugin-require error can't strip the bindings (they're harvested after the whole file runs). The remaining loss-of-bindings cases are narrow and already-fatal/degraded:

- No runtime found at all → the binary already `exit(1)`s at startup (`main.rs`), independent of where defaults live.
- A syntax error in the shipped `init.lua`, or a Rust-side API-install failure (`build_subsystem` fallback paths) → bindings empty. Both are our-bug / caught-in-CI cases; user `~/.config/ttymap/init.lua` errors are already isolated.

## Verification

- New end-to-end test `bundled_init_lua_seeds_default_keymap`: boots the real subsystem via `build_subsystem`, asserts `h → pan_left` and `q → quit` land in the harvested `KeyMap`.
- `keymap.rs` unit tests reworked to exercise `with_overrides` with explicit bindings (mechanism coverage) instead of asserting the shipped default set.
- `cargo test` (full workspace), `clippy --all-targets`, `fmt --check`, `luac -p runtime/init.lua` all pass.