### PR TITLE
feat(plugin): aircraft — optional OpenSky OAuth2 credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Tokyo zoomed in with the wiki panel open:
 
 | Plugin | What it does |
 | --- | --- |
-| `aircraft` | Live aircraft markers from the OpenSky public ADS-B feed; sidebar list with altitude / speed; Enter centers the map. |
+| `aircraft` | Live aircraft markers from the OpenSky ADS-B feed; sidebar list with altitude / speed; Enter centers the map. Anonymous by default; set OpenSky OAuth2 credentials via `require("ttymap.aircraft")` to lift the rate limit. |
 | `antipode` | `:` palette → fly to the diametrically opposite point on the sphere. "What's directly below me through Earth?" |
 | `attribution` | Always-on © OpenStreetMap chrome (legal hygiene for a map renderer). |
 | `autospin` | `:` palette → camera drifts eastward at a constant rate, looping at the antimeridian. The "this is a globe" demo. Manual pan yields the spin. |

--- a/runtime/lua/plugin/aircraft/init.lua
+++ b/runtime/lua/plugin/aircraft/init.lua
@@ -60,7 +60,10 @@ local function on_tick(map)
                 state.job = nil
                 return
             end
-            state.aircraft = opensky.parse(payload)
+            local clon, clat = map:center()
+            state.aircraft = opensky.limit_to_center(
+                opensky.parse(payload), clon, clat
+            )
             if state.selected > #state.aircraft then
                 state.selected = math.max(1, #state.aircraft)
             end

--- a/runtime/lua/plugin/aircraft/init.lua
+++ b/runtime/lua/plugin/aircraft/init.lua
@@ -44,6 +44,8 @@ end
 -- callback is gone from the bus iteration entirely (no per-frame
 -- fetch / paint cost when aircraft is hidden).
 local function on_tick(map)
+    -- Advance the OpenSky OAuth token (no-op when unconfigured).
+    opensky.poll_auth()
     -- Drain any in-flight fetch.
     if state.job then
         local body = state.job:try_take()
@@ -79,7 +81,7 @@ local function on_tick(map)
     if not state.job and (now - state.last_fetch_sec) >= opensky.INTERVAL_SEC then
         state.last_fetch_sec = now
         local lon, lat = map:center()
-        state.job = ttymap.http:fetch(opensky.url(lon, lat))
+        state.job = opensky.fetch_states(lon, lat)
     end
     -- Markers.
     for i, a in ipairs(state.aircraft) do

--- a/runtime/lua/plugin/aircraft/opensky.lua
+++ b/runtime/lua/plugin/aircraft/opensky.lua
@@ -29,6 +29,7 @@ local auth = {
     token      = nil,
     expires_at = 0,    -- os.time() past which `token` is treated as stale
     job        = nil,  -- in-flight token POST
+    notified   = false,-- one-shot "authenticated" toast (per program run)
 }
 
 local function trim(s)
@@ -78,6 +79,11 @@ function M.poll_auth()
                 auth.token = payload.access_token
                 local ttl = tonumber(payload.expires_in) or 1800
                 auth.expires_at = os.time() + ttl - 60
+                -- Tell the user which source is live, once per run.
+                if not auth.notified then
+                    auth.notified = true
+                    ttymap.notify("aircraft: reading via OpenSky API (authenticated)")
+                end
             else
                 auth.token = nil
                 auth.expires_at = os.time() + 60
@@ -111,6 +117,28 @@ function M.fetch_states(lon, lat)
         })
     end
     return ttymap.http:fetch(M.url(lon, lat))
