### PR TITLE
feat(aircraft): hover-select, follow-on-select, richer sidebar, stable list, configurable area/refresh

### DIFF
--- a/runtime/lua/plugin/aircraft/display.lua
+++ b/runtime/lua/plugin/aircraft/display.lua
@@ -24,11 +24,22 @@ end
 -- the host. Secondary info (altitude, ground state) renders muted.
 function M.fmt(a)
     local cs = a.callsign ~= "" and a.callsign or "(no callsign)"
-    local secondary = ""
+    local secondary
     if a.on_ground then
         secondary = "  (ground)"
-    elseif type(a.alt) == "number" then
-        secondary = string.format("  %dm", math.floor(a.alt))
+    else
+        local parts = {}
+        if type(a.alt) == "number" then
+            parts[#parts + 1] = string.format("%dm", math.floor(a.alt))
+        end
+        if type(a.velocity) == "number" then
+            -- m/s → km/h.
+            parts[#parts + 1] = string.format("%dkm/h", math.floor(a.velocity * 3.6 + 0.5))
+        end
+        if type(a.vrate) == "number" and math.abs(a.vrate) > 0.5 then
+            parts[#parts + 1] = a.vrate > 0 and "↑" or "↓"
+        end
+        secondary = "  " .. table.concat(parts, " ")
     end
     return {
         { text = cs,        style = "accent" },

--- a/runtime/lua/plugin/aircraft/init.lua
+++ b/runtime/lua/plugin/aircraft/init.lua
@@ -11,11 +11,13 @@ local sidebar = require("ttymap.sidebar")
 local anim    = require("ttymap.animation")
 
 local state = {
-    aircraft       = {},  -- list of { callsign, lon, lat, on_ground, alt, heading }
+    aircraft       = {},  -- list of { callsign, lon, lat, on_ground, alt, ... }
     selected       = 1,   -- 1-based index
     job            = nil, -- pending fetch
     last_fetch_sec = 0,   -- wall-clock second of last fetch start
     initial_done   = false, -- whether the first fetch after open landed
+    cur_col        = nil, -- last cursor cell (for hover-select movement gate)
+    cur_row        = nil,
 }
 local w = nil       -- card handle while open; nil while closed
 local tick_handle = nil  -- on_tick subscription while open; nil while closed
@@ -24,8 +26,8 @@ local tick_handle = nil  -- on_tick subscription while open; nil while closed
 -- below returns an empty list (= no fetch result yet).
 local function build_lines()
     return {
-        { { text = "Loading...",           style = "muted" } },
-        { { text = "(OpenSky takes ~12s)", style = "muted" } },
+        { { text = "Loading...",          style = "muted" } },
+        { { text = "(fetching OpenSky…)", style = "muted" } },
     }
 end
 
@@ -36,6 +38,14 @@ local function build_items()
         table.insert(items, { display.fmt(a) })
     end
     return items
+end
+
+-- Centre the map on the currently selected aircraft. Called whenever
+-- the selection changes (keyboard nav or hover) so the view follows
+-- the list, wiki-plugin style.
+local function fly_to_selected()
+    local a = state.aircraft[state.selected]
+    if a then anim.fly_to(a.lon, a.lat) end
 end
 
 -- Per-frame work: drain the in-flight fetch, schedule the next one,
@@ -81,10 +91,34 @@ local function on_tick(map)
     end
     -- Schedule the next fetch when the interval has elapsed.
     local now = os.time()
-    if not state.job and (now - state.last_fetch_sec) >= opensky.INTERVAL_SEC then
+    if not state.job and (now - state.last_fetch_sec) >= opensky.interval_sec() then
         state.last_fetch_sec = now
         local lon, lat = map:center()
         state.job = opensky.fetch_states(lon, lat)
+    end
+    -- Hover-select: when the mouse moves onto (within ~2 cells of) a
+    -- marker, select that aircraft. Gated on cursor *movement* so
+    -- keyboard selection (C-n/C-p) still works while the mouse is
+    -- parked; leaves the selection untouched when the cursor is over
+    -- empty space.
+    local clon, clat = map:cursor()
+    if clon then
+        local ccol, crow = map:project(clon, clat)
+        if ccol and (ccol ~= state.cur_col or crow ~= state.cur_row) then
+            state.cur_col, state.cur_row = ccol, crow
+            local best, best_d = nil, 3   -- chebyshev distance < 3 ⇒ within 2 cells
+            for i, a in ipairs(state.aircraft) do
+                local acol, arow = map:project(a.lon, a.lat)
+                if acol then
+                    local d = math.max(math.abs(acol - ccol), math.abs(arow - crow))
+                    if d < best_d then best, best_d = i, d end
+                end
+            end
+            if best and best ~= state.selected then
+                state.selected = best
+                fly_to_selected()
+            end
+        end
     end
     -- Markers.
     for i, a in ipairs(state.aircraft) do
@@ -125,10 +159,12 @@ local function open()
             local n = #state.aircraft
             if sidebar.up_pressed(key) then
                 state.selected = sidebar.cycle(state.selected, n, -1)
+                fly_to_selected()
                 return nil
             end
             if sidebar.down_pressed(key) then
                 state.selected = sidebar.cycle(state.selected, n, 1)
+                fly_to_selected()
                 return nil
             end
             if key.code == "Enter" then

--- a/runtime/lua/plugin/aircraft/init.lua
+++ b/runtime/lua/plugin/aircraft/init.lua
@@ -130,9 +130,13 @@ local function on_tick(map)
                     if d < best_d then best, best_d = i, d end
                 end
             end
+            -- Hover only *highlights* (and pins the selection across
+            -- refreshes); it deliberately does NOT move the map —
+            -- flying on every mouse twitch is disorienting. Keyboard
+            -- nav / Enter still centre the view.
             if best and best ~= state.selected then
                 state.selected = best
-                fly_to_selected()
+                state.selected_icao = state.aircraft[best].icao
             end
         end
     end

--- a/runtime/lua/plugin/aircraft/init.lua
+++ b/runtime/lua/plugin/aircraft/init.lua
@@ -16,6 +16,8 @@ local state = {
     job            = nil, -- pending fetch
     last_fetch_sec = 0,   -- wall-clock second of last fetch start
     initial_done   = false, -- whether the first fetch after open landed
+    selected_icao  = nil, -- icao24 of the selected plane (pins selection
+                          -- across refreshes; index alone points elsewhere)
     cur_col        = nil, -- last cursor cell (for hover-select movement gate)
     cur_row        = nil,
 }
@@ -45,7 +47,10 @@ end
 -- the list, wiki-plugin style.
 local function fly_to_selected()
     local a = state.aircraft[state.selected]
-    if a then anim.fly_to(a.lon, a.lat) end
+    if a then
+        state.selected_icao = a.icao
+        anim.fly_to(a.lon, a.lat)
+    end
 end
 
 -- Per-frame work: drain the in-flight fetch, schedule the next one,
@@ -74,6 +79,17 @@ local function on_tick(map)
             state.aircraft = opensky.limit_to_center(
                 opensky.parse(payload), clon, clat
             )
+            -- Re-pin the selection to the same physical plane (by
+            -- icao) in the refreshed list, so the highlight doesn't
+            -- jump to whatever now sits at the old index.
+            if state.selected_icao then
+                for i, a in ipairs(state.aircraft) do
+                    if a.icao == state.selected_icao then
+                        state.selected = i
+                        break
+                    end
+                end
+            end
             if state.selected > #state.aircraft then
                 state.selected = math.max(1, #state.aircraft)
             end
@@ -168,8 +184,7 @@ local function open()
                 return nil
             end
             if key.code == "Enter" then
-                local a = state.aircraft[state.selected]
-                if a then anim.fly_to(a.lon, a.lat) end
+                fly_to_selected()
                 return nil
             end
             if sidebar.is_close_key(key) then

--- a/runtime/lua/plugin/aircraft/opensky.lua
+++ b/runtime/lua/plugin/aircraft/opensky.lua
@@ -55,10 +55,11 @@ end
 -- longitude to [-180, 180]; OpenSky doesn't accept antimeridian-
 -- wrapping bboxes so this just stops at the edge.
 function M.url(lon, lat)
-    local lamin = clamp(lat - BBOX_HALF_DEG, -90.0, 90.0)
-    local lamax = clamp(lat + BBOX_HALF_DEG, -90.0, 90.0)
-    local lomin = clamp(lon - BBOX_HALF_DEG, -180.0, 180.0)
-    local lomax = clamp(lon + BBOX_HALF_DEG, -180.0, 180.0)
+    local half = cfg.bbox_half_deg or BBOX_HALF_DEG
+    local lamin = clamp(lat - half, -90.0, 90.0)
+    local lamax = clamp(lat + half, -90.0, 90.0)
+    local lomin = clamp(lon - half, -180.0, 180.0)
+    local lomax = clamp(lon + half, -180.0, 180.0)
     return string.format(
         "%s?lamin=%f&lomin=%f&lamax=%f&lomax=%f",
         BASE_URL, lamin, lomin, lamax, lomax

--- a/runtime/lua/plugin/aircraft/opensky.lua
+++ b/runtime/lua/plugin/aircraft/opensky.lua
@@ -128,26 +128,29 @@ function M.fetch_states(lon, lat)
     return ttymap.http:fetch(M.url(lon, lat))
 end
 
--- Cap the list to the nearest `ttymap.aircraft.max_count` aircraft to
--- the map centre `(lon, lat)`. Pass-through when the cap is unset or
--- the list already fits. Ranking uses an equirectangular distance
--- (longitude scaled by cos(lat)) — exact ground distance is overkill
--- for ordering within a single ~10° fetch window.
+-- Build the display list: cap to the nearest `ttymap.aircraft.max_count`
+-- aircraft to the map centre `(lon, lat)` (equirectangular ranking,
+-- longitude scaled by cos(lat)), then sort by icao24 so the row order
+-- is *stable* across refreshes — the same plane keeps its row instead
+-- of the whole table reshuffling every fetch.
 function M.limit_to_center(list, lon, lat)
     local max = cfg.max_count
-    if not max or #list <= max then return list end
-    local cos_lat = math.cos(math.rad(lat))
-    local function d2(a)
-        local dlon = a.lon - lon
-        if dlon > 180 then dlon = dlon - 360 elseif dlon < -180 then dlon = dlon + 360 end
-        dlon = dlon * cos_lat
-        local dlat = a.lat - lat
-        return dlon * dlon + dlat * dlat
+    if max and #list > max then
+        local cos_lat = math.cos(math.rad(lat))
+        local function d2(a)
+            local dlon = a.lon - lon
+            if dlon > 180 then dlon = dlon - 360 elseif dlon < -180 then dlon = dlon + 360 end
+            dlon = dlon * cos_lat
+            local dlat = a.lat - lat
+            return dlon * dlon + dlat * dlat
+        end
+        table.sort(list, function(a, b) return d2(a) < d2(b) end)
+        local nearest = {}
+        for i = 1, max do nearest[i] = list[i] end
+        list = nearest
     end
-    table.sort(list, function(a, b) return d2(a) < d2(b) end)
-    local out = {}
-    for i = 1, max do out[i] = list[i] end
-    return out
+    table.sort(list, function(a, b) return (a.icao or "") < (b.icao or "") end)
+    return list
 end
 
 function M.parse(payload)
@@ -159,6 +162,7 @@ function M.parse(payload)
         local lon, lat = s[6], s[7]
         if type(lon) == "number" and type(lat) == "number" then
             table.insert(out, {
+                icao      = s[1],          -- icao24 hex id (stable key)
                 callsign  = trim(s[2]),
                 country   = trim(s[3]),
                 lon       = lon,

--- a/runtime/lua/plugin/aircraft/opensky.lua
+++ b/runtime/lua/plugin/aircraft/opensky.lua
@@ -20,8 +20,6 @@ local TOKEN_URL      =
     "https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token"
 local BBOX_HALF_DEG  = 5.0   -- half-side of the bbox sent per fetch
 
-M.INTERVAL_SEC = 12
-
 -- OAuth2 client-credentials state (see ttymap.aircraft). Anonymous
 -- when credentials are unset; otherwise we hold a Bearer token and
 -- refresh it ~1 min before its `expires_in` (≈30 min) lapses.
@@ -31,6 +29,17 @@ local auth = {
     job        = nil,  -- in-flight token POST
     notified   = false,-- one-shot "authenticated" toast (per program run)
 }
+
+-- Refresh cadence. OpenSky's state resolution is 5 s authenticated /
+-- 10 s anonymous, so polling faster just re-fetches identical data.
+-- Authenticated → 5 s, anonymous → 12 s; `ttymap.aircraft.interval_sec`
+-- overrides. (At ~2 credits/call, 5 s burns ~24/min, so the 4000/day
+-- authed budget lasts ~2.5 h of continuous viewing.)
+function M.interval_sec()
+    if cfg.interval_sec then return cfg.interval_sec end
+    if auth.token then return 5 end
+    return 12
+end
 
 local function trim(s)
     return (s or ""):gsub("^%s+", ""):gsub("%s+$", "")
@@ -151,11 +160,15 @@ function M.parse(payload)
         if type(lon) == "number" and type(lat) == "number" then
             table.insert(out, {
                 callsign  = trim(s[2]),
+                country   = trim(s[3]),
                 lon       = lon,
                 lat       = lat,
                 on_ground = s[9] == true,
-                alt       = s[8],
-                heading   = s[11],
+                alt       = s[8],          -- baro_altitude (m)
+                velocity  = s[10],         -- ground speed (m/s)
+                heading   = s[11],         -- true_track (deg)
+                vrate     = s[12],         -- vertical_rate (m/s, +up)
+                squawk    = s[15],
             })
         end
     end

--- a/runtime/lua/ttymap/aircraft.lua
+++ b/runtime/lua/ttymap/aircraft.lua
@@ -23,10 +23,16 @@
 -- centre are kept (markers + sidebar). `nil` = no cap (show all).
 --
 --   require("ttymap.aircraft").max_count = 50
+--
+-- `interval_sec` overrides the refresh cadence. Default auto-picks by
+-- auth state — 5 s authenticated (OpenSky's 5 s resolution), 12 s
+-- anonymous. Lower burns credits faster; faster than the resolution
+-- just re-fetches identical data.
 local M = {
     client_id = nil,
     client_secret = nil,
     max_count = nil,
+    interval_sec = nil,
 }
 
 return M

--- a/runtime/lua/ttymap/aircraft.lua
+++ b/runtime/lua/ttymap/aircraft.lua
@@ -28,11 +28,17 @@
 -- auth state — 5 s authenticated (OpenSky's 5 s resolution), 12 s
 -- anonymous. Lower burns credits faster; faster than the resolution
 -- just re-fetches identical data.
+-- `bbox_half_deg` is the half-side (degrees) of the box queried around
+-- the map centre — only aircraft inside it are returned, so this, not
+-- `max_count`, is what bounds how many you can see. Default 5 (a
+-- 10°×10° box). Bigger = more aircraft but more credits per call
+-- (≤25 sq°=1, ≤100=2, ≤400=3, else 4) and they're farther from view.
 local M = {
     client_id = nil,
     client_secret = nil,
     max_count = nil,
     interval_sec = nil,
+    bbox_half_deg = nil,
 }
 
 return M

--- a/ttymap-lua/src/api/map.rs
+++ b/ttymap-lua/src/api/map.rs
@@ -206,6 +206,19 @@ where
             None => Ok((None, None)),
         })?,
     )?;
+    // `map:project(lon, lat) -> col, row | nil, nil` — the absolute
+    // terminal cell a world coordinate draws at (nil when off the
+    // visible map area). For screen-space hit-testing, e.g. matching
+    // `map:cursor()` against plugin markers.
+    table.set(
+        "project",
+        scope.create_function(|_, (_self, lon, lat): (mlua::Table, f64, f64)| {
+            match cell.borrow().project(LonLat { lon, lat }) {
+                Some((c, r)) => Ok((Some(c), Some(r))),
+                None => Ok((None, None)),
+            }
+        })?,
+    )?;
     // Palette colour accessors — return the active theme's colour as an
     // xterm-256 index so plugins can pass them back into `map:polyline`
     // or compare colours at runtime.
@@ -519,6 +532,31 @@ mod tests {
         .expect("scope");
         assert_eq!(sink.len(), 1);
         assert!(sink[0].coords.len() > 2);
+    }
+
+    /// `map:project(lon, lat)` returns the on-screen cell for a visible
+    /// point (here, the frame centre) and `nil` for an off-canvas one.
+    #[test]
+    fn project_maps_center_onscreen_and_far_point_off() {
+        let (mut buf, area, frame, theme) = fixture(40, 10);
+        let mut sink: Vec<UserPolyline> = Vec::new();
+        let mut api = MapApi::new(&mut buf, area, &frame, &theme, None, &mut sink);
+        let lua = Lua::new();
+        let cell = std::cell::RefCell::new(&mut api);
+        let (c1, r1, c2, _r2): (Option<u16>, Option<u16>, Option<u16>, Option<u16>) = lua
+            .scope(|scope| {
+                let map_table = make_map_table(&lua, scope, &cell)?;
+                lua.globals().set("map", map_table)?;
+                lua.load(
+                    r#"local c1, r1 = map:project(0, 0)
+                       local c2, r2 = map:project(179, 85)
+                       return c1, r1, c2, r2"#,
+                )
+                .eval()
+            })
+            .expect("scope");
+        assert!(c1.is_some() && r1.is_some(), "centre on-screen");
+        assert!(c2.is_none(), "far point off the small canvas");
     }
 
     /// `arc` resolves colour through the same path as `polyline`.

--- a/ttymap-lua/src/map_api.rs
+++ b/ttymap-lua/src/map_api.rs
@@ -279,6 +279,14 @@ impl<'a> MapApi<'a> {
         self.proj.cell_to_ll(local_col, local_row)
     }
 
+    /// Project a world coordinate to the absolute terminal cell it
+    /// draws at, or `None` if it falls outside the visible map area.
+    /// Plugin-facing: lets a plugin hit-test the mouse cursor against
+    /// its own markers in screen space (e.g. hover-to-select).
+    pub fn project(&self, ll: LonLat) -> Option<(u16, u16)> {
+        self.cell_for(ll)
+    }
+
     // ── Internal: project + clip in one place ───────────────────────
 
     /// Project a world coordinate into terminal-cell space and clip


### PR DESCRIPTION
Builds on the OpenSky auth work (#393) with a batch of aircraft UX, plus one reusable engine primitive.

## New primitive

- **`map:project(lon, lat) -> col, row | nil`** (`MapApi::project`) — exposes the world→terminal-cell projection so plugins can hit-test the mouse cursor against their own markers in screen space. Unit-tested.

## Aircraft

- **Follow-on-select** (the headline): changing the selection — keyboard `C-n/C-p`, `Enter`, or hover — now `anim.fly_to`s the selected aircraft, so the map follows the list like the `wiki` plugin. Previously only `Enter` moved the map.
- **Hover-select**: moving the mouse onto (~2 cells of) a marker selects that aircraft. Movement-gated (keyboard selection still works while the mouse is parked) and pan-stable (compares projected cells, not lon/lat).
- **Stable list + pinned selection**: the sidebar is sorted by `icao24` so rows keep their place across refreshes instead of reshuffling every fetch, and the selection is re-pinned to the same physical plane (by icao) after each refresh rather than a bare index.
- **Richer sidebar**: shows ground speed (km/h) and climb/descent (↑/↓) alongside altitude; also parses `origin_country` / `squawk`.
- **Auth-aware refresh**: `opensky.interval_sec()` = 5 s authenticated (matches OpenSky's 5 s resolution) / 12 s anonymous, overridable via `ttymap.aircraft.interval_sec`.
- **Configurable fetch area**: `ttymap.aircraft.bbox_half_deg` (default 5° → 10°×10°) — the bbox, not `max_count`, is what bounds how many aircraft are returned; widen it (at higher credit cost) to see more.

## Verification

- `luac -p` on all touched Lua; unit test for `map:project` (on-screen → cell, off-canvas → nil).
- `cargo test` (full workspace), `clippy --all-targets`, `fmt --check` pass.
- **Not exercised in CI**: the live interactive behaviour (hover, fly, OpenSky round-trip) — needs a real TTY + credentials; verified manually against a live OpenSky account.

## Follow-ups (not in this PR)

- Country flags in the sidebar (needs a name→ISO2 table; terminal flag-emoji rendering varies).
- Possibly restrict hover to highlight-only if follow-on-hover proves too aggressive.