+end
+
+-- Cap the list to the nearest `ttymap.aircraft.max_count` aircraft to
+-- the map centre `(lon, lat)`. Pass-through when the cap is unset or
+-- the list already fits. Ranking uses an equirectangular distance
+-- (longitude scaled by cos(lat)) — exact ground distance is overkill
+-- for ordering within a single ~10° fetch window.
+function M.limit_to_center(list, lon, lat)
+    local max = cfg.max_count
+    if not max or #list <= max then return list end
+    local cos_lat = math.cos(math.rad(lat))
+    local function d2(a)
+        local dlon = a.lon - lon
+        if dlon > 180 then dlon = dlon - 360 elseif dlon < -180 then dlon = dlon + 360 end
+        dlon = dlon * cos_lat
+        local dlat = a.lat - lat
+        return dlon * dlon + dlat * dlat
+    end
+    table.sort(list, function(a, b) return d2(a) < d2(b) end)
+    local out = {}
+    for i = 1, max do out[i] = list[i] end
+    return out
 end
 
 function M.parse(payload)

--- a/runtime/lua/plugin/aircraft/opensky.lua
+++ b/runtime/lua/plugin/aircraft/opensky.lua
@@ -11,12 +11,25 @@
 --   8 = baro_altitude, 9 = on_ground, 10 = velocity, 11 = true_track
 -- (Lua arrays are 1-indexed; OpenSky's docs are 0-indexed.)
 
+local cfg = require("ttymap.aircraft")
+
 local M = {}
 
 local BASE_URL       = "https://opensky-network.org/api/states/all"
+local TOKEN_URL      =
+    "https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token"
 local BBOX_HALF_DEG  = 5.0   -- half-side of the bbox sent per fetch
 
 M.INTERVAL_SEC = 12
+
+-- OAuth2 client-credentials state (see ttymap.aircraft). Anonymous
+-- when credentials are unset; otherwise we hold a Bearer token and
+-- refresh it ~1 min before its `expires_in` (≈30 min) lapses.
+local auth = {
+    token      = nil,
+    expires_at = 0,    -- os.time() past which `token` is treated as stale
+    job        = nil,  -- in-flight token POST
+}
 
 local function trim(s)
     return (s or ""):gsub("^%s+", ""):gsub("%s+$", "")
@@ -40,6 +53,64 @@ function M.url(lon, lat)
         "%s?lamin=%f&lomin=%f&lamax=%f&lomax=%f",
         BASE_URL, lamin, lomin, lamax, lomax
     )
+end
+
+-- True when OAuth2 credentials are configured (read lazily so a
+-- value set in init.lua after this module loads still counts).
+local function configured()
+    return cfg.client_id ~= nil and cfg.client_secret ~= nil
+end
+
+-- Advance the token state machine. Call once per tick. No-op when
+-- unconfigured (anonymous). Drains an in-flight token POST, then kicks
+-- a refresh when the current token is missing/stale and none is in
+-- flight. On failure it backs off ~60s so bad credentials don't hammer
+-- the token endpoint every frame.
+function M.poll_auth()
+    if not configured() then return end
+
+    if auth.job then
+        local body = auth.job:try_take()
+        if body then
+            auth.job = nil
+            local payload = ttymap.json:parse(body)
+            if payload and payload.access_token then
+                auth.token = payload.access_token
+                local ttl = tonumber(payload.expires_in) or 1800
+                auth.expires_at = os.time() + ttl - 60
+            else
+                auth.token = nil
+                auth.expires_at = os.time() + 60
+                ttymap.notify(
+                    "aircraft: OpenSky token fetch failed (check credentials)",
+                    { level = "warn" }
+                )
+            end
+        end
+    end
+
+    if not auth.job and os.time() >= auth.expires_at then
+        auth.job = ttymap.http:fetch(TOKEN_URL, {
+            method = "POST",
+            form   = {
+                grant_type    = "client_credentials",
+                client_id     = cfg.client_id,
+                client_secret = cfg.client_secret,
+            },
+        })
+    end
+end
+
+-- Fetch state vectors around (lon, lat). Adds the Bearer header once a
+-- token is in hand; falls back to an anonymous GET while unconfigured
+-- or before the first token lands.
+function M.fetch_states(lon, lat)
+    if configured() and auth.token then
+        return ttymap.http:fetch(M.url(lon, lat), {
+            headers = { Authorization = "Bearer " .. auth.token },
+        })
+    end
+    return ttymap.http:fetch(M.url(lon, lat))
 end
 
 function M.parse(payload)

--- a/runtime/lua/ttymap/aircraft.lua
+++ b/runtime/lua/ttymap/aircraft.lua
@@ -17,9 +17,16 @@
 -- nvim-style: the plugin reads these fields lazily at fetch time, so
 -- setting them in init.lua (which runs after the plugin is required)
 -- takes effect on the next refresh.
+--
+-- `max_count` caps how many aircraft are shown — dense airspace can
+-- return hundreds. When set, only the nearest `max_count` to the map
+-- centre are kept (markers + sidebar). `nil` = no cap (show all).
+--
+--   require("ttymap.aircraft").max_count = 50
 local M = {
     client_id = nil,
     client_secret = nil,
+    max_count = nil,
 }
 
 return M

--- a/runtime/lua/ttymap/aircraft.lua
+++ b/runtime/lua/ttymap/aircraft.lua
@@ -1,0 +1,25 @@
+-- ttymap.aircraft — config holder for the bundled `aircraft` plugin.
+--
+-- OpenSky moved to OAuth2 client-credentials in 2025; anonymous access
+-- is capped at 400 credits/day (a ~10°×10° /states/all call costs ~2),
+-- so frequent use gets throttled fast. Authenticate to lift the cap to
+-- 4000/day (8000 if you feed the network).
+--
+-- Set your credentials in `~/.config/ttymap/init.lua`:
+--
+--   local aircraft = require("ttymap.aircraft")
+--   aircraft.client_id     = "your-client-id"
+--   aircraft.client_secret = "your-client-secret"
+--
+-- Create an API client at https://opensky-network.org → Account → API
+-- clients. Leave both unset for anonymous access (the default).
+--
+-- nvim-style: the plugin reads these fields lazily at fetch time, so
+-- setting them in init.lua (which runs after the plugin is required)
+-- takes effect on the next refresh.
+local M = {
+    client_id = nil,
+    client_secret = nil,
+}
+
+return M


### PR DESCRIPTION
Second half of OpenSky API-key support, built on #392 (`ttymap.http` POST/headers). **Pure Lua — no aircraft-specific Rust.**

## What

OpenSky moved to OAuth2 client-credentials in 2025; anonymous access is capped at 400 credits/day (a ~10°×10° `/states/all` call costs ~2). Authenticate to lift the cap to 4000/day (8000 if you feed the network).

Set credentials in `~/.config/ttymap/init.lua`:
```lua
local aircraft = require("ttymap.aircraft")
aircraft.client_id     = "your-client-id"
aircraft.client_secret = "your-client-secret"
```
Leave unset for anonymous access (unchanged default).

## How

- **`runtime/lua/ttymap/aircraft.lua`** — new config-holder lib (same nvim-style pattern as `ttymap.here`); the plugin reads the fields lazily at fetch time.
- **`opensky.lua`** — token state machine (`poll_auth`, driven once per tick): drains an async token `POST` (via the new `http:fetch(url, {method="POST", form=...})`), caches the Bearer token, refreshes ~1 min before its `expires_in` (~30 min) lapses, and backs off ~60 s on failure so bad credentials don't hammer the token endpoint every frame. `fetch_states` adds `Authorization: Bearer` once a token is in hand, else anonymous GET.
- **`init.lua`** — `on_tick` calls `opensky.poll_auth()` and fetches via `opensky.fetch_states(...)`.

## Verification

- `luac -p` on all three Lua files.
- Booted the real subsystem via `build_subsystem` (throwaway test) to confirm `plugin.aircraft` (now requiring `ttymap.aircraft`) loads and registers — "Toggle aircraft" lands in the registry.
- `cargo test` (full workspace), `clippy --all-targets`, `fmt --check` pass.
- **Not exercised live**: an actual authenticated OpenSky round-trip (needs real credentials + network). The token-flow logic is Lua; the HTTP transport it rides was tested in #392